### PR TITLE
fix: make --target-size the governing constraint with accurate disk measurement

### DIFF
--- a/generator/config.go
+++ b/generator/config.go
@@ -115,9 +115,9 @@ type Config struct {
 	InjectAddresses []common.Address
 
 	// TargetSize is the target total database size on disk in bytes.
-	// When set (> 0), the generator stops creating contracts once the
-	// estimated on-disk size reaches this target. NumAccounts and
-	// NumContracts serve as upper bounds. 0 means no size limit.
+	// When set (> 0), this is the GOVERNING constraint: contracts are
+	// generated until the projected on-disk size reaches this target.
+	// NumContracts serves as a safety upper bound. 0 means no size limit.
 	TargetSize uint64
 
 	// OutputFormat specifies the database format to generate.
@@ -151,6 +151,10 @@ type Stats struct {
 
 	// CodeBytes is the number of bytes for contract code.
 	CodeBytes uint64
+
+	// TrieNodeBytes is the number of bytes written for trie nodes (Phase 2).
+	// Only populated when WriteTrieNodes is true.
+	TrieNodeBytes uint64
 
 	// StateRoot is the computed state root hash.
 	StateRoot common.Hash


### PR DESCRIPTION
## Summary

- **`--target-size` now governs generation**: When `--target-size` is set without explicit `--contracts`, the contract cap is raised to `MaxInt32` so generation continues until the target disk size is reached. Previously, exhausting `--contracts` would stop generation regardless of the target.
- **Accurate disk measurement**: Replaced the hardcoded `bytesPerEntry = 240` constant (which overestimated by ~3x) with periodic `dirSize()` calls that measure actual Pebble file sizes. Trie node overhead is projected with a 2.5x multiplier based on empirical data (trie nodes add ~1.5x snapshot data).
- **On-demand slot generation**: Added `generateSlotCount()` for per-contract slot generation in the streaming binary path, avoiding an 8 GB pre-allocation when contract count is unbounded. Uses the same RNG sequence as `generateSlotDistribution()`, preserving golden hash determinism.
- **Trie node stats**: `computeBinaryRootStreaming` now returns `trieNodeStats` (node count + bytes). `Stats.TotalBytes` includes trie node bytes. Output shows `Trie Node Bytes` and `Total DB Size` (actual on-disk after Pebble compression).
- **Target-size progress**: When `--target-size` governs, progress logging shows percentage of target size instead of contract count.

## Bug

Running `--target-size=400GB --contracts=10000000` produced only 17.7 GB because:
1. All 10M contracts were exhausted before the target was reached
2. The `bytesPerEntry = 240` estimate predicted 131 GB for 548M entries, but actual on-disk was ~44 GB (~80 bytes/entry after Pebble compression)
3. `stats.TotalBytes` only reported snapshot layer (17.7 GB), ignoring trie nodes (26.8 GB)