### PR TITLE
Add deep-state module

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ state-actor \
 | `--inject-accounts` | - | Comma-separated hex addresses to pre-fund with 999999999 ETH |
 | `--chain-id` | 0 | Override genesis chainId (0 = use value from genesis.json) |
 | `--target-size` | - | Target total DB size on disk (e.g. `5GB`, `500MB`). Stops when reached. |
+| `--deep-branch-accounts` | 0 | Additional contracts with max-depth storage tries (0 = disabled) |
+| `--deep-branch-depth` | 64 | Branch depth in nibbles per deep slot (1-64) |
+| `--deep-branch-known-slots` | 1 | Legitimate storage slots with known preimages per deep-branch account |
 | `--verbose` | false | Verbose output |
 | `--benchmark` | false | Print detailed stats |
 
@@ -280,6 +283,22 @@ Exponential decay in slot counts. Middle ground between power-law and uniform.
 ```bash
 --distribution exponential
 ```
+
+## Deep-Branch Storage Tries
+
+The `--deep-branch-accounts` flag adds contracts whose storage tries have branch nodes at every nibble position — up to 64 levels deep with no extension nodes. This is useful for stress-testing client trie traversal performance.
+
+```bash
+state-actor --db ./chaindata --genesis genesis.json \
+    --accounts 10000 --contracts 5000 \
+    --deep-branch-accounts 2 --deep-branch-depth 64 --deep-branch-known-slots 3
+```
+
+**How it works**: For each deep-branch account, `M` legitimate storage slots use sequential indices (0, 1, ..., M-1) so `SLOAD` works via their known preimages. For each legitimate slot, `D` phantom entries are injected into the trie and snapshot — each sharing a progressively longer nibble prefix with the legitimate key's `keccak256` hash but diverging at exactly one position. This forces a branch node at every depth along the legitimate key's path.
+
+The phantom entries have no known preimage, so they cannot be accessed via `SLOAD`, but the legitimate slots traverse the full branch chain during reads.
+
+> **Note**: Deep-branch mode is only supported with `--output-format geth`. Erigon's PlainState uses unhashed keys, which is incompatible with phantom entry injection.
 
 ## Architecture
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -237,6 +237,10 @@ Real Ethereum state follows a power-law distribution: a few contracts (Uniswap, 
 
 When merging genesis accounts, we preserve their exact addresses (not random). This ensures validator addresses, system contracts, and prefunded accounts work correctly.
 
+### Deep-Branch Phantom Injection
+
+Deep-branch accounts use phantom entries to force branch nodes at every nibble depth in a storage trie. For a legitimate slot with trie key `T = keccak256(pad32(slotIndex))`, we construct `D` phantom keys where phantom `d` matches `T` on nibbles `[0..d-1]` but differs at nibble `d`. These are written to the snapshot via `WriteRawStorage` (bypassing `keccak256`) and inserted directly into the StackTrie. The legitimate slot's `SLOAD` path traverses all `D` branch nodes.
+
 ### Parallel Batch Writers
 
 Pebble performs best with parallel batch commits. We use a worker pool to maximize throughput while maintaining ordering within batches.
@@ -249,6 +253,10 @@ state-actor/
 ├── generator/
 │   ├── config.go              # Configuration types
 │   ├── generator.go           # Core generation logic
+│   ├── deep_branch.go         # Deep-branch phantom key construction
+│   ├── writer.go              # StateWriter interface
+│   ├── writer_geth.go         # Geth/Pebble snapshot writer
+│   ├── writer_erigon.go       # Erigon/MDBX PlainState writer
 │   └── generator_test.go      # Unit tests
 ├── genesis/
 │   ├── genesis.go             # Genesis loading and writing

--- a/generator/config.go
+++ b/generator/config.go
@@ -124,6 +124,12 @@ type Config struct {
 	// Defaults to OutputGeth if empty.
 	OutputFormat OutputFormat
 
+	// DeepBranch configures deep-branch account generation. When enabled,
+	// additional contract accounts are created with storage tries that have
+	// maximally deep chains of branch nodes (no extension nodes along the
+	// target path). Disabled by default (NumAccounts=0).
+	DeepBranch DeepBranchConfig
+
 	// LiveStats is an optional live stats tracker for real-time monitoring.
 	// When set, the generator updates stats during generation.
 	LiveStats *LiveStats
@@ -155,6 +161,12 @@ type Stats struct {
 	// TrieNodeBytes is the number of bytes written for trie nodes (Phase 2).
 	// Only populated when WriteTrieNodes is true.
 	TrieNodeBytes uint64
+
+	// DeepBranchAccounts is the number of deep-branch contracts created.
+	DeepBranchAccounts int
+
+	// DeepBranchDepth is the configured branch depth for deep-branch accounts.
+	DeepBranchDepth int
 
 	// StateRoot is the computed state root hash.
 	StateRoot common.Hash

--- a/generator/deep_branch.go
+++ b/generator/deep_branch.go
@@ -1,0 +1,125 @@
+package generator
+
+import (
+	"bytes"
+	"math/big"
+	mrand "math/rand"
+	"sort"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// DeepBranchConfig configures deep-branch account generation.
+// Deep-branch accounts have storage tries with maximally deep chains
+// of branch nodes, achieved by injecting phantom entries that force
+// a branch at each nibble position along legitimate slots' trie paths.
+type DeepBranchConfig struct {
+	// NumAccounts is the number of additional contract accounts to create
+	// with deep storage tries. Default: 0 (disabled).
+	NumAccounts int
+
+	// Depth is the branch depth in nibbles (1-64). Each legitimate slot
+	// gets this many phantom entries forcing branch nodes along its
+	// trie path. Default: 64 (maximum possible depth).
+	Depth int
+
+	// KnownSlots is the number of legitimate storage slots with known
+	// preimages per deep-branch account. These use sequential slot
+	// indices (0, 1, 2, ...) so SLOAD works normally. Default: 1.
+	KnownSlots int
+}
+
+// Enabled returns true if deep-branch generation is configured.
+func (c DeepBranchConfig) Enabled() bool { return c.NumAccounts > 0 }
+
+// deepBranchEntry represents a single storage entry in a deep-branch account.
+type deepBranchEntry struct {
+	rawSlotKey common.Hash // Original slot key (pad32(index)) — only meaningful for legitimate entries
+	trieKey    common.Hash // Trie path: keccak256(rawSlotKey) for legit, constructed for phantom
+	value      common.Hash // Storage value
+	isPhantom  bool        // true = write with pre-hashed key (bypass keccak256)
+}
+
+// getNibble returns the nibble at position pos (0-63) from a 32-byte hash.
+// Position 0 is the highest nibble of the first byte.
+func getNibble(h common.Hash, pos int) byte {
+	b := h[pos/2]
+	if pos%2 == 0 {
+		return b >> 4
+	}
+	return b & 0x0F
+}
+
+// setNibble sets the nibble at position pos (0-63) in a 32-byte hash.
+func setNibble(h *common.Hash, pos int, val byte) {
+	if pos%2 == 0 {
+		h[pos/2] = (h[pos/2] & 0x0F) | (val << 4)
+	} else {
+		h[pos/2] = (h[pos/2] & 0xF0) | (val & 0x0F)
+	}
+}
+
+// constructPhantomKeys builds phantom trie keys from a target trie path.
+// Each phantom[d] matches target on nibbles [0..d-1] and differs at nibble d,
+// forcing a branch node at depth d in the MPT. Returns `depth` phantom keys.
+func constructPhantomKeys(target common.Hash, depth int) []common.Hash {
+	if depth > 64 {
+		depth = 64
+	}
+	phantoms := make([]common.Hash, depth)
+	for d := 0; d < depth; d++ {
+		phantoms[d] = target
+		currentNibble := getNibble(target, d)
+		newNibble := (currentNibble + 1) % 16
+		setNibble(&phantoms[d], d, newNibble)
+	}
+	return phantoms
+}
+
+// generateDeepBranchStorage generates all storage entries (legitimate + phantom)
+// for one deep-branch account. Returns entries sorted by trieKey, ready for
+// StackTrie insertion and snapshot writing.
+func generateDeepBranchStorage(knownSlots, depth int, rng *mrand.Rand) []deepBranchEntry {
+	totalEntries := knownSlots * (1 + depth)
+	entries := make([]deepBranchEntry, 0, totalEntries)
+
+	for i := 0; i < knownSlots; i++ {
+		// Legitimate slot: pad32(i) as the raw slot key
+		rawKey := common.BigToHash(big.NewInt(int64(i)))
+		trieKey := crypto.Keccak256Hash(rawKey[:])
+
+		// Random value for the legitimate entry
+		var value common.Hash
+		rng.Read(value[:])
+		if value == (common.Hash{}) {
+			value[31] = 1
+		}
+
+		entries = append(entries, deepBranchEntry{
+			rawSlotKey: rawKey,
+			trieKey:    trieKey,
+			value:      value,
+			isPhantom:  false,
+		})
+
+		// Phantom entries: one per depth level
+		phantoms := constructPhantomKeys(trieKey, depth)
+		for _, phantom := range phantoms {
+			var phantomValue common.Hash
+			phantomValue[31] = 1 // Minimal non-zero value
+			entries = append(entries, deepBranchEntry{
+				trieKey:   phantom,
+				value:     phantomValue,
+				isPhantom: true,
+			})
+		}
+	}
+
+	// Sort all entries by trieKey for StackTrie insertion
+	sort.Slice(entries, func(i, j int) bool {
+		return bytes.Compare(entries[i].trieKey[:], entries[j].trieKey[:]) < 0
+	})
+
+	return entries
+}

--- a/generator/deep_branch_test.go
+++ b/generator/deep_branch_test.go
@@ -1,0 +1,367 @@
+package generator
+
+import (
+	"bytes"
+	"math/big"
+	mrand "math/rand"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func TestGetSetNibble(t *testing.T) {
+	var h common.Hash
+	h[0] = 0xAB
+	h[1] = 0xCD
+
+	tests := []struct {
+		pos  int
+		want byte
+	}{
+		{0, 0xA},
+		{1, 0xB},
+		{2, 0xC},
+		{3, 0xD},
+	}
+	for _, tt := range tests {
+		got := getNibble(h, tt.pos)
+		if got != tt.want {
+			t.Errorf("getNibble(pos=%d) = %x, want %x", tt.pos, got, tt.want)
+		}
+	}
+
+	// Test setNibble
+	setNibble(&h, 0, 0xF)
+	if h[0] != 0xFB {
+		t.Errorf("after setNibble(0, F): byte 0 = %x, want FB", h[0])
+	}
+	setNibble(&h, 3, 0x0)
+	if h[1] != 0xC0 {
+		t.Errorf("after setNibble(3, 0): byte 1 = %x, want C0", h[1])
+	}
+}
+
+func TestConstructPhantomKeys(t *testing.T) {
+	target := crypto.Keccak256Hash(common.BigToHash(big.NewInt(5)).Bytes())
+	depth := 64
+	phantoms := constructPhantomKeys(target, depth)
+
+	if len(phantoms) != depth {
+		t.Fatalf("expected %d phantoms, got %d", depth, len(phantoms))
+	}
+
+	for d := 0; d < depth; d++ {
+		phantom := phantoms[d]
+
+		// Verify shared prefix: nibbles [0..d-1] must match target
+		for n := 0; n < d; n++ {
+			tNib := getNibble(target, n)
+			pNib := getNibble(phantom, n)
+			if tNib != pNib {
+				t.Errorf("phantom[%d]: nibble %d = %x, want %x (should match target prefix)",
+					d, n, pNib, tNib)
+			}
+		}
+
+		// Verify divergence: nibble d must differ from target
+		tNib := getNibble(target, d)
+		pNib := getNibble(phantom, d)
+		if tNib == pNib {
+			t.Errorf("phantom[%d]: nibble %d = %x, same as target (should differ)", d, d, pNib)
+		}
+
+		// Verify the specific nibble value: (target[d] + 1) % 16
+		expectedNib := (tNib + 1) % 16
+		if pNib != expectedNib {
+			t.Errorf("phantom[%d]: nibble %d = %x, want %x", d, d, pNib, expectedNib)
+		}
+	}
+}
+
+func TestConstructPhantomKeysVariableDepth(t *testing.T) {
+	target := crypto.Keccak256Hash(common.BigToHash(big.NewInt(0)).Bytes())
+
+	tests := []int{1, 4, 8, 16, 32, 64}
+	for _, depth := range tests {
+		phantoms := constructPhantomKeys(target, depth)
+		if len(phantoms) != depth {
+			t.Errorf("depth=%d: got %d phantoms, want %d", depth, len(phantoms), depth)
+		}
+	}
+}
+
+func TestConstructPhantomKeysClampedAt64(t *testing.T) {
+	var target common.Hash
+	phantoms := constructPhantomKeys(target, 100)
+	if len(phantoms) != 64 {
+		t.Errorf("depth=100 should be clamped to 64, got %d", len(phantoms))
+	}
+}
+
+func TestGenerateDeepBranchStorage(t *testing.T) {
+	rng := mrand.New(mrand.NewSource(42))
+	knownSlots := 3
+	depth := 10
+	entries := generateDeepBranchStorage(knownSlots, depth, rng)
+
+	expectedCount := knownSlots * (1 + depth) // 3 * 11 = 33
+	if len(entries) != expectedCount {
+		t.Fatalf("expected %d entries, got %d", expectedCount, len(entries))
+	}
+
+	// Verify entries are sorted by trieKey
+	for i := 1; i < len(entries); i++ {
+		if bytes.Compare(entries[i-1].trieKey[:], entries[i].trieKey[:]) >= 0 {
+			t.Errorf("entries not sorted: entry[%d] >= entry[%d]", i-1, i)
+		}
+	}
+
+	// Count legitimate vs phantom entries
+	legit, phantom := 0, 0
+	for _, e := range entries {
+		if e.isPhantom {
+			phantom++
+		} else {
+			legit++
+		}
+	}
+	if legit != knownSlots {
+		t.Errorf("expected %d legitimate entries, got %d", knownSlots, legit)
+	}
+	if phantom != knownSlots*depth {
+		t.Errorf("expected %d phantom entries, got %d", knownSlots*depth, phantom)
+	}
+
+	// Verify legitimate entries have correct rawSlotKey → trieKey mapping
+	for _, e := range entries {
+		if !e.isPhantom {
+			expectedTrieKey := crypto.Keccak256Hash(e.rawSlotKey[:])
+			if e.trieKey != expectedTrieKey {
+				t.Errorf("legitimate entry: trieKey mismatch for rawSlotKey %s",
+					e.rawSlotKey.Hex())
+			}
+		}
+	}
+
+	// Verify all values are non-zero
+	for i, e := range entries {
+		if e.value == (common.Hash{}) {
+			t.Errorf("entry[%d] has zero value", i)
+		}
+	}
+}
+
+func TestGenerateDeepBranchStorageMaxDepth(t *testing.T) {
+	rng := mrand.New(mrand.NewSource(99))
+	entries := generateDeepBranchStorage(1, 64, rng)
+
+	// 1 legitimate + 64 phantoms = 65 entries
+	if len(entries) != 65 {
+		t.Fatalf("expected 65 entries, got %d", len(entries))
+	}
+
+	// Find the legitimate entry
+	var legitTrieKey common.Hash
+	for _, e := range entries {
+		if !e.isPhantom {
+			legitTrieKey = e.trieKey
+			break
+		}
+	}
+
+	// Verify there's a phantom diverging at each of the 64 nibble positions
+	covered := make(map[int]bool, 64)
+	for _, e := range entries {
+		if !e.isPhantom {
+			continue
+		}
+		// Find the first nibble where this phantom differs from the legitimate key
+		for d := 0; d < 64; d++ {
+			if getNibble(e.trieKey, d) != getNibble(legitTrieKey, d) {
+				// All nibbles before d must match
+				for n := 0; n < d; n++ {
+					if getNibble(e.trieKey, n) != getNibble(legitTrieKey, n) {
+						t.Errorf("phantom diverges at nibble %d but doesn't match prefix at %d", d, n)
+					}
+				}
+				covered[d] = true
+				break
+			}
+		}
+	}
+
+	if len(covered) != 64 {
+		t.Errorf("expected 64 depth levels covered, got %d", len(covered))
+	}
+}
+
+func TestDeepBranchReproducibility(t *testing.T) {
+	rng1 := mrand.New(mrand.NewSource(123))
+	entries1 := generateDeepBranchStorage(2, 32, rng1)
+
+	rng2 := mrand.New(mrand.NewSource(123))
+	entries2 := generateDeepBranchStorage(2, 32, rng2)
+
+	if len(entries1) != len(entries2) {
+		t.Fatalf("entry counts differ: %d vs %d", len(entries1), len(entries2))
+	}
+
+	for i := range entries1 {
+		if entries1[i].trieKey != entries2[i].trieKey {
+			t.Errorf("entry[%d] trieKey differs", i)
+		}
+		if entries1[i].value != entries2[i].value {
+			t.Errorf("entry[%d] value differs", i)
+		}
+		if entries1[i].isPhantom != entries2[i].isPhantom {
+			t.Errorf("entry[%d] isPhantom differs", i)
+		}
+	}
+}
+
+func TestDeepBranchIntegration(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "testdb")
+
+	config := Config{
+		DBPath:       dbPath,
+		NumAccounts:  5,
+		NumContracts: 3,
+		MaxSlots:     50,
+		MinSlots:     5,
+		Distribution: Uniform,
+		Seed:         42,
+		BatchSize:    100,
+		Workers:      2,
+		CodeSize:     128,
+		DeepBranch: DeepBranchConfig{
+			NumAccounts: 2,
+			Depth:       16,
+			KnownSlots:  3,
+		},
+	}
+
+	gen, err := New(config)
+	if err != nil {
+		t.Fatalf("Failed to create generator: %v", err)
+	}
+	defer gen.Close()
+
+	stats, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("Failed to generate state: %v", err)
+	}
+
+	// Verify deep-branch stats
+	if stats.DeepBranchAccounts != 2 {
+		t.Errorf("expected 2 deep-branch accounts, got %d", stats.DeepBranchAccounts)
+	}
+	if stats.DeepBranchDepth != 16 {
+		t.Errorf("expected depth 16, got %d", stats.DeepBranchDepth)
+	}
+
+	// Verify total contract count includes deep-branch accounts
+	if stats.ContractsCreated != 5 { // 3 random + 2 deep-branch
+		t.Errorf("expected 5 total contracts, got %d", stats.ContractsCreated)
+	}
+
+	// Verify state root is non-empty
+	if stats.StateRoot == (common.Hash{}) {
+		t.Error("state root should not be empty")
+	}
+
+	// Verify storage slots include deep-branch entries
+	deepSlots := 2 * 3 * (1 + 16) // 2 accounts * 3 known_slots * (1 legit + 16 phantom)
+	if stats.StorageSlotsCreated < deepSlots {
+		t.Errorf("expected at least %d storage slots from deep-branch, got %d total",
+			deepSlots, stats.StorageSlotsCreated)
+	}
+}
+
+func TestDeepBranchWithMaxDepthIntegration(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "testdb")
+
+	config := Config{
+		DBPath:       dbPath,
+		NumAccounts:  2,
+		NumContracts: 0,
+		MaxSlots:     10,
+		MinSlots:     1,
+		Distribution: Uniform,
+		Seed:         99,
+		BatchSize:    100,
+		Workers:      1,
+		CodeSize:     64,
+		DeepBranch: DeepBranchConfig{
+			NumAccounts: 1,
+			Depth:       64,
+			KnownSlots:  1,
+		},
+	}
+
+	gen, err := New(config)
+	if err != nil {
+		t.Fatalf("Failed to create generator: %v", err)
+	}
+	defer gen.Close()
+
+	stats, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("Failed to generate state: %v", err)
+	}
+
+	if stats.StateRoot == (common.Hash{}) {
+		t.Error("state root should not be empty")
+	}
+	if stats.DeepBranchAccounts != 1 {
+		t.Errorf("expected 1 deep-branch account, got %d", stats.DeepBranchAccounts)
+	}
+}
+
+func TestDeepBranchStateRootReproducibility(t *testing.T) {
+	run := func() common.Hash {
+		tmpDir := t.TempDir()
+		dbPath := filepath.Join(tmpDir, "testdb")
+
+		config := Config{
+			DBPath:       dbPath,
+			NumAccounts:  5,
+			NumContracts: 3,
+			MaxSlots:     50,
+			MinSlots:     5,
+			Distribution: Uniform,
+			Seed:         777,
+			BatchSize:    100,
+			Workers:      2,
+			CodeSize:     128,
+			DeepBranch: DeepBranchConfig{
+				NumAccounts: 1,
+				Depth:       32,
+				KnownSlots:  2,
+			},
+		}
+
+		gen, err := New(config)
+		if err != nil {
+			t.Fatalf("Failed to create generator: %v", err)
+		}
+		defer gen.Close()
+
+		stats, err := gen.Generate()
+		if err != nil {
+			t.Fatalf("Failed to generate state: %v", err)
+		}
+		return stats.StateRoot
+	}
+
+	root1 := run()
+	root2 := run()
+
+	if root1 != root2 {
+		t.Errorf("state roots differ across runs with same seed:\n  run1: %s\n  run2: %s",
+			root1.Hex(), root2.Hex())
+	}
+}

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -175,6 +175,8 @@ type accountMeta struct {
 	genesisStorage map[common.Hash]common.Hash
 	genesisCode    []byte
 	genesisCH      common.Hash // pre-computed code hash for genesis
+	// Deep-branch fields
+	isDeepBranch bool // true if this is a deep-branch contract
 }
 
 // generateAccountMetas creates lightweight metadata for all accounts.
@@ -286,6 +288,46 @@ func (g *Generator) generateAccountMetas(stats *Stats) ([]*accountMeta, error) {
 	}
 	stats.ContractsCreated = genesisContracts + g.config.NumContracts
 
+	// Generate deep-branch contract accounts (additional, on top of random state)
+	if g.config.DeepBranch.Enabled() {
+		deepSlots := g.config.DeepBranch.KnownSlots * (1 + g.config.DeepBranch.Depth)
+		for i := 0; i < g.config.DeepBranch.NumAccounts; i++ {
+			var addr common.Address
+			g.rng.Read(addr[:])
+			for usedAddresses[addr] {
+				g.rng.Read(addr[:])
+			}
+			usedAddresses[addr] = true
+
+			metas = append(metas, &accountMeta{
+				address:      addr,
+				addrHash:     crypto.Keccak256Hash(addr[:]),
+				nonce:        1,
+				balance:      new(uint256.Int).Mul(uint256.NewInt(uint64(g.rng.Intn(100)+1)), uint256.NewInt(1e18)),
+				isContract:   true,
+				isDeepBranch: true,
+				numSlots:     deepSlots,
+				codeSize:     g.config.CodeSize + g.rng.Intn(g.config.CodeSize),
+				codeSeed:     g.rng.Int63(),
+			})
+
+			stats.StorageSlotsCreated += deepSlots
+			stats.ContractsCreated++
+
+			if g.config.LiveStats != nil {
+				g.config.LiveStats.AddContract(deepSlots)
+			}
+		}
+		stats.DeepBranchAccounts = g.config.DeepBranch.NumAccounts
+		stats.DeepBranchDepth = g.config.DeepBranch.Depth
+
+		if g.config.Verbose {
+			log.Printf("Added %d deep-branch contracts (depth=%d, known_slots=%d, %d entries each)",
+				g.config.DeepBranch.NumAccounts, g.config.DeepBranch.Depth,
+				g.config.DeepBranch.KnownSlots, deepSlots)
+		}
+	}
+
 	if g.config.Verbose {
 		log.Printf("Generated metadata for %d accounts, %d contracts with %d total storage slots",
 			stats.AccountsCreated, stats.ContractsCreated, stats.StorageSlotsCreated)
@@ -323,6 +365,46 @@ func (g *Generator) streamWriteStateMPT(metas []*accountMeta, stats *Stats) erro
 			if meta.genesisStorage != nil {
 				storageSlots = mapToSortedSlots(meta.genesisStorage)
 			}
+		} else if meta.isDeepBranch {
+			// Deep-branch contract: generate code + phantom-injected storage
+			rng := mrand.New(mrand.NewSource(meta.codeSeed))
+			code = make([]byte, meta.codeSize)
+			rng.Read(code)
+			codeHash = crypto.Keccak256Hash(code)
+
+			entries := generateDeepBranchStorage(
+				g.config.DeepBranch.KnownSlots,
+				g.config.DeepBranch.Depth,
+				rng,
+			)
+
+			// Write storage and build trie directly from deep-branch entries
+			storageTrie := trie.NewStackTrie(nil)
+			for _, entry := range entries {
+				if entry.isPhantom {
+					if err := g.writer.WriteRawStorage(meta.address, 0, entry.trieKey, entry.value); err != nil {
+						return fmt.Errorf("write raw storage: %w", err)
+					}
+				} else {
+					if err := g.writer.WriteStorage(meta.address, 0, entry.rawSlotKey, entry.value); err != nil {
+						return fmt.Errorf("write storage: %w", err)
+					}
+				}
+
+				valueRLP, err := encodeStorageValue(entry.value)
+				if err != nil {
+					return err
+				}
+				storageTrie.Update(entry.trieKey[:], valueRLP)
+			}
+
+			stateAccount = types.StateAccount{
+				Nonce:    meta.nonce,
+				Balance:  meta.balance,
+				Root:     storageTrie.Hash(),
+				CodeHash: codeHash.Bytes(),
+			}
+			// storageSlots stays nil, so the normal storage block below is skipped
 		} else if meta.isContract {
 			// Generated contract: create code and storage from seed
 			rng := mrand.New(mrand.NewSource(meta.codeSeed))
@@ -904,12 +986,12 @@ type storageSlot struct {
 
 // accountData holds generated account data.
 type accountData struct {
-	address   common.Address
-	addrHash  common.Hash
-	account   *types.StateAccount
-	code      []byte
-	codeHash  common.Hash
-	storage   []storageSlot // pre-sorted by Key for deterministic trie insertion
+	address  common.Address
+	addrHash common.Hash
+	account  *types.StateAccount
+	code     []byte
+	codeHash common.Hash
+	storage  []storageSlot // pre-sorted by Key for deterministic trie insertion
 }
 
 // mapToSortedSlots converts a storage map to a sorted slice of storageSlot.

--- a/generator/stats_server.go
+++ b/generator/stats_server.go
@@ -29,13 +29,18 @@ type LiveStats struct {
 	CodeBytes           int64 `json:"codeBytes"`
 
 	// Timing
-	StartTime   time.Time `json:"startTime"`
-	ElapsedMs   int64     `json:"elapsedMs"`
-	Throughput  float64   `json:"throughput"` // slots/sec
+	StartTime  time.Time `json:"startTime"`
+	ElapsedMs  int64     `json:"elapsedMs"`
+	Throughput float64   `json:"throughput"` // slots/sec
 
 	// State
 	Phase     string `json:"phase"` // "init", "accounts", "contracts", "finalizing", "done"
 	StateRoot string `json:"stateRoot"`
+
+	// Deep-branch
+	DeepBranchAccounts   int `json:"deepBranchAccounts"`
+	DeepBranchDepth      int `json:"deepBranchDepth"`
+	DeepBranchKnownSlots int `json:"deepBranchKnownSlots"`
 
 	// Distribution histogram (slots per contract)
 	SlotHistogram []int `json:"slotHistogram"` // buckets: 0-10, 10-100, 100-1K, 1K-10K, 10K+
@@ -194,6 +199,15 @@ func (ls *LiveStats) SyncBytes(ws WriterStats) {
 	ls.StorageBytes = int64(ws.StorageBytes)
 	ls.CodeBytes = int64(ws.CodeBytes)
 	ls.TotalBytes = ls.AccountBytes + ls.StorageBytes + ls.CodeBytes
+}
+
+// SetDeepBranch configures deep-branch display fields.
+func (ls *LiveStats) SetDeepBranch(accounts, depth, knownSlots int) {
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	ls.DeepBranchAccounts = accounts
+	ls.DeepBranchDepth = depth
+	ls.DeepBranchKnownSlots = knownSlots
 }
 
 func (ls *LiveStats) SetStateRoot(root string) {
@@ -526,6 +540,20 @@ const dashboardHTML = `<!DOCTYPE html>
                     '<div class="card-title">state treemap (recent contracts by slot count)</div>' +
                     '<div class="treemap">' + buildTreemap(s.treemapData, 520, 180) + '</div>' +
                 '</div>' +
+                (s.deepBranchAccounts > 0 ?
+                    '<div class="card">' +
+                        '<div class="card-title">deep-branch accounts</div>' +
+                        '<div class="metric purple">' + s.deepBranchAccounts + '</div>' +
+                    '</div>' +
+                    '<div class="card">' +
+                        '<div class="card-title">trie depth</div>' +
+                        '<div class="metric purple">' + s.deepBranchDepth + '<span class="unit">nibbles</span></div>' +
+                    '</div>' +
+                    '<div class="card">' +
+                        '<div class="card-title">known preimage slots</div>' +
+                        '<div class="metric purple">' + s.deepBranchKnownSlots + '<span class="unit">/account</span></div>' +
+                    '</div>'
+                : '') +
                 (s.stateRoot ? '<div class="card span6"><div class="card-title">state root</div><div class="root-hash">' + s.stateRoot + '</div></div>' : '');
         }
 

--- a/generator/writer.go
+++ b/generator/writer.go
@@ -36,6 +36,11 @@ type StateWriter interface {
 	// WriteStorage writes a storage slot for an account.
 	WriteStorage(addr common.Address, incarnation uint64, slot, value common.Hash) error
 
+	// WriteRawStorage writes a storage slot using a pre-hashed trie key.
+	// The hashedSlot is used directly as the snapshot/trie key without
+	// keccak256 hashing. Used for phantom entries in deep-branch mode.
+	WriteRawStorage(addr common.Address, incarnation uint64, hashedSlot, value common.Hash) error
+
 	// WriteCode writes contract bytecode.
 	WriteCode(codeHash common.Hash, code []byte) error
 

--- a/generator/writer_erigon.go
+++ b/generator/writer_erigon.go
@@ -148,6 +148,13 @@ func (w *ErigonWriter) WriteStorage(addr common.Address, incarnation uint64, slo
 	return nil
 }
 
+// WriteRawStorage returns an error because deep-branch mode is not supported
+// with Erigon output format. Erigon's PlainState uses unhashed keys, and
+// phantom entries have no known preimage.
+func (w *ErigonWriter) WriteRawStorage(addr common.Address, incarnation uint64, hashedSlot, value common.Hash) error {
+	return fmt.Errorf("deep-branch storage mode is not supported with erigon output format")
+}
+
 // WriteCode buffers a code write.
 func (w *ErigonWriter) WriteCode(codeHash common.Hash, code []byte) error {
 	w.mu.Lock()

--- a/generator/writer_geth.go
+++ b/generator/writer_geth.go
@@ -82,6 +82,20 @@ func (w *GethWriter) WriteStorage(addr common.Address, incarnation uint64, slot,
 	return w.bw.put(key, valueRLP, &w.storageBytes)
 }
 
+// WriteRawStorage writes a storage slot using a pre-hashed trie key.
+// The hashedSlot bypasses keccak256 and is used directly as the snapshot key.
+func (w *GethWriter) WriteRawStorage(addr common.Address, incarnation uint64, hashedSlot, value common.Hash) error {
+	addrHash := crypto.Keccak256Hash(addr[:])
+
+	valueRLP, err := gethEncodeStorageValue(value)
+	if err != nil {
+		return fmt.Errorf("encode storage value: %w", err)
+	}
+
+	key := gethStorageSnapshotKey(addrHash, hashedSlot)
+	return w.bw.put(key, valueRLP, &w.storageBytes)
+}
+
 // WriteCode writes contract bytecode.
 func (w *GethWriter) WriteCode(codeHash common.Hash, code []byte) error {
 	key := gethCodeKey(codeHash)

--- a/main.go
+++ b/main.go
@@ -33,20 +33,25 @@ import (
 )
 
 var (
-	dbPath       = flag.String("db", "", "Path to the database directory (required)")
-	accounts     = flag.Int("accounts", 1000, "Number of EOA accounts to create")
-	contracts    = flag.Int("contracts", 100, "Number of contracts to create")
-	maxSlots     = flag.Int("max-slots", 10000, "Maximum storage slots per contract")
-	minSlots     = flag.Int("min-slots", 1, "Minimum storage slots per contract")
-	distribution = flag.String("distribution", "power-law", "Storage distribution: 'power-law', 'uniform', or 'exponential'")
-	seed         = flag.Int64("seed", 0, "Random seed (0 = use current time)")
-	batchSize    = flag.Int("batch-size", 10000, "Database batch size")
-	workers      = flag.Int("workers", 0, "Number of parallel workers (0 = NumCPU)")
-	codeSize     = flag.Int("code-size", 1024, "Average contract code size in bytes")
-	verbose      = flag.Bool("verbose", false, "Verbose output")
-	benchmark    = flag.Bool("benchmark", false, "Run in benchmark mode (print detailed stats)")
+	dbPath         = flag.String("db", "", "Path to the database directory (required)")
+	accounts       = flag.Int("accounts", 1000, "Number of EOA accounts to create")
+	contracts      = flag.Int("contracts", 100, "Number of contracts to create")
+	maxSlots       = flag.Int("max-slots", 10000, "Maximum storage slots per contract")
+	minSlots       = flag.Int("min-slots", 1, "Minimum storage slots per contract")
+	distribution   = flag.String("distribution", "power-law", "Storage distribution: 'power-law', 'uniform', or 'exponential'")
+	seed           = flag.Int64("seed", 0, "Random seed (0 = use current time)")
+	batchSize      = flag.Int("batch-size", 10000, "Database batch size")
+	workers        = flag.Int("workers", 0, "Number of parallel workers (0 = NumCPU)")
+	codeSize       = flag.Int("code-size", 1024, "Average contract code size in bytes")
+	verbose        = flag.Bool("verbose", false, "Verbose output")
+	benchmark      = flag.Bool("benchmark", false, "Run in benchmark mode (print detailed stats)")
 	binaryTrie     = flag.Bool("binary-trie", false, "Generate state for binary trie mode (EIP-7864)")
 	commitInterval = flag.Int("commit-interval", 500000, "Binary trie: commit to disk every N trie insertions (default 500K, 0 = all in-memory)")
+
+	// Deep-branch accounts
+	deepBranchAccounts   = flag.Int("deep-branch-accounts", 0, "Number of additional contracts with deep storage tries (0 = disabled)")
+	deepBranchDepth      = flag.Int("deep-branch-depth", 64, "Branch depth per deep slot in nibbles (1-64)")
+	deepBranchKnownSlots = flag.Int("deep-branch-known-slots", 1, "Legitimate storage slots with known preimages per deep-branch account")
 
 	// Target size
 	targetSize = flag.String("target-size", "", "Target total DB size on disk (e.g. '5GB', '500MB'). Stops generating when estimated size is reached.")
@@ -117,6 +122,9 @@ func main() {
 		statsServer = generator.NewStatsServer(*statsPort)
 		liveStats = statsServer.Stats()
 		liveStats.SetConfig(*accounts, *contracts, *outputFormat, *distribution, *seed)
+		if *deepBranchAccounts > 0 {
+			liveStats.SetDeepBranch(*deepBranchAccounts, *deepBranchDepth, *deepBranchKnownSlots)
+		}
 		if err := statsServer.Start(); err != nil {
 			log.Fatalf("Failed to start stats server: %v", err)
 		}
@@ -153,6 +161,19 @@ func main() {
 		}
 	}
 
+	// Validate deep-branch flags
+	if *deepBranchAccounts > 0 {
+		if *outputFormat == "erigon" {
+			log.Fatalf("--deep-branch-accounts is not supported with --output-format erigon")
+		}
+		if *deepBranchDepth < 1 || *deepBranchDepth > 64 {
+			log.Fatalf("--deep-branch-depth must be 1-64, got %d", *deepBranchDepth)
+		}
+		if *deepBranchKnownSlots < 1 {
+			log.Fatalf("--deep-branch-known-slots must be >= 1, got %d", *deepBranchKnownSlots)
+		}
+	}
+
 	config := generator.Config{
 		DBPath:          *dbPath,
 		NumAccounts:     *accounts,
@@ -171,7 +192,12 @@ func main() {
 		InjectAddresses: injectAddrs,
 		TargetSize:      parsedTargetSize,
 		OutputFormat:    generator.ParseOutputFormat(*outputFormat),
-		LiveStats:       liveStats,
+		DeepBranch: generator.DeepBranchConfig{
+			NumAccounts: *deepBranchAccounts,
+			Depth:       *deepBranchDepth,
+			KnownSlots:  *deepBranchKnownSlots,
+		},
+		LiveStats: liveStats,
 	}
 
 	// Load genesis if provided
@@ -231,6 +257,10 @@ func main() {
 		if config.TargetSize > 0 {
 			log.Printf("  Target Size:  %s", formatBytes(config.TargetSize))
 		}
+		if config.DeepBranch.Enabled() {
+			log.Printf("  Deep Branch:  %d accounts, depth=%d, known_slots=%d",
+				config.DeepBranch.NumAccounts, config.DeepBranch.Depth, config.DeepBranch.KnownSlots)
+		}
 		if *genesisPath != "" {
 			log.Printf("  Genesis:      %s", *genesisPath)
 		}
@@ -289,6 +319,10 @@ func main() {
 		fmt.Printf("Total DB Size:     %s\n", formatBytes(dbSize))
 	}
 	fmt.Printf("Throughput:        %.2f slots/sec\n", float64(stats.StorageSlotsCreated)/elapsed.Seconds())
+	if stats.DeepBranchAccounts > 0 {
+		fmt.Printf("Deep Branch:       %d accounts, depth %d nibbles, %d known slots each\n",
+			stats.DeepBranchAccounts, stats.DeepBranchDepth, *deepBranchKnownSlots)
+	}
 	fmt.Printf("State Root:        %s\n", stats.StateRoot.Hex())
 
 	if genesisConfig != nil {


### PR DESCRIPTION
- Add `--deep-branch-accounts`, `--deep-branch-depth`, and `--deep-branch-known-slots` flags to generate contracts whose storage tries have branch nodes at every nibble depth (up to 64 levels)
- For each deep-branch account, legitimate slots use sequential indices (known preimages, so `SLOAD` works) while phantom entries are injected via nibble manipulation to force branch nodes at every trie depth — zero brute-force cost
- Phantoms bypass `keccak256` using `WriteRawStorage` and are written directly to the snapshot; geth-only (Erigon returns error)
- Composable with existing random state generation — deep-branch accounts are appended on top of normal `--accounts` / `--contracts`