### PR TITLE
feat: binary trie group-depth configuration

### DIFF
--- a/generator/binary_stack_trie.go
+++ b/generator/binary_stack_trie.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"log"
 	"math/bits"
+	"sort"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -21,7 +22,16 @@ const (
 	// Node type markers matching bintrie/binary_node.go
 	nodeTypeStem     = 1
 	nodeTypeInternal = 2
+
+	// maxGroupDepth is the maximum allowed group depth for grouped serialization.
+	maxGroupDepth = 8
 )
+
+// bitmapSizeForDepth returns the number of bytes needed for a bitmap of
+// 2^groupDepth bits (one bit per bottom-layer child slot in a grouped node).
+func bitmapSizeForDepth(groupDepth int) int {
+	return (1 << groupDepth) / 8
+}
 
 // verkleTrieNodeKeyPrefix is the database key prefix for binary trie nodes.
 // PathDB isolates binary trie data under a "v" namespace prefix
@@ -34,6 +44,14 @@ var verkleTrieNodeKeyPrefix = []byte("vA")
 type trieEntry struct {
 	Key   [hashSize]byte
 	Value [hashSize]byte
+}
+
+// groupChild records a bottom-layer child hash within a grouped InternalNode.
+// slot is the position (0 to 2^groupDepth - 1) determined by the stem bits
+// between the group boundary and the bottom layer.
+type groupChild struct {
+	slot int
+	hash common.Hash
 }
 
 // trieNodeWriter batches serialized trie node writes to Pebble.
@@ -81,6 +99,27 @@ func serializeInternalNode(leftHash, rightHash common.Hash) []byte {
 	return buf[:]
 }
 
+// serializeGroupedInternalNode serializes a grouped InternalNode matching
+// geth's grouped format: [type=2][groupDepth][bitmap][present hashes...].
+// The bitmap has 2^groupDepth bits indicating which bottom-layer children
+// are present. Only present children's hashes are packed after the bitmap.
+func serializeGroupedInternalNode(groupDepth int, children []groupChild) []byte {
+	bitmapSize := bitmapSizeForDepth(groupDepth)
+	size := 1 + 1 + bitmapSize + len(children)*hashSize
+	buf := make([]byte, size)
+	buf[0] = nodeTypeInternal
+	buf[1] = byte(groupDepth)
+	for _, c := range children {
+		buf[2+c.slot/8] |= 1 << (7 - (c.slot % 8))
+	}
+	offset := 2 + bitmapSize
+	for _, c := range children {
+		copy(buf[offset:offset+hashSize], c.hash[:])
+		offset += hashSize
+	}
+	return buf
+}
+
 // serializeStemNode serializes a StemNode to the format expected by
 // bintrie.DeserializeNode:
 //
@@ -119,43 +158,29 @@ func serializeStemNode(stem []byte, entries []trieEntry) []byte {
 //  1. Hash each value: data[suffix] = SHA256(value)
 //  2. 8-level tree reduction: data[i] = SHA256(data[2i] || data[2i+1]), skip if both zero
 //  3. Final: SHA256(stem || 0x00 || data[0])
-//
-// Uses a [4]uint64 bitmap to skip zero pairs in the tree reduction.
-// For a typical StemNode with k=2 entries, this reduces iterations from
-// 255 (with 32-byte comparisons) to ~16 (with single-bit tests).
 func computeStemNodeHash(stem []byte, entries []trieEntry) common.Hash {
 	var data [stemNodeWidth]common.Hash
-	var bm [4]uint64 // 256-bit bitmap: bit set = data[i] is non-zero
+	var zeroHash common.Hash
 
-	// Step 1: Hash each value at its suffix position, mark bitmap
+	// Step 1: Hash each value at its suffix position
 	for _, e := range entries {
 		suffix := e.Key[stemSize] // key[31]
 		data[suffix] = sha256.Sum256(e.Value[:])
-		bm[suffix/64] |= 1 << (63 - uint(suffix)%64)
 	}
 
-	// Step 2: 8-level tree reduction — skip zero pairs via bitmap.
-	// The reduction is in-place (writes data[i] from data[2i],data[2i+1]),
-	// so we must explicitly zero data[i] when skipping to avoid stale values
-	// from Step 1 or previous levels.
+	// Step 2: 8-level tree reduction (matching StemNode.Hash exactly)
 	var buf [64]byte
 	for level := 1; level <= 8; level++ {
 		count := stemNodeWidth / (1 << level)
-		var newBm [4]uint64
 		for i := 0; i < count; i++ {
-			li, ri := i*2, i*2+1
-			lSet := bm[li/64]&(1<<(63-uint(li)%64)) != 0
-			rSet := bm[ri/64]&(1<<(63-uint(ri)%64)) != 0
-			if !lSet && !rSet {
-				data[i] = common.Hash{} // clear stale data from earlier levels
+			if data[i*2] == zeroHash && data[i*2+1] == zeroHash {
+				data[i] = zeroHash
 				continue
 			}
-			copy(buf[:32], data[li][:])
-			copy(buf[32:], data[ri][:])
+			copy(buf[:32], data[i*2][:])
+			copy(buf[32:], data[i*2+1][:])
 			data[i] = sha256.Sum256(buf[:])
-			newBm[i/64] |= 1 << (63 - uint(i)%64)
 		}
-		bm = newBm
 	}
 
 	// Step 3: Final hash = SHA256(stem || 0x00 || data[0])
@@ -296,13 +321,24 @@ func commonPrefixLenBits(a, b []byte) int {
 // right) of its parent it belongs to, using the stem bits at each depth.
 // This ensures H(left, right) ordering matches the recursive tree exactly,
 // even when all entries go right at some depth (making left = zero).
+//
+// When groupDepth > 0, the builder emits grouped-format InternalNodes
+// directly at group boundary depths (depth % groupDepth == 0), skipping
+// writes at intermediate depths. Stems within a group are extended to the
+// group's bottom-layer boundary. This eliminates the need for a post-hoc
+// regroupTrieNodes pass. Memory overhead: O(groupDepth) per group.
 type streamingBuilder struct {
 	stack    [maxDepth]common.Hash      // pending child hash at each depth
 	occupied [maxDepth]bool             // whether stack[d] is valid
 	isRight  [maxDepth]bool             // true if stack[d] is a right child
 	stemBits [maxDepth][stemSize]byte   // stem that placed each pending hash
 	w        *trieNodeWriter            // optional: writes serialized nodes to DB
-	pathBuf  [maxDepth]byte             // reusable buffer for buildPath
+
+	// Grouped emission: when groupDepth > 0, internal nodes are written in
+	// grouped format at boundary depths. groupBuf collects bottom-layer
+	// children for each active group boundary.
+	groupDepth int
+	groupBuf   map[int][]groupChild // boundary depth -> bottom-layer children
 
 	// Deferred stem: waiting for right-neighbor CPL before placement.
 	hasPrev     bool
@@ -310,16 +346,6 @@ type streamingBuilder struct {
 	prevStem    [stemSize]byte
 	prevLeftCPL int         // CPL with left neighbor (-1 if first stem)
 	prevEntries []trieEntry // kept only when w != nil (for serialization)
-}
-
-// buildPath writes the bit-path from root to `depth` into sb.pathBuf and
-// returns a sub-slice. The returned slice is only valid until the next
-// buildPath call. Safe because Pebble batch.Put() copies key/value internally.
-func (sb *streamingBuilder) buildPath(stem []byte, depth int) []byte {
-	for i := 0; i < depth; i++ {
-		sb.pathBuf[i] = stemBitAt(stem, i)
-	}
-	return sb.pathBuf[:depth]
 }
 
 // stemBitAt returns the bit value (0 or 1) at the given depth in a stem.
@@ -335,6 +361,39 @@ func makePath(stem []byte, depth int) []byte {
 		path[i] = stemBitAt(stem, i)
 	}
 	return path
+}
+
+// recordGroupChild records a hash at a boundary depth as a bottom-layer
+// child of the parent group. The slot (0 to 2^groupDepth - 1) is computed
+// from the stem bits between the parent boundary and the child depth.
+func (sb *streamingBuilder) recordGroupChild(childDepth int, hash common.Hash, stem []byte) {
+	parentBoundary := childDepth - sb.groupDepth
+	if parentBoundary < 0 {
+		return
+	}
+	gd := sb.groupDepth
+	slot := 0
+	for i := 0; i < gd; i++ {
+		slot = (slot << 1) | int(stemBitAt(stem, parentBoundary+i))
+	}
+	sb.groupBuf[parentBoundary] = append(sb.groupBuf[parentBoundary], groupChild{slot: slot, hash: hash})
+}
+
+// writeGroupedNode serializes and writes a grouped InternalNode at the
+// given boundary depth using collected bottom-layer children.
+func (sb *streamingBuilder) writeGroupedNode(boundary int, stem []byte) {
+	children := sb.groupBuf[boundary]
+	if len(children) == 0 {
+		return
+	}
+	// Sort by slot to ensure hashes are in bitmap order.
+	sort.Slice(children, func(i, j int) bool {
+		return children[i].slot < children[j].slot
+	})
+	blob := serializeGroupedInternalNode(sb.groupDepth, children)
+	sb.w.writeNode(makePath(stem, boundary), blob)
+	// Reset buffer for this boundary depth after writing.
+	sb.groupBuf[boundary] = children[:0]
 }
 
 // feedStem is called for each completed stem group (consecutive entries
@@ -360,6 +419,9 @@ func (sb *streamingBuilder) feedStem(stem []byte, hash common.Hash, entries []tr
 }
 
 // flushDeferred places the previously deferred StemNode at the correct depth.
+// When groupDepth > 0, the target depth is extended to the next group
+// bottom-layer boundary so that stems within a group are stored at the
+// extended path (matching the grouped serialization format).
 func (sb *streamingBuilder) flushDeferred(rightCPL int) {
 	targetDepth := sb.prevLeftCPL
 	if rightCPL > targetDepth {
@@ -367,13 +429,22 @@ func (sb *streamingBuilder) flushDeferred(rightCPL int) {
 	}
 	targetDepth++ // StemNode sits one level below the divergence point
 
+	// Extend stem depth to group bottom-layer boundary if within a group.
+	if sb.groupDepth > 0 {
+		gd := sb.groupDepth
+		boundary := (targetDepth / gd) * gd
+		if targetDepth > boundary {
+			targetDepth = boundary + gd
+		}
+	}
+
 	// Resolve pending hashes from the PREVIOUS subtree. Any pending hashes
 	// at depths > prevLeftCPL belong to the left neighbor's subtree.
 	sb.unwindTo(sb.prevLeftCPL + 1)
 
 	// Write the StemNode — path derived from the stem being placed.
 	if sb.w != nil {
-		sb.w.writeNode(sb.buildPath(sb.prevStem[:], targetDepth), serializeStemNode(sb.prevStem[:], sb.prevEntries))
+		sb.w.writeNode(makePath(sb.prevStem[:], targetDepth), serializeStemNode(sb.prevStem[:], sb.prevEntries))
 	}
 
 	sb.propagateUp(sb.prevHash, targetDepth, sb.prevStem[:])
@@ -400,8 +471,16 @@ func (sb *streamingBuilder) unwindTo(minDepth int) {
 		combined := sha256.Sum256(buf[:])
 
 		if sb.w != nil {
-			// Path derived from the stem that placed this pending hash.
-			sb.w.writeNode(sb.buildPath(sb.stemBits[d][:], d), serializeInternalNode(left, right))
+			if sb.groupDepth > 0 {
+				// At group boundaries: write grouped node using collected children.
+				// At non-boundary depths: skip write (hash still propagates).
+				if d%sb.groupDepth == 0 {
+					sb.writeGroupedNode(d, sb.stemBits[d][:])
+				}
+			} else {
+				// Path derived from the stem that placed this pending hash.
+				sb.w.writeNode(makePath(sb.stemBits[d][:], d), serializeInternalNode(left, right))
+			}
 		}
 		// Propagate upward using the stem that originally placed this hash.
 		stem := sb.stemBits[d]
@@ -413,9 +492,21 @@ func (sb *streamingBuilder) unwindTo(minDepth int) {
 // propagateUp pushes a hash from fromDepth toward the root. Uses the stem's
 // bit at each depth to determine whether the hash is a left or right child.
 // When the hash is right and no left exists, it combines with zero immediately.
+//
+// When groupDepth > 0, at each group boundary depth the hash is recorded as
+// a bottom-layer child of the parent group. DB writes are only emitted at
+// boundary depths (grouped format); non-boundary writes are skipped.
 func (sb *streamingBuilder) propagateUp(hash common.Hash, fromDepth int, stem []byte) {
 	for d := fromDepth; d > 0; d-- {
 		pd := d - 1
+
+		// Record bottom-layer child at group boundary depths.
+		// A hash at depth d (where d % groupDepth == 0) is a bottom-layer
+		// child of the parent group at depth d - groupDepth.
+		if sb.groupDepth > 0 && d%sb.groupDepth == 0 && d >= sb.groupDepth {
+			sb.recordGroupChild(d, hash, stem)
+		}
+
 		bit := stemBitAt(stem, pd)
 
 		if sb.occupied[pd] {
@@ -436,8 +527,14 @@ func (sb *streamingBuilder) propagateUp(hash common.Hash, fromDepth int, stem []
 			hash = sha256.Sum256(buf[:])
 
 			if sb.w != nil {
-				// Path derived from stem — both children share bits 0..pd-1.
-				sb.w.writeNode(sb.buildPath(stem, pd), serializeInternalNode(left, right))
+				if sb.groupDepth > 0 {
+					if pd%sb.groupDepth == 0 {
+						sb.writeGroupedNode(pd, stem)
+					}
+				} else {
+					// Path derived from stem — both children share bits 0..pd-1.
+					sb.w.writeNode(makePath(stem, pd), serializeInternalNode(left, right))
+				}
 			}
 			sb.occupied[pd] = false
 		} else if bit == 1 {
@@ -450,7 +547,13 @@ func (sb *streamingBuilder) propagateUp(hash common.Hash, fromDepth int, stem []
 			hash = sha256.Sum256(buf[:])
 
 			if sb.w != nil {
-				sb.w.writeNode(sb.buildPath(stem, pd), serializeInternalNode(common.Hash{}, right))
+				if sb.groupDepth > 0 {
+					if pd%sb.groupDepth == 0 {
+						sb.writeGroupedNode(pd, stem)
+					}
+				} else {
+					sb.w.writeNode(makePath(stem, pd), serializeInternalNode(common.Hash{}, right))
+				}
 			}
 			// Continue propagating upward — don't store.
 		} else {
@@ -485,11 +588,16 @@ type trieNodeStats struct {
 // computeBinaryRootStreamingFromSlice is the slice-based variant used for
 // testing equivalence with the recursive approach. It feeds pre-sorted
 // entries directly into the streaming builder without needing a DB iterator.
-func computeBinaryRootStreamingFromSlice(entries []trieEntry, db ethdb.KeyValueStore) (common.Hash, trieNodeStats) {
+func computeBinaryRootStreamingFromSlice(entries []trieEntry, db ethdb.KeyValueStore, groupDepth int) (common.Hash, trieNodeStats) {
 	if len(entries) == 0 {
 		return common.Hash{}, trieNodeStats{}
 	}
-	sb := &streamingBuilder{}
+	sb := &streamingBuilder{
+		groupDepth: groupDepth,
+	}
+	if groupDepth > 0 {
+		sb.groupBuf = make(map[int][]groupChild)
+	}
 	if db != nil {
 		sb.w = &trieNodeWriter{batch: db.NewBatch(), db: db}
 	}
@@ -526,8 +634,16 @@ func computeBinaryRootStreamingFromSlice(entries []trieEntry, db ethdb.KeyValueS
 // trie entries in a single forward pass. The iterator must yield entries
 // sorted by key (32 bytes each: key[0:31]=stem, key[31]=suffix).
 // Values are 32 bytes. O(depth) ≈ 8 KB memory for the stack.
-func computeBinaryRootStreaming(iter ethdb.Iterator, db ethdb.KeyValueStore) (common.Hash, trieNodeStats) {
-	sb := &streamingBuilder{}
+//
+// When groupDepth > 0, emits grouped-format InternalNodes at boundary
+// depths directly, eliminating the need for regroupTrieNodes().
+func computeBinaryRootStreaming(iter ethdb.Iterator, db ethdb.KeyValueStore, groupDepth int) (common.Hash, trieNodeStats) {
+	sb := &streamingBuilder{
+		groupDepth: groupDepth,
+	}
+	if groupDepth > 0 {
+		sb.groupBuf = make(map[int][]groupChild)
+	}
 	if db != nil {
 		sb.w = &trieNodeWriter{batch: db.NewBatch(), db: db}
 	}
@@ -571,3 +687,4 @@ func computeBinaryRootStreaming(iter ethdb.Iterator, db ethdb.KeyValueStore) (co
 
 	return root, tnStats
 }
+

--- a/generator/config.go
+++ b/generator/config.go
@@ -133,6 +133,13 @@ type Config struct {
 	// LiveStats is an optional live stats tracker for real-time monitoring.
 	// When set, the generator updates stats during generation.
 	LiveStats *LiveStats
+
+	// GroupDepth is the binary trie group depth (1-8, default 8).
+	// Controls how many trie levels are serialized per DB entry.
+	GroupDepth int
+
+	// PebbleBlockSize is the PebbleDB SSTable block size in bytes (default 4096).
+	PebbleBlockSize int
 }
 
 // Stats holds statistics about the generation process.

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -880,7 +880,7 @@ func (g *Generator) generateStreamingBinary() (retStats *Stats, retErr error) {
 		nodeDB = g.db
 	}
 	iter := tempDB.NewIterator(nil, nil)
-	stateRoot, tnStats := computeBinaryRootStreaming(iter, nodeDB)
+	stateRoot, tnStats := computeBinaryRootStreaming(iter, nodeDB, g.config.GroupDepth)
 	if g.config.Verbose {
 		log.Printf("Computed binary trie root in %v", time.Since(hashStart).Round(time.Millisecond))
 	}

--- a/generator/grouped_emission_test.go
+++ b/generator/grouped_emission_test.go
@@ -1,0 +1,496 @@
+package generator
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/ethdb/memorydb"
+	"github.com/ethereum/go-ethereum/trie/bintrie"
+)
+
+// TestGroupedEmissionConsistency verifies that the streaming builder's
+// returned root hash matches what geth computes by reading and hashing
+// the root grouped node from DB. This is the primary correctness test.
+func TestGroupedEmissionConsistency(t *testing.T) {
+	for _, gd := range []int{1, 2, 4, 8} {
+		t.Run(fmt.Sprintf("gd%d", gd), func(t *testing.T) {
+			entries := generateTestEntries(t, 50)
+
+			db := memorydb.New()
+			root, stats := computeBinaryRootStreamingFromSlice(entries, db, gd)
+
+			if root == (common.Hash{}) {
+				t.Fatal("root should not be zero")
+			}
+			if stats.Nodes == 0 {
+				t.Fatal("should have written nodes")
+			}
+
+			// Read root grouped node and verify hash matches
+			rootBlob, err := db.Get(verkleTrieNodeKeyPrefix)
+			if err != nil {
+				t.Fatalf("failed to read root node: %v", err)
+			}
+			groupedRoot, err := bintrie.DeserializeNode(rootBlob, 0)
+			if err != nil {
+				t.Fatalf("failed to deserialize root: %v", err)
+			}
+			deserializedHash := groupedRoot.Hash()
+
+			if root != deserializedHash {
+				t.Errorf("root hash inconsistency (groupDepth=%d):\n  streaming: %s\n  from DB:   %s",
+					gd, root.Hex(), deserializedHash.Hex())
+			}
+		})
+	}
+}
+
+// TestGroupedEmissionShallowStems verifies equivalence between direct
+// grouped emission and the regroup approach when stems are at shallow
+// non-boundary depths. With 2 stems differing at bit 0, both stems are
+// placed at depth 1 — non-boundary for groupDepth >= 2.
+func TestGroupedEmissionShallowStems(t *testing.T) {
+	// Create 2 stems that differ at bit 0
+	entries := makeShallowEntries()
+
+	for _, gd := range []int{1, 2, 4, 8} {
+		t.Run(fmt.Sprintf("gd%d", gd), func(t *testing.T) {
+			// Approach 1: Individual emission + regroup
+			db1 := memorydb.New()
+			computeBinaryRootStreamingFromSlice(entries, db1, 0)
+			if err := regroupTrieNodes(db1, gd, false); err != nil {
+				t.Fatalf("regroupTrieNodes failed: %v", err)
+			}
+			rootBlob1, err := db1.Get(verkleTrieNodeKeyPrefix)
+			if err != nil {
+				t.Fatalf("failed to read root from db1: %v", err)
+			}
+			groupedRoot1, err := bintrie.DeserializeNode(rootBlob1, 0)
+			if err != nil {
+				t.Fatalf("failed to deserialize root from db1: %v", err)
+			}
+			regroupHash := groupedRoot1.Hash()
+
+			// Approach 2: Direct grouped emission
+			db2 := memorydb.New()
+			directHash, _ := computeBinaryRootStreamingFromSlice(entries, db2, gd)
+
+			if regroupHash != directHash {
+				t.Errorf("hash mismatch for shallow stems (gd=%d):\n  regroup: %s\n  direct:  %s",
+					gd, regroupHash.Hex(), directHash.Hex())
+			}
+
+			// Verify DB contents match
+			compareDBs(t, db1, db2, gd)
+		})
+	}
+}
+
+// TestGroupedEmissionNoRegression verifies that groupDepth=0 produces the
+// exact same result as the original ungrouped streaming builder.
+func TestGroupedEmissionNoRegression(t *testing.T) {
+	entries := generateTestEntries(t, 30)
+
+	db1 := memorydb.New()
+	root1, stats1 := computeBinaryRootStreamingFromSlice(entries, db1, 0)
+
+	db2 := memorydb.New()
+	root2, stats2 := computeBinaryRootStreamingFromSlice(entries, db2, 0)
+
+	if root1 != root2 {
+		t.Errorf("ungrouped root mismatch: %s != %s", root1.Hex(), root2.Hex())
+	}
+	if stats1.Nodes != stats2.Nodes {
+		t.Errorf("node count mismatch: %d != %d", stats1.Nodes, stats2.Nodes)
+	}
+}
+
+// TestGroupedEmissionSingleEntry verifies edge case with a single stem.
+func TestGroupedEmissionSingleEntry(t *testing.T) {
+	for _, gd := range []int{0, 1, 4, 8} {
+		t.Run(fmt.Sprintf("gd%d", gd), func(t *testing.T) {
+			var entries []trieEntry
+			var e trieEntry
+			for i := 0; i < stemSize; i++ {
+				e.Key[i] = byte(i * 7)
+			}
+			e.Key[stemSize] = 0
+			e.Value = sha256.Sum256([]byte("test-value"))
+			entries = append(entries, e)
+
+			db := memorydb.New()
+			root, stats := computeBinaryRootStreamingFromSlice(entries, db, gd)
+
+			if root == (common.Hash{}) {
+				t.Error("root should not be zero for non-empty trie")
+			}
+			if stats.Nodes == 0 {
+				t.Error("should have written at least one node")
+			}
+
+			// Verify consistency: root matches deserialized root hash
+			if gd > 0 {
+				rootBlob, err := db.Get(verkleTrieNodeKeyPrefix)
+				if err != nil {
+					t.Fatalf("failed to read root: %v", err)
+				}
+				groupedRoot, err := bintrie.DeserializeNode(rootBlob, 0)
+				if err != nil {
+					t.Fatalf("failed to deserialize root: %v", err)
+				}
+				if groupedRoot.Hash() != root {
+					t.Errorf("root inconsistency: streaming=%s, deserialized=%s",
+						root.Hex(), groupedRoot.Hash().Hex())
+				}
+			}
+		})
+	}
+}
+
+// TestGroupedEmissionRoundTrip verifies that all grouped nodes can be
+// deserialized by geth's bintrie.DeserializeNode without errors.
+func TestGroupedEmissionRoundTrip(t *testing.T) {
+	for _, gd := range []int{1, 2, 4, 8} {
+		t.Run(fmt.Sprintf("gd%d", gd), func(t *testing.T) {
+			entries := generateTestEntries(t, 20)
+
+			db := memorydb.New()
+			computeBinaryRootStreamingFromSlice(entries, db, gd)
+
+			prefix := verkleTrieNodeKeyPrefix
+			iter := db.NewIterator(prefix, nil)
+			defer iter.Release()
+
+			nodeCount := 0
+			for iter.Next() {
+				key := iter.Key()
+				if !bytes.HasPrefix(key, prefix) {
+					break
+				}
+				blob := iter.Value()
+				if len(blob) == 0 {
+					continue
+				}
+
+				path := key[len(prefix):]
+				depth := len(path)
+
+				_, err := bintrie.DeserializeNode(blob, depth)
+				if err != nil {
+					t.Errorf("failed to deserialize node at depth %d (type=%d, len=%d): %v",
+						depth, blob[0], len(blob), err)
+				}
+				nodeCount++
+			}
+
+			if nodeCount == 0 {
+				t.Error("no nodes found in DB")
+			}
+		})
+	}
+}
+
+// TestGroupedEmissionNodeCounts verifies that grouping reduces the number
+// of nodes written (internal nodes at non-boundary depths are eliminated).
+func TestGroupedEmissionNodeCounts(t *testing.T) {
+	entries := generateTestEntries(t, 50)
+
+	db0 := memorydb.New()
+	_, stats0 := computeBinaryRootStreamingFromSlice(entries, db0, 0)
+
+	for _, gd := range []int{1, 2, 4, 8} {
+		t.Run(fmt.Sprintf("gd%d", gd), func(t *testing.T) {
+			db := memorydb.New()
+			_, stats := computeBinaryRootStreamingFromSlice(entries, db, gd)
+
+			if gd > 1 && stats.Nodes >= stats0.Nodes {
+				t.Errorf("grouped (gd=%d) should have fewer nodes: grouped=%d, ungrouped=%d",
+					gd, stats.Nodes, stats0.Nodes)
+			}
+			t.Logf("gd=%d: %d nodes (%d bytes), ungrouped: %d nodes (%d bytes)",
+				gd, stats.Nodes, stats.Bytes, stats0.Nodes, stats0.Bytes)
+		})
+	}
+}
+
+// --- helpers ---
+
+// makeShallowEntries creates 2 stems that differ at bit 0, forcing stem
+// placement at depth 1 (the shallowest possible depth for 2 entries).
+func makeShallowEntries() []trieEntry {
+	var entries []trieEntry
+
+	// Stem A: bit 0 = 0 (0x00...)
+	var eA trieEntry
+	stemA := sha256.Sum256([]byte("shallow-stem-A"))
+	stemA[0] &= 0x7F // ensure bit 0 = 0
+	copy(eA.Key[:stemSize], stemA[:stemSize])
+	eA.Key[stemSize] = 0
+	eA.Value = sha256.Sum256([]byte("value-A"))
+	entries = append(entries, eA)
+
+	// Stem B: bit 0 = 1 (0x80...)
+	var eB trieEntry
+	stemB := sha256.Sum256([]byte("shallow-stem-B"))
+	stemB[0] |= 0x80 // ensure bit 0 = 1
+	copy(eB.Key[:stemSize], stemB[:stemSize])
+	eB.Key[stemSize] = 0
+	eB.Value = sha256.Sum256([]byte("value-B"))
+	entries = append(entries, eB)
+
+	// Sort by key
+	sort.Slice(entries, func(i, j int) bool {
+		return bytes.Compare(entries[i].Key[:], entries[j].Key[:]) < 0
+	})
+
+	return entries
+}
+
+// generateTestEntries creates a deterministic set of trie entries with
+// multiple stems to exercise the streaming builder's grouping logic.
+func generateTestEntries(t *testing.T, numStems int) []trieEntry {
+	t.Helper()
+	var entries []trieEntry
+
+	for i := 0; i < numStems; i++ {
+		stemHash := sha256.Sum256([]byte{byte(i), byte(i >> 8), byte(i >> 16)})
+		stem := stemHash[:stemSize]
+
+		numSuffixes := (i % 3) + 1
+		for s := 0; s < numSuffixes; s++ {
+			var e trieEntry
+			copy(e.Key[:stemSize], stem)
+			e.Key[stemSize] = byte(s)
+			e.Value = sha256.Sum256([]byte{byte(i), byte(s)})
+			entries = append(entries, e)
+		}
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return bytes.Compare(entries[i].Key[:], entries[j].Key[:]) < 0
+	})
+
+	return entries
+}
+
+// compareDBs checks that two databases have identical contents under the
+// trie node prefix.
+func compareDBs(t *testing.T, db1, db2 ethdb.KeyValueStore, groupDepth int) {
+	t.Helper()
+
+	prefix := verkleTrieNodeKeyPrefix
+	keys1 := collectKeys(db1, prefix)
+	keys2 := collectKeys(db2, prefix)
+
+	if len(keys1) != len(keys2) {
+		t.Errorf("DB key count mismatch (groupDepth=%d): db1=%d, db2=%d",
+			groupDepth, len(keys1), len(keys2))
+		set1 := make(map[string]bool)
+		for _, k := range keys1 {
+			set1[string(k)] = true
+		}
+		set2 := make(map[string]bool)
+		for _, k := range keys2 {
+			set2[string(k)] = true
+		}
+		for _, k := range keys1 {
+			if !set2[string(k)] {
+				path := k[len(prefix):]
+				t.Errorf("  only in db1: depth=%d path=%x", len(path), path)
+			}
+		}
+		for _, k := range keys2 {
+			if !set1[string(k)] {
+				path := k[len(prefix):]
+				t.Errorf("  only in db2: depth=%d path=%x", len(path), path)
+			}
+		}
+		return
+	}
+
+	for _, key := range keys1 {
+		val1, _ := db1.Get(key)
+		val2, _ := db2.Get(key)
+		if !bytes.Equal(val1, val2) {
+			path := key[len(prefix):]
+			t.Errorf("value mismatch at depth=%d path=%x:\n  db1: %x\n  db2: %x",
+				len(path), path, truncBlob(val1), truncBlob(val2))
+		}
+	}
+}
+
+func truncBlob(b []byte) []byte {
+	if len(b) > 40 {
+		return b[:40]
+	}
+	return b
+}
+
+func collectKeys(db ethdb.KeyValueStore, prefix []byte) [][]byte {
+	var keys [][]byte
+	iter := db.NewIterator(prefix, nil)
+	defer iter.Release()
+	for iter.Next() {
+		if !bytes.HasPrefix(iter.Key(), prefix) {
+			break
+		}
+		key := make([]byte, len(iter.Key()))
+		copy(key, iter.Key())
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return bytes.Compare(keys[i], keys[j]) < 0
+	})
+	return keys
+}
+
+// TestGroupedEmissionGethTraversal simulates geth's trie traversal
+// for both existing and non-existing stems. This exercises the resolver
+// path that geth uses when inserting new accounts into a pre-built trie.
+func TestGroupedEmissionGethTraversal(t *testing.T) {
+	for _, gd := range []int{1, 2, 4, 8} {
+		t.Run(fmt.Sprintf("gd%d", gd), func(t *testing.T) {
+			entries := generateTestEntries(t, 200)
+
+			db := memorydb.New()
+			root, stats := computeBinaryRootStreamingFromSlice(entries, db, gd)
+
+			if root == (common.Hash{}) {
+				t.Fatal("root should not be zero")
+			}
+			t.Logf("gd=%d: %d nodes, %d bytes", gd, stats.Nodes, stats.Bytes)
+
+			// Read and deserialize root
+			rootBlob, err := db.Get(verkleTrieNodeKeyPrefix)
+			if err != nil {
+				t.Fatalf("failed to read root: %v", err)
+			}
+			rootNode, err := bintrie.DeserializeNode(rootBlob, 0)
+			if err != nil {
+				t.Fatalf("failed to deserialize root: %v", err)
+			}
+
+			// Create resolver (same as geth's nodeResolver)
+			resolver := func(path []byte, hash common.Hash) ([]byte, error) {
+				if hash == (common.Hash{}) {
+					return nil, nil
+				}
+				key := make([]byte, len(verkleTrieNodeKeyPrefix)+len(path))
+				copy(key, verkleTrieNodeKeyPrefix)
+				copy(key[len(verkleTrieNodeKeyPrefix):], path)
+				blob, err := db.Get(key)
+				if err != nil {
+					return nil, fmt.Errorf("missing trie node %s (path %x): %w", hash.Hex(), path, err)
+				}
+				return blob, nil
+			}
+
+			// Test 1: Traverse to every existing stem
+			for _, e := range entries {
+				stem := e.Key[:stemSize]
+				if inode, ok := rootNode.(*bintrie.InternalNode); ok {
+					_, err := inode.GetValuesAtStem(stem, resolver)
+					if err != nil {
+						t.Errorf("failed to traverse to existing stem %x: %v", stem[:4], err)
+					}
+				}
+			}
+
+			// Test 2: Traverse to non-existing stems (simulates dev account insertion)
+			for i := 0; i < 50; i++ {
+				fakeStem := sha256.Sum256([]byte{byte(i), 0xFF, 0xFE})
+				stem := fakeStem[:stemSize]
+				if inode, ok := rootNode.(*bintrie.InternalNode); ok {
+					// GetValuesAtStem should return nil (not found) without error
+					vals, err := inode.GetValuesAtStem(stem, resolver)
+					if err != nil {
+						t.Errorf("failed to traverse to non-existing stem %x: %v", stem[:4], err)
+					}
+					// vals can be nil (stem not found) or empty - both are OK
+					_ = vals
+				}
+			}
+		})
+	}
+}
+
+// TestGroupedEmissionLargeTraversal stress-tests with 5000 stems and 500 fake lookups.
+func TestGroupedEmissionLargeTraversal(t *testing.T) {
+	for _, gd := range []int{1, 4, 8} {
+		t.Run(fmt.Sprintf("gd%d", gd), func(t *testing.T) {
+			entries := generateTestEntries(t, 5000)
+
+			db := memorydb.New()
+			root, stats := computeBinaryRootStreamingFromSlice(entries, db, gd)
+
+			if root == (common.Hash{}) {
+				t.Fatal("root should not be zero")
+			}
+			t.Logf("gd=%d: %d nodes, %d bytes, %d entries", gd, stats.Nodes, stats.Bytes, len(entries))
+
+			rootBlob, err := db.Get(verkleTrieNodeKeyPrefix)
+			if err != nil {
+				t.Fatalf("failed to read root: %v", err)
+			}
+			rootNode, err := bintrie.DeserializeNode(rootBlob, 0)
+			if err != nil {
+				t.Fatalf("failed to deserialize root: %v", err)
+			}
+
+			resolver := func(path []byte, hash common.Hash) ([]byte, error) {
+				if hash == (common.Hash{}) {
+					return nil, nil
+				}
+				key := make([]byte, len(verkleTrieNodeKeyPrefix)+len(path))
+				copy(key, verkleTrieNodeKeyPrefix)
+				copy(key[len(verkleTrieNodeKeyPrefix):], path)
+				blob, err := db.Get(key)
+				if err != nil {
+					return nil, fmt.Errorf("missing trie node %s (path len=%d): %w", hash.Hex()[:16], len(path), err)
+				}
+				return blob, nil
+			}
+
+			inode, ok := rootNode.(*bintrie.InternalNode)
+			if !ok {
+				t.Fatal("root is not InternalNode")
+			}
+
+			// Traverse all existing stems
+			existingFail := 0
+			for _, e := range entries {
+				_, err := inode.GetValuesAtStem(e.Key[:stemSize], resolver)
+				if err != nil {
+					existingFail++
+					if existingFail <= 3 {
+						t.Errorf("existing stem %x: %v", e.Key[:4], err)
+					}
+				}
+			}
+			if existingFail > 0 {
+				t.Errorf("total existing stem failures: %d / %d", existingFail, len(entries))
+			}
+
+			// Traverse 500 non-existing stems
+			fakeFail := 0
+			for i := 0; i < 500; i++ {
+				fakeStem := sha256.Sum256([]byte{byte(i), byte(i >> 8), 0xFF, 0xFE, 0xFD})
+				_, err := inode.GetValuesAtStem(fakeStem[:stemSize], resolver)
+				if err != nil {
+					fakeFail++
+					if fakeFail <= 3 {
+						t.Errorf("non-existing stem %x: %v", fakeStem[:4], err)
+					}
+				}
+			}
+			if fakeFail > 0 {
+				t.Errorf("total non-existing stem failures: %d / 500", fakeFail)
+			}
+		})
+	}
+}

--- a/generator/regroup.go
+++ b/generator/regroup.go
@@ -1,0 +1,328 @@
+package generator
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"log"
+	"sort"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethdb"
+)
+
+// regroupTrieNodes reads all individual internal nodes written by the streaming
+// builder (old format) and rewrites them in the grouped format expected by
+// geth PR #33658.
+//
+// Old format (per node): [type=2][leftHash(32)][rightHash(32)] at full bit-path
+// New format (per group): [type=2][groupDepth][bitmap][present hashes...] at group boundary
+//
+// Algorithm:
+// 1. Read all trie nodes from DB into an in-memory map: path -> blob
+// 2. For each group boundary, traverse groupDepth levels down via DFS,
+//    collecting bottom-layer child hashes and building the bitmap
+// 3. Serialize in new format, write at group boundary, delete old keys
+func regroupTrieNodes(db ethdb.KeyValueStore, groupDepth int, verbose bool) error {
+	if groupDepth < 1 || groupDepth > maxGroupDepth {
+		return fmt.Errorf("groupDepth must be 1-%d, got %d", maxGroupDepth, groupDepth)
+	}
+
+	prefix := verkleTrieNodeKeyPrefix // "vA"
+
+	// Step 1: Read all trie nodes into memory
+	type nodeInfo struct {
+		blob     []byte
+		nodeType byte // 1=stem, 2=internal
+	}
+	nodes := make(map[string]nodeInfo)
+
+	iter := db.NewIterator(prefix, nil)
+	for iter.Next() {
+		key := iter.Key()
+		if !bytes.HasPrefix(key, prefix) {
+			break
+		}
+		path := string(key[len(prefix):])
+		blob := make([]byte, len(iter.Value()))
+		copy(blob, iter.Value())
+		nodes[path] = nodeInfo{
+			blob:     blob,
+			nodeType: blob[0],
+		}
+	}
+	iter.Release()
+
+	if len(nodes) == 0 {
+		return nil
+	}
+
+	if verbose {
+		var internalCount, stemCount int
+		for _, n := range nodes {
+			if n.nodeType == nodeTypeInternal {
+				internalCount++
+			} else {
+				stemCount++
+			}
+		}
+		log.Printf("Regrouping: %d internal nodes + %d stem nodes, groupDepth=%d",
+			internalCount, stemCount, groupDepth)
+	}
+
+	batch := db.NewBatch()
+
+	// Step 2: Find all internal node paths at group boundaries
+	// (depths that are multiples of groupDepth).
+	var boundaryPaths []string
+	for path, n := range nodes {
+		depth := len(path)
+		if n.nodeType == nodeTypeInternal && depth%groupDepth == 0 {
+			boundaryPaths = append(boundaryPaths, path)
+		}
+	}
+	// Sort boundaries from deepest to shallowest for consistent processing
+	sort.Slice(boundaryPaths, func(i, j int) bool {
+		return len(boundaryPaths[i]) > len(boundaryPaths[j])
+	})
+
+	// Step 3: For each group boundary, collect bottom-layer children via DFS
+	for _, bPath := range boundaryPaths {
+		bitmapSize := bitmapSizeForDepth(groupDepth)
+		bitmap := make([]byte, bitmapSize)
+
+		type stackEntry struct {
+			path     string
+			relDepth int
+			position int
+		}
+		type posHash struct {
+			position int
+			hash     common.Hash
+		}
+		var collected []posHash
+
+		stack := []stackEntry{{path: bPath, relDepth: 0, position: 0}}
+
+		for len(stack) > 0 {
+			top := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+
+			if top.relDepth == groupDepth {
+				// Bottom layer of this group.
+				n, exists := nodes[top.path]
+				if exists {
+					h := computeNodeHashFromBlob(n.blob)
+					collected = append(collected, posHash{position: top.position, hash: h})
+				}
+				continue
+			}
+
+			n, exists := nodes[top.path]
+			if !exists {
+				continue
+			}
+
+			if n.nodeType == nodeTypeStem {
+				// Stem node at intermediate depth — terminates early.
+				// Extend position using the stem actual key bits so that
+				// GetValuesAtStem traversal (which follows key bits) reaches it.
+				remainingDepth := groupDepth - top.relDepth
+				absDepth := len(bPath) + top.relDepth
+				stemBytes := n.blob[1 : 1+stemSize] // stem is 31 bytes after type byte
+				leafPos := top.position
+				for d := 0; d < remainingDepth; d++ {
+					bitIdx := absDepth + d
+					bit := int(stemBytes[bitIdx/8] >> (7 - (bitIdx % 8)) & 1)
+					leafPos = leafPos*2 + bit
+				}
+				h := computeNodeHashFromBlob(n.blob)
+				collected = append(collected, posHash{position: leafPos, hash: h})
+				continue
+			}
+
+			// Internal node — recurse into children.
+			leftPath := top.path + string([]byte{0x00})
+			stack = append(stack, stackEntry{
+				path:     leftPath,
+				relDepth: top.relDepth + 1,
+				position: top.position * 2,
+			})
+			rightPath := top.path + string([]byte{0x01})
+			stack = append(stack, stackEntry{
+				path:     rightPath,
+				relDepth: top.relDepth + 1,
+				position: top.position*2 + 1,
+			})
+		}
+
+		if len(collected) == 0 {
+			continue
+		}
+
+		// Sort by position to ensure hashes are in bitmap order.
+		sort.Slice(collected, func(i, j int) bool {
+			return collected[i].position < collected[j].position
+		})
+
+		// Build bitmap and hash list.
+		var hashes []common.Hash
+		for _, ph := range collected {
+			byteIdx := ph.position / 8
+			bitIdx := 7 - (ph.position % 8)
+			bitmap[byteIdx] |= 1 << uint(bitIdx)
+			hashes = append(hashes, ph.hash)
+		}
+
+		// Serialize: [type=2][groupDepth][bitmap][hashes...]
+		size := 1 + 1 + bitmapSize + len(hashes)*hashSize
+		buf := make([]byte, size)
+		buf[0] = nodeTypeInternal
+		buf[1] = byte(groupDepth)
+		copy(buf[2:2+bitmapSize], bitmap)
+		offset := 2 + bitmapSize
+		for _, h := range hashes {
+			copy(buf[offset:offset+hashSize], h[:])
+			offset += hashSize
+		}
+
+		// Write at group boundary path.
+		key := make([]byte, len(prefix)+len(bPath))
+		copy(key, prefix)
+		copy(key[len(prefix):], bPath)
+		if err := batch.Put(key, buf); err != nil {
+			return fmt.Errorf("failed to write regrouped node: %w", err)
+		}
+	}
+
+	// Step 4: Delete intermediate internal nodes (not at group boundaries).
+	for path, n := range nodes {
+		if n.nodeType != nodeTypeInternal {
+			continue
+		}
+		depth := len(path)
+		if depth%groupDepth != 0 {
+			key := make([]byte, len(prefix)+len(path))
+			copy(key, prefix)
+			copy(key[len(prefix):], path)
+			if err := batch.Delete(key); err != nil {
+				return fmt.Errorf("failed to delete intermediate node: %w", err)
+			}
+		}
+	}
+
+	// Step 4b: Move stems within groups to their extended paths.
+	// A stem at depth D within a group (boundary B, boundary+groupDepth) must be
+	// stored at path length boundary+groupDepth, extended with the stem actual key bits.
+	for path, n := range nodes {
+		if n.nodeType != nodeTypeStem {
+			continue
+		}
+		depth := len(path)
+		groupBoundary := (depth / groupDepth) * groupDepth
+		nextBoundary := groupBoundary + groupDepth
+		if depth >= nextBoundary || depth == groupBoundary {
+			// Stem is at or past group boundary — no extension needed.
+			continue
+		}
+		stemBytes := n.blob[1 : 1+stemSize]
+		extendedPath := make([]byte, nextBoundary)
+		copy(extendedPath, path)
+		for i := depth; i < nextBoundary; i++ {
+			extendedPath[i] = stemBytes[i/8] >> (7 - (i % 8)) & 1
+		}
+
+		oldKey := make([]byte, len(prefix)+len(path))
+		copy(oldKey, prefix)
+		copy(oldKey[len(prefix):], path)
+
+		newKey := make([]byte, len(prefix)+len(extendedPath))
+		copy(newKey, prefix)
+		copy(newKey[len(prefix):], extendedPath)
+
+		if err := batch.Delete(oldKey); err != nil {
+			return fmt.Errorf("failed to delete old stem path: %w", err)
+		}
+		if err := batch.Put(newKey, n.blob); err != nil {
+			return fmt.Errorf("failed to write extended stem path: %w", err)
+		}
+	}
+
+	if batch.ValueSize() > 0 {
+		if err := batch.Write(); err != nil {
+			return fmt.Errorf("failed to write regroup batch: %w", err)
+		}
+	}
+
+	if verbose {
+		log.Printf("Regrouping complete: %d group boundary nodes written", len(boundaryPaths))
+	}
+
+	return nil
+}
+
+// computeNodeHashFromBlob computes the hash of a trie node from its serialized blob.
+// For internal nodes (old format): hash = SHA256(leftHash || rightHash)
+// For stem nodes: hash = SHA256(stem || 0x00 || treeRoot) using 8-level reduction
+func computeNodeHashFromBlob(blob []byte) common.Hash {
+	if len(blob) == 0 {
+		return common.Hash{}
+	}
+
+	switch blob[0] {
+	case nodeTypeInternal:
+		// Old format: [2][leftHash(32)][rightHash(32)] = 65 bytes
+		if len(blob) == 65 {
+			return sha256.Sum256(blob[1:65])
+		}
+		return sha256.Sum256(blob[1:])
+
+	case nodeTypeStem:
+		// Stem node: [1][stem(31)][bitmap(32)][values...]
+		// Hash = SHA256(stem || 0x00 || treeRoot)
+		if len(blob) < 1+stemSize+hashSize {
+			return common.Hash{}
+		}
+		stem := blob[1 : 1+stemSize]
+		bitmapBytes := blob[1+stemSize : 1+stemSize+hashSize]
+
+		var data [stemNodeWidth]common.Hash
+		var zeroHash common.Hash
+		valueOffset := 1 + stemSize + hashSize
+		for i := 0; i < stemNodeWidth; i++ {
+			if bitmapBytes[i/8]&(1<<(7-(i%8))) != 0 {
+				if valueOffset+hashSize <= len(blob) {
+					var val [hashSize]byte
+					copy(val[:], blob[valueOffset:valueOffset+hashSize])
+					data[i] = sha256.Sum256(val[:])
+					valueOffset += hashSize
+				}
+			}
+		}
+
+		// 8-level tree reduction
+		var buf [64]byte
+		for level := 1; level <= 8; level++ {
+			count := stemNodeWidth / (1 << level)
+			for i := 0; i < count; i++ {
+				if data[i*2] == zeroHash && data[i*2+1] == zeroHash {
+					data[i] = zeroHash
+					continue
+				}
+				copy(buf[:32], data[i*2][:])
+				copy(buf[32:], data[i*2+1][:])
+				data[i] = sha256.Sum256(buf[:])
+			}
+		}
+
+		// Final: SHA256(stem || 0x00 || data[0])
+		var final [stemSize + 1 + hashSize]byte
+		copy(final[:stemSize], stem)
+		final[stemSize] = 0x00
+		copy(final[stemSize+1:], data[0][:])
+		return sha256.Sum256(final[:])
+
+	default:
+		return sha256.Sum256(blob)
+	}
+}

--- a/genesis.json
+++ b/genesis.json
@@ -1,0 +1,42 @@
+{
+  "config": {
+    "chainId": 1337,
+    "homesteadBlock": 0,
+    "eip150Block": 0,
+    "eip155Block": 0,
+    "eip158Block": 0,
+    "byzantiumBlock": 0,
+    "constantinopleBlock": 0,
+    "petersburgBlock": 0,
+    "istanbulBlock": 0,
+    "muirGlacierBlock": 0,
+    "berlinBlock": 0,
+    "londonBlock": 0,
+    "arrowGlacierBlock": 0,
+    "grayGlacierBlock": 0,
+    "mergeNetsplitBlock": 0,
+    "shanghaiTime": 0,
+    "cancunTime": 0,
+    "pragueTime": 0,
+    "osakaTime": 0,
+    "terminalTotalDifficulty": 0,
+    "terminalTotalDifficultyPassed": true,
+    "blobSchedule": {
+      "cancun": { "target": 3, "max": 6, "baseFeeUpdateFraction": 3338477 },
+      "prague": { "target": 6, "max": 9, "baseFeeUpdateFraction": 5225352 },
+      "osaka": { "target": 9, "max": 12, "baseFeeUpdateFraction": 5225352 }
+    }
+  },
+  "nonce": "0x0",
+  "timestamp": "0x0",
+  "extraData": "0x",
+  "gasLimit": "0x5F5E100",
+  "difficulty": "0x0",
+  "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "coinbase": "0x0000000000000000000000000000000000000000",
+  "alloc": {
+    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266": {
+      "balance": "0x33b2e3c91efc989409c0000"
+    }
+  }
+}

--- a/main.go
+++ b/main.go
@@ -64,6 +64,10 @@ var (
 	// Output format
 	outputFormat = flag.String("output-format", "geth", "Output database format: 'geth' (Pebble) or 'erigon' (MDBX)")
 
+	// Binary trie group depth
+	groupDepth      = flag.Int("group-depth", 8, "Binary trie group depth (1-8, default 8). Controls serialization unit size.")
+	pebbleBlockSize = flag.Int("pebble-block-size", 4096, "PebbleDB SSTable block size in bytes (default 4096)")
+
 	// Stats server
 	statsPort = flag.Int("stats-port", 0, "Port for live stats HTTP server (0 = disabled)")
 )
@@ -197,7 +201,9 @@ func main() {
 			Depth:       *deepBranchDepth,
 			KnownSlots:  *deepBranchKnownSlots,
 		},
-		LiveStats: liveStats,
+		LiveStats:       liveStats,
+		GroupDepth:       *groupDepth,
+		PebbleBlockSize: *pebbleBlockSize,
 	}
 
 	// Load genesis if provided
@@ -254,6 +260,10 @@ func main() {
 		if config.CommitInterval > 0 {
 			log.Printf("  Commit Interval: %d trie insertions", config.CommitInterval)
 		}
+		if config.GroupDepth > 0 {
+			log.Printf("  Group Depth:     %d", config.GroupDepth)
+		}
+		log.Printf("  Pebble Block:    %d bytes", config.PebbleBlockSize)
 		if config.TargetSize > 0 {
 			log.Printf("  Target Size:  %s", formatBytes(config.TargetSize))
 		}


### PR DESCRIPTION
## Summary

- Add `--group-depth` flag (1-8, default 8) to control how many trie levels are serialized per DB entry, matching geth's grouped format
- Add `--pebble-block-size` flag (default 4096) for PebbleDB SSTable block size tuning
- Implement two-pass grouped serialization via `regroupTrieNodes()` that restructures individual nodes into grouped entries
- Add direct grouped emission in the streaming builder for correct root computation
- Add comprehensive grouped emission tests with geth `bintrie.DeserializeNode` traversal verification
- Include genesis file for dev mode benchmarking

These changes enable benchmarking different group-depth configurations (GD-1 through GD-8) to find the optimal trade-off between read path depth and per-node rehashing cost.