### PR TITLE
fix: use full StateAccount RLP for account trie entries

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -251,9 +251,17 @@ func (g *Generator) generateStreamingMPT() (*Stats, error) {
 				snapErrCh <- fmt.Errorf("write account: %w", err)
 				return
 			}
-			// Store trie entry for Phase 2
-			slimData := types.SlimAccountRLP(work.acc)
-			if err := writeAcctTrieEntry(work.addrHash, slimData); err != nil {
+			// Store trie entry for Phase 2.
+			// MUST use full StateAccount RLP (not SlimAccountRLP) because geth's
+			// trie reader decodes leaf values as StateAccount with a fixed 32-byte
+			// Root field. SlimAccountRLP omits Root for EOAs → decode crash:
+			// "rlp: input string too short for common.Hash"
+			trieData, err := rlp.EncodeToBytes(&work.acc)
+			if err != nil {
+				snapErrCh <- fmt.Errorf("encode account for trie: %w", err)
+				return
+			}
+			if err := writeAcctTrieEntry(work.addrHash, trieData); err != nil {
 				snapErrCh <- fmt.Errorf("write trie entry: %w", err)
 				return
 			}


### PR DESCRIPTION
## Summary

Fixes geth crash when reading MPT databases:
```
rlp: input string too short for common.Hash, decoding into (types.StateAccount).Root
```

**Root cause**: `writeAcctTrieEntry` stored `SlimAccountRLP` in the temp DB, which Phase 2 fed verbatim to the account StackTrie. Geth's trie reader decodes leaf values as `StateAccount` (fixed 32-byte Root field), but `SlimAccountRLP` omits Root for EOAs (nil) → shorter RLP → crash.

**Fix**: Use `rlp.EncodeToBytes(StateAccount)` for trie entries. The snapshot layer continues to use `SlimAccountRLP` (correct — geth expects slim format in snapshots).

This is a 1-line semantic change: `SlimAccountRLP` → `rlp.EncodeToBytes`.

## Context

- The snapshot layer (`WriteAccount`) uses `SlimAccountRLP` → correct
- The account trie (`StackTrie.Update`) must use full `StateAccount` RLP → was wrong
- Bug existed since the original `streamWriteStateMPT` but was hidden because trie nodes weren't persisted before PR #14

## Test plan

- [x] All tests pass: `go test ./generator/... ./genesis/...`
- [ ] Generate 5GB MPT DB, start geth, send 10 txs across 10 blocks