### PR TITLE
feat: bintrie flat-state stem blobs

### DIFF
--- a/generator/binary_stack_trie.go
+++ b/generator/binary_stack_trie.go
@@ -44,6 +44,12 @@ func bitmapSizeForDepth(groupDepth int) int {
 // (rawdb.VerklePrefix), so the full key is "v" + "A" + path.
 var verkleTrieNodeKeyPrefix = []byte("vA")
 
+// binTrieFlatStatePrefix is the database key prefix for bintrie flat-state
+// stem blobs. Each stem blob stores the packed (offset, value) pairs for a
+// single 31-byte stem. Full key: "v" + "X" + stem(31 bytes).
+// Matches rawdb.BinTrieStemPrefix in the go-ethereum bintrie-flat-state branch.
+var binTrieFlatStatePrefix = []byte("vX")
+
 // trieEntry is a single key-value pair destined for the binary trie.
 // Key[0:31] is the stem (routes through InternalNode bit tree, 248 bits).
 // Key[31] is the suffix (indexes into a StemNode's 256-slot Values array).
@@ -96,6 +102,73 @@ func (w *trieNodeWriter) flush() {
 	if w.batch.ValueSize() > 0 {
 		if err := w.batch.Write(); err != nil {
 			log.Fatalf("failed to flush trie node batch: %v", err)
+		}
+	}
+}
+
+// serializeStemBlob encodes trie entries sharing a stem into the bintrie
+// flat-state stem blob format: [bitmap(32)][value₀(32)][value₁(32)]...
+// This is the same bitmap+values encoding as serializeStemNode, minus the
+// [type][stem] prefix (the stem is stored in the DB key instead).
+//
+// Entries must share the same stem and be sorted by suffix (Key[31]).
+func serializeStemBlob(entries []trieEntry) []byte {
+	var bitmap [hashSize]byte
+	for _, e := range entries {
+		suffix := e.Key[stemSize]
+		bitmap[suffix/8] |= 1 << (7 - (suffix % 8))
+	}
+
+	buf := make([]byte, hashSize+len(entries)*hashSize)
+	copy(buf[:hashSize], bitmap[:])
+
+	offset := hashSize
+	for _, e := range entries {
+		copy(buf[offset:offset+hashSize], e.Value[:])
+		offset += hashSize
+	}
+	return buf
+}
+
+// stemBlobWriter batches flat-state stem blob writes to Pebble.
+// Each blob is written at key "vX" + stem(31 bytes). Flushes when
+// batch exceeds 256MB (same threshold as trieNodeWriter).
+type stemBlobWriter struct {
+	batch  ethdb.Batch
+	db     ethdb.KeyValueStore
+	stems  int
+	bytes  int64
+	keyBuf []byte
+}
+
+func (w *stemBlobWriter) writeStemBlob(stem []byte, entries []trieEntry) {
+	blob := serializeStemBlob(entries)
+
+	needed := len(binTrieFlatStatePrefix) + stemSize
+	if cap(w.keyBuf) < needed {
+		w.keyBuf = make([]byte, needed)
+	}
+	key := w.keyBuf[:needed]
+	copy(key, binTrieFlatStatePrefix)
+	copy(key[len(binTrieFlatStatePrefix):], stem[:stemSize])
+
+	if err := w.batch.Put(key, blob); err != nil {
+		log.Fatalf("failed to write stem blob: %v", err)
+	}
+	w.stems++
+	w.bytes += int64(len(key) + len(blob))
+	if w.batch.ValueSize() >= 256*1024*1024 {
+		if err := w.batch.Write(); err != nil {
+			log.Fatalf("failed to flush stem blob batch: %v", err)
+		}
+		w.batch.Reset()
+	}
+}
+
+func (w *stemBlobWriter) flush() {
+	if w.batch.ValueSize() > 0 {
+		if err := w.batch.Write(); err != nil {
+			log.Fatalf("failed to flush stem blob batch: %v", err)
 		}
 	}
 }
@@ -639,6 +712,11 @@ type trieNodeStats struct {
 	Bytes int64
 }
 
+type stemBlobStats struct {
+	Stems int
+	Bytes int64
+}
+
 // computeBinaryRootStreamingFromSlice is the slice-based variant used for
 // testing equivalence with the recursive approach. It feeds pre-sorted
 // entries directly into the streaming builder without needing a DB iterator.
@@ -826,7 +904,8 @@ func computeBinaryRootStreamingParallel(
 	db ethdb.KeyValueStore,
 	groupDepth int,
 	numWorkers int,
-) (common.Hash, trieNodeStats, error) {
+	sbw *stemBlobWriter, // nil to skip flat-state stem blob writes
+) (common.Hash, trieNodeStats, stemBlobStats, error) {
 	if numWorkers < 1 {
 		numWorkers = 1
 	}
@@ -846,6 +925,7 @@ func computeBinaryRootStreamingParallel(
 	// --- Builder goroutine ---
 	var rootHash common.Hash
 	var tnStats trieNodeStats
+	var sbStats stemBlobStats
 	var builderWg sync.WaitGroup
 	builderWg.Add(1)
 	go func() {
@@ -862,6 +942,9 @@ func computeBinaryRootStreamingParallel(
 
 		for r := range builderCh {
 			sb.feedStem(r.stem[:], r.hash, r.entries)
+			if sbw != nil {
+				sbw.writeStemBlob(r.stem[:], r.entries)
+			}
 		}
 
 		rootHash = sb.finish()
@@ -869,6 +952,11 @@ func computeBinaryRootStreamingParallel(
 			sb.w.flush()
 			tnStats = trieNodeStats{Nodes: sb.w.nodes, Bytes: sb.w.bytes}
 			log.Printf("Wrote %d trie nodes (%d MB)", sb.w.nodes, sb.w.bytes/1024/1024)
+		}
+		if sbw != nil {
+			sbw.flush()
+			sbStats = stemBlobStats{Stems: sbw.stems, Bytes: sbw.bytes}
+			log.Printf("Wrote %d stem blobs (%d MB)", sbw.stems, sbw.bytes/1024/1024)
 		}
 	}()
 
@@ -1014,13 +1102,13 @@ done:
 	// Check for errors
 	select {
 	case err := <-errCh:
-		return common.Hash{}, trieNodeStats{}, err
+		return common.Hash{}, trieNodeStats{}, stemBlobStats{}, err
 	default:
 	}
 
 	if ctx.Err() != nil {
-		return common.Hash{}, trieNodeStats{}, ctx.Err()
+		return common.Hash{}, trieNodeStats{}, stemBlobStats{}, ctx.Err()
 	}
 
-	return rootHash, tnStats, nil
+	return rootHash, tnStats, sbStats, nil
 }

--- a/generator/config.go
+++ b/generator/config.go
@@ -169,6 +169,10 @@ type Stats struct {
 	// Only populated when WriteTrieNodes is true.
 	TrieNodeBytes uint64
 
+	// StemBlobBytes is the number of bytes written for bintrie flat-state
+	// stem blobs (Phase 2). Only populated in binary trie mode.
+	StemBlobBytes uint64
+
 	// DeepBranchAccounts is the number of deep-branch contracts created.
 	DeepBranchAccounts int
 

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -778,8 +778,9 @@ func (g *Generator) generateStreamingBinary() (retStats *Stats, retErr error) {
 
 	// Note: We use g.writer (StateWriter) for final output, not batchWriter
 
-	// Snapshot writes happen in a background goroutine so they don't block
-	// the critical path (temp DB writes for Phase 2).
+	// Background goroutine writes code entries ("c" + keccak256(code)) during
+	// Phase 1. Account/storage flat state is NOT written here — stem blobs are
+	// written in Phase 2 by the builder goroutine via stemBlobWriter.
 	type snapshotWork struct {
 		acc *accountData
 	}
@@ -790,7 +791,7 @@ func (g *Generator) generateStreamingBinary() (retStats *Stats, retErr error) {
 	go func() {
 		defer snapWg.Done()
 		for sw := range snapCh {
-			if err := g.writeAccountSnapshot(sw.acc); err != nil {
+			if err := g.writeCodeOnly(sw.acc); err != nil {
 				snapErr.Store(err)
 				for range snapCh {
 				}
@@ -1112,6 +1113,14 @@ func (g *Generator) generateStreamingBinary() (retStats *Stats, retErr error) {
 	if g.config.WriteTrieNodes && g.config.OutputFormat == OutputGeth && g.db != nil {
 		nodeDB = g.db
 	}
+
+	// Create stem blob writer for bintrie flat-state.
+	// Writes stem blobs at "vX" + stem during Phase 2 (alongside trie nodes).
+	var sbw *stemBlobWriter
+	if g.config.OutputFormat == OutputGeth && g.db != nil {
+		sbw = &stemBlobWriter{batch: g.db.NewBatch(), db: g.db}
+	}
+
 	iter := tempDB.NewIterator(nil, nil)
 	numWorkers := runtime.GOMAXPROCS(0) - 2
 	if numWorkers < 2 {
@@ -1120,8 +1129,8 @@ func (g *Generator) generateStreamingBinary() (retStats *Stats, retErr error) {
 	if g.config.Verbose {
 		log.Printf("Phase 2: using %d parallel workers", numWorkers)
 	}
-	stateRoot, tnStats, err := computeBinaryRootStreamingParallel(
-		context.Background(), iter, nodeDB, g.config.GroupDepth, numWorkers,
+	stateRoot, tnStats, sbStats, err := computeBinaryRootStreamingParallel(
+		context.Background(), iter, nodeDB, g.config.GroupDepth, numWorkers, sbw,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute binary root: %w", err)
@@ -1130,11 +1139,11 @@ func (g *Generator) generateStreamingBinary() (retStats *Stats, retErr error) {
 		log.Printf("Computed binary trie root in %v", time.Since(hashStart).Round(time.Millisecond))
 	}
 
-	// Wait for snapshot writes to complete (they ran concurrently with Phase 2).
+	// Wait for code writes to complete (they ran concurrently with Phase 2).
 	closeSnap()
 	snapWg.Wait()
 	if e := snapErr.Load(); e != nil {
-		return nil, fmt.Errorf("snapshot write failed: %w", e.(error))
+		return nil, fmt.Errorf("code write failed: %w", e.(error))
 	}
 	if err := g.writer.Flush(); err != nil {
 		return nil, fmt.Errorf("failed to flush writer: %w", err)
@@ -1158,7 +1167,8 @@ func (g *Generator) generateStreamingBinary() (retStats *Stats, retErr error) {
 	stats.StorageBytes = writerStats.StorageBytes
 	stats.CodeBytes = writerStats.CodeBytes
 	stats.TrieNodeBytes = uint64(tnStats.Bytes)
-	stats.TotalBytes = stats.AccountBytes + stats.StorageBytes + stats.CodeBytes + stats.TrieNodeBytes
+	stats.StemBlobBytes = uint64(sbStats.Bytes)
+	stats.TotalBytes = stats.AccountBytes + stats.StorageBytes + stats.CodeBytes + stats.TrieNodeBytes + stats.StemBlobBytes
 
 	elapsed := time.Since(start)
 	stats.GenerationTime = elapsed
@@ -1167,33 +1177,16 @@ func (g *Generator) generateStreamingBinary() (retStats *Stats, retErr error) {
 	return stats, nil
 }
 
-// writeAccountSnapshot writes snapshot entries for an account using the StateWriter.
-// Handles storage, account, and code writes. This is the snapshot layer —
-// separate from trie root computation.
-func (g *Generator) writeAccountSnapshot(acc *accountData) error {
-	// Storage: write each slot via StateWriter (pre-compute hashes to avoid redundant work)
-	for _, slot := range acc.storage {
-		slotHash := crypto.Keccak256Hash(slot.Key[:])
-		if err := g.writer.WriteStorage(acc.address, acc.addrHash, slot.Key, slotHash, slot.Value); err != nil {
-			return fmt.Errorf("write storage: %w", err)
-		}
-	}
-
-	// Account: Root is always EmptyRootHash in binary trie mode
-	// (binary trie doesn't use per-account storage roots like MPT).
-	snapshotAcc := *acc.account
-	snapshotAcc.Root = types.EmptyRootHash
-	if err := g.writer.WriteAccount(acc.address, acc.addrHash, &snapshotAcc, 0); err != nil {
-		return fmt.Errorf("write account: %w", err)
-	}
-
-	// Code
+// writeCodeOnly writes only contract code to the DB. Used in binary trie mode
+// where account/storage flat state is written as stem blobs in Phase 2, but
+// code still needs to be persisted under "c" + keccak256(code) for geth's
+// code reader (the EVM reads full code from there, not from trie chunks).
+func (g *Generator) writeCodeOnly(acc *accountData) error {
 	if len(acc.code) > 0 {
 		if err := g.writer.WriteCode(acc.codeHash, acc.code); err != nil {
 			return fmt.Errorf("write code: %w", err)
 		}
 	}
-
 	return nil
 }
 

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -1,12 +1,12 @@
 package generator
 
 import (
+	"math/bits"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb/pebble"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -487,42 +487,68 @@ func TestDatabaseContentBinaryTrie(t *testing.T) {
 		t.Errorf("Snapshot root mismatch: got %s, want %s", snapshotRoot.Hex(), stats.StateRoot.Hex())
 	}
 
-	// Count account snapshots (prefix "a")
+	// MPT-style snapshot entries ("a", "o") should NOT exist in binary trie mode.
+	// Flat state is stored as stem blobs under "vX" prefix instead.
 	iter := db.NewIterator([]byte("a"), nil)
 	accountCount := 0
 	for iter.Next() {
-		// Decode slim account and verify Root == EmptyRootHash
-		// This is the key binary trie invariant: no per-account storage subtries
-		val := iter.Value()
-		acc, err := types.FullAccount(val)
-		if err != nil {
-			t.Fatalf("Failed to decode slim account: %v", err)
-		}
-		if acc.Root != types.EmptyRootHash {
-			t.Errorf("Binary trie account should have EmptyRootHash, got %s", acc.Root.Hex())
-		}
 		accountCount++
 	}
 	iter.Release()
-
-	expectedAccounts := config.NumAccounts + config.NumContracts
-	if accountCount != expectedAccounts {
-		t.Errorf("Expected %d accounts in DB, got %d", expectedAccounts, accountCount)
+	if accountCount != 0 {
+		t.Errorf("Expected 0 MPT account snapshots in binary trie mode, got %d", accountCount)
 	}
 
-	// Count storage snapshots (prefix "o")
 	iter = db.NewIterator([]byte("o"), nil)
 	storageCount := 0
 	for iter.Next() {
 		storageCount++
 	}
 	iter.Release()
-
-	if storageCount != stats.StorageSlotsCreated {
-		t.Errorf("Expected %d storage slots in DB, got %d", stats.StorageSlotsCreated, storageCount)
+	if storageCount != 0 {
+		t.Errorf("Expected 0 MPT storage snapshots in binary trie mode, got %d", storageCount)
 	}
 
-	// Count code entries (prefix "c")
+	// Verify stem blobs exist under "vX" prefix.
+	iter = db.NewIterator([]byte("vX"), nil)
+	stemBlobCount := 0
+	for iter.Next() {
+		key := iter.Key()
+		val := iter.Value()
+		// Key must be "vX" + stem(31 bytes) = 33 bytes total
+		if len(key) != len(binTrieFlatStatePrefix)+stemSize {
+			t.Errorf("Unexpected stem blob key length: got %d, want %d", len(key), len(binTrieFlatStatePrefix)+stemSize)
+		}
+		// Value must be bitmap(32) + N*32 bytes where N = popcount(bitmap)
+		if len(val) < hashSize {
+			t.Errorf("Stem blob too short: got %d bytes, want at least %d", len(val), hashSize)
+			continue
+		}
+		var bitmap [hashSize]byte
+		copy(bitmap[:], val[:hashSize])
+		popcount := 0
+		for _, b := range bitmap {
+			popcount += bits.OnesCount8(b)
+		}
+		expectedLen := hashSize + popcount*hashSize
+		if len(val) != expectedLen {
+			t.Errorf("Stem blob length mismatch: got %d, want %d (popcount=%d)", len(val), expectedLen, popcount)
+		}
+		stemBlobCount++
+	}
+	iter.Release()
+
+	if stemBlobCount == 0 {
+		t.Errorf("Expected stem blobs under 'vX' prefix, got 0")
+	}
+	t.Logf("Found %d stem blobs under 'vX' prefix", stemBlobCount)
+
+	// Verify StemBlobBytes stat is populated
+	if stats.StemBlobBytes == 0 {
+		t.Errorf("Expected StemBlobBytes > 0, got 0")
+	}
+
+	// Count code entries (prefix "c") — still written in binary trie mode
 	iter = db.NewIterator([]byte("c"), nil)
 	codeCount := 0
 	for iter.Next() {
@@ -532,6 +558,64 @@ func TestDatabaseContentBinaryTrie(t *testing.T) {
 
 	if codeCount != config.NumContracts {
 		t.Errorf("Expected %d code entries in DB, got %d", config.NumContracts, codeCount)
+	}
+}
+
+func TestStemBlobEncoding(t *testing.T) {
+	// Verify serializeStemBlob produces the expected format:
+	// [bitmap(32)][value0(32)][value1(32)]...
+	// Bitmap: byte offset/8, MSB = lowest in-byte offset.
+
+	entries := []trieEntry{
+		// Offset 0 (BasicData) — byte 0, bit 7
+		{Key: [32]byte{31: 0}, Value: [32]byte{0: 0xAA}},
+		// Offset 1 (CodeHash) — byte 0, bit 6
+		{Key: [32]byte{31: 1}, Value: [32]byte{0: 0xBB}},
+		// Offset 128 (code chunk 0) — byte 16, bit 7
+		{Key: [32]byte{31: 128}, Value: [32]byte{0: 0xCC}},
+	}
+
+	blob := serializeStemBlob(entries)
+
+	// Expected size: 32 (bitmap) + 3*32 (values) = 128
+	if len(blob) != 128 {
+		t.Fatalf("Expected blob length 128, got %d", len(blob))
+	}
+
+	// Check bitmap bits
+	bitmap := blob[:32]
+	// Offset 0: byte 0, bit 7 (0x80)
+	// Offset 1: byte 0, bit 6 (0x40)
+	// Combined byte 0 = 0xC0
+	if bitmap[0] != 0xC0 {
+		t.Errorf("Bitmap byte 0: got 0x%02X, want 0xC0", bitmap[0])
+	}
+	// Offset 128: byte 16, bit 7 (0x80)
+	if bitmap[16] != 0x80 {
+		t.Errorf("Bitmap byte 16: got 0x%02X, want 0x80", bitmap[16])
+	}
+	// All other bitmap bytes should be 0
+	for i, b := range bitmap {
+		if i == 0 || i == 16 {
+			continue
+		}
+		if b != 0 {
+			t.Errorf("Bitmap byte %d should be 0, got 0x%02X", i, b)
+		}
+	}
+
+	// Check values are packed in order
+	val0 := blob[32:64]
+	val1 := blob[64:96]
+	val2 := blob[96:128]
+	if val0[0] != 0xAA {
+		t.Errorf("Value 0 first byte: got 0x%02X, want 0xAA", val0[0])
+	}
+	if val1[0] != 0xBB {
+		t.Errorf("Value 1 first byte: got 0x%02X, want 0xBB", val1[0])
+	}
+	if val2[0] != 0xCC {
+		t.Errorf("Value 2 first byte: got 0x%02X, want 0xCC", val2[0])
 	}
 }
 
@@ -607,7 +691,7 @@ func TestBinaryTrieStateRootValue(t *testing.T) {
 		t.Fatalf("Failed to generate state: %v", err)
 	}
 
-	expected := common.HexToHash("0x705a2444d071172ede2025116221d21ee38c8dc9fc426b76eb61ecc348f913c2")
+	expected := common.HexToHash("0xee656cf3921d8cbd1aa003a881128846feed2f2c670fa9110cac78f6f8e9d263")
 	if stats.StateRoot != expected {
 		t.Errorf("Binary trie state root mismatch:\n  got:  %s\n  want: %s\nThis may indicate an upstream bintrie API change.",
 			stats.StateRoot.Hex(), expected.Hex())
@@ -726,7 +810,7 @@ func TestBinaryTrieCommitIntervalGoldenHash(t *testing.T) {
 	}
 
 	// Must match the same golden hash as TestBinaryTrieStateRootValue.
-	expected := common.HexToHash("0x705a2444d071172ede2025116221d21ee38c8dc9fc426b76eb61ecc348f913c2")
+	expected := common.HexToHash("0xee656cf3921d8cbd1aa003a881128846feed2f2c670fa9110cac78f6f8e9d263")
 	if stats.StateRoot != expected {
 		t.Errorf("CommitInterval golden hash mismatch:\n  got:  %s\n  want: %s",
 			stats.StateRoot.Hex(), expected.Hex())

--- a/generator/genesis_integration_test.go
+++ b/generator/genesis_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/trie/bintrie"
 	"github.com/holiman/uint256"
 )
 
@@ -227,43 +228,36 @@ func TestGenesisAccountsIntegrationBinaryTrie(t *testing.T) {
 		t.Errorf("Expected at least 2 storage slots from genesis, got %d", stats.StorageSlotsCreated)
 	}
 
-	// Verify genesis accounts are in the database
+	// In binary trie mode, flat state is stored as stem blobs under "vX" prefix,
+	// NOT as MPT-style "a"/"o" snapshot entries.
 	db := gen.DB()
 
+	// Verify genesis EOA exists in stem blobs
 	addr1 := common.HexToAddress("0x1111111111111111111111111111111111111111")
-	addrHash1 := crypto.Keccak256Hash(addr1[:])
-	data1, err := db.Get(append([]byte("a"), addrHash1[:]...))
+	var zeroKey [hashSize]byte
+	stem1 := bintrie.GetBinaryTreeKey(addr1, zeroKey[:])
+	stemBlobKey1 := append([]byte("vX"), stem1[:stemSize]...)
+	data1, err := db.Get(stemBlobKey1)
 	if err != nil {
-		t.Errorf("Genesis EOA not found in database: %v", err)
+		t.Errorf("Genesis EOA stem blob not found in database: %v", err)
 	}
-	if len(data1) == 0 {
-		t.Error("Genesis EOA data is empty")
+	if len(data1) < hashSize {
+		t.Error("Genesis EOA stem blob is too short")
 	}
 
+	// Verify genesis contract exists in stem blobs
 	addr2 := common.HexToAddress("0x2222222222222222222222222222222222222222")
-	addrHash2 := crypto.Keccak256Hash(addr2[:])
-	data2, err := db.Get(append([]byte("a"), addrHash2[:]...))
+	stem2 := bintrie.GetBinaryTreeKey(addr2, zeroKey[:])
+	stemBlobKey2 := append([]byte("vX"), stem2[:stemSize]...)
+	data2, err := db.Get(stemBlobKey2)
 	if err != nil {
-		t.Errorf("Genesis contract not found in database: %v", err)
+		t.Errorf("Genesis contract stem blob not found in database: %v", err)
 	}
-	if len(data2) == 0 {
-		t.Error("Genesis contract data is empty")
+	if len(data2) < hashSize {
+		t.Error("Genesis contract stem blob is too short")
 	}
 
-	// Verify storage slot
-	slotKey := common.HexToHash("0x01")
-	slotKeyHash := crypto.Keccak256Hash(slotKey[:])
-	storageKey := append([]byte("o"), addrHash2[:]...)
-	storageKey = append(storageKey, slotKeyHash[:]...)
-	storageData, err := db.Get(storageKey)
-	if err != nil {
-		t.Errorf("Genesis storage slot not found: %v", err)
-	}
-	if len(storageData) == 0 {
-		t.Error("Genesis storage slot data is empty")
-	}
-
-	// Verify code
+	// Verify code (still under "c" prefix)
 	codeHash := crypto.Keccak256Hash(genesisCode[addr2])
 	codeData, err := db.Get(append([]byte("c"), codeHash[:]...))
 	if err != nil {

--- a/generator/grouped_emission_test.go
+++ b/generator/grouped_emission_test.go
@@ -434,8 +434,8 @@ func TestParallelStreamingEquivalence(t *testing.T) {
 				parallelDB = rawdb.NewMemoryDatabase()
 			}
 			iter := tempDB.NewIterator(nil, nil)
-			parallelRoot, _, pErr := computeBinaryRootStreamingParallel(
-				context.Background(), iter, parallelDB, tc.groupDepth, 4,
+			parallelRoot, _, _, pErr := computeBinaryRootStreamingParallel(
+				context.Background(), iter, parallelDB, tc.groupDepth, 4, nil,
 			)
 			if pErr != nil {
 				t.Fatalf("parallel computation failed: %v", pErr)

--- a/main.go
+++ b/main.go
@@ -395,6 +395,9 @@ func main() {
 	if stats.TrieNodeBytes > 0 {
 		fmt.Printf("Trie Node Bytes:   %s\n", formatBytes(stats.TrieNodeBytes))
 	}
+	if stats.StemBlobBytes > 0 {
+		fmt.Printf("Stem Blob Bytes:   %s\n", formatBytes(stats.StemBlobBytes))
+	}
 	// Report actual on-disk size (after Pebble compression).
 	if dbSize, err := dirSize(config.DBPath); err == nil {
 		fmt.Printf("Total DB Size:     %s\n", formatBytes(dbSize))


### PR DESCRIPTION
## Summary

Write native stem blobs (`"vX" + stem`) instead of useless MPT-style `"a"`/`"o"` snapshot entries in binary trie mode. DBs are now immediately usable by geth's `bintrie-flat-state` branch without snapshot regeneration.

## Details

In binary trie mode, state-actor was writing MPT-style snapshot entries (`"a" + keccak256(addr)`, `"o" + keccak256(addr) + keccak256(slot)`) that are invisible to geth — it wraps diskdb with a `"v"` prefix table, so `"a"`/`"o"` entries are never read.

Now writes stem blobs at `"vX" + stem(31 bytes)` matching geth's `bintrieFlatCodec` format:
```
[bitmap: 32 bytes]  -- bit i set if offset i populated
[value_0: 32 bytes] -- first populated offset's value
...
```

Stem blobs are written in Phase 2 by the builder goroutine — entries are already grouped by stem at that point. Code entries (`"c" + keccak256(code)`) are still written since geth reads contract bytecode from there in all modes.

Also fixes pre-existing golden hash drift from the full-RLP change in commit 4cb06f7.

## Test plan

- [x] `go test -count=1 ./generator/... ./genesis/...` — all pass
- [x] `TestBinaryTrieStateRootValue` — golden hash verified
- [x] `TestBinaryTrieReproducibility` — same seed → same root
- [x] `TestDatabaseContentBinaryTrie` — verifies stem blobs under `"vX"` prefix
- [x] `TestStemBlobEncoding` — unit test for bitmap/value encoding
- [x] `TestGenesisAccountsIntegrationBinaryTrie` — genesis accounts found in stem blobs