### PR TITLE
fix(geth): write DatabaseVersion + IsBintrie + writer-side PathDB metadata prefix

### DIFF
--- a/client/geth/genesis_block.go
+++ b/client/geth/genesis_block.go
@@ -16,6 +16,12 @@ import (
 	"github.com/nerolation/state-actor/genesis"
 )
 
+// pathdbSchemaVersion mirrors the on-disk schema constant from
+// triedb/pathdb. Geth's startup uses rawdb.ReadDatabaseVersion as a gate
+// for "is this DB initialized?" — without this entry the DB looks blank
+// and geth silently overwrites it with a fresh dev genesis.
+const pathdbSchemaVersion = 9
+
 // prefixWriter wraps a KeyValueWriter to prepend a fixed prefix to all keys.
 // Used to write PathDB metadata into the "v" (verkle) namespace.
 type prefixWriter struct {
@@ -29,6 +35,33 @@ func (pw *prefixWriter) Put(key, value []byte) error {
 
 func (pw *prefixWriter) Delete(key []byte) error {
 	return pw.w.Delete(append(pw.prefix, key...))
+}
+
+// WritePathDBMetadata persists the metadata that geth's PathDB and snapshot
+// layers expect on a freshly populated database. Without these entries geth
+// treats the DB as uninitialized and either overwrites it with a fresh
+// genesis (missing DatabaseVersion) or triggers a full snapshot
+// regeneration (missing/mismatched SnapshotGenerator).
+//
+// Layout note: in binary trie mode pathdb wraps its diskdb under the "v"
+// (rawdb.VerklePrefix) namespace at construction time
+// (triedb/pathdb/database.go:168-170), so StateID, PersistentStateID,
+// SnapshotRoot, and SnapshotGenerator must be written under that prefix.
+// DatabaseVersion is read by geth before pathdb is constructed, so it
+// always lives at the raw key.
+func WritePathDBMetadata(w ethdb.KeyValueWriter, stateRoot common.Hash, binaryTrie bool) error {
+	pathdbWriter := w
+	if binaryTrie {
+		pathdbWriter = &prefixWriter{prefix: []byte("v"), w: w}
+	}
+	rawdb.WriteStateID(pathdbWriter, stateRoot, 0)
+	rawdb.WritePersistentStateID(pathdbWriter, 0)
+	rawdb.WriteSnapshotRoot(pathdbWriter, stateRoot)
+	if err := WriteCompletedSnapshotGenerator(pathdbWriter, binaryTrie); err != nil {
+		return fmt.Errorf("failed to write snapshot generator: %w", err)
+	}
+	rawdb.WriteDatabaseVersion(w, pathdbSchemaVersion)
+	return nil
 }
 
 // WriteGenesisBlock writes the genesis block and associated metadata to the database.
@@ -147,21 +180,8 @@ func WriteGenesisBlock(db ethdb.KeyValueStore, gen *genesis.Genesis, stateRoot c
 	rawdb.WriteHeadHeaderHash(batch, block.Hash())
 	rawdb.WriteChainConfig(batch, block.Hash(), chainCfg)
 
-	// PathDB metadata: state ID tracking and snapshot root.
-	// Required for geth's PathDB disk layer initialization (loadLayers).
-	//
-	// In binary trie mode, PathDB namespaces all its data under the "v"
-	// prefix (rawdb.VerklePrefix). A prefixWriter wraps the batch to add
-	// this prefix transparently, so rawdb functions write to the correct keys.
-	var metadataWriter ethdb.KeyValueWriter = batch
-	if binaryTrie {
-		metadataWriter = &prefixWriter{prefix: []byte("v"), w: batch}
-	}
-	rawdb.WriteStateID(metadataWriter, stateRoot, 0)
-	rawdb.WritePersistentStateID(metadataWriter, 0)
-	rawdb.WriteSnapshotRoot(metadataWriter, stateRoot)
-	if err := WriteCompletedSnapshotGenerator(metadataWriter); err != nil {
-		return nil, fmt.Errorf("failed to write snapshot generator: %w", err)
+	if err := WritePathDBMetadata(batch, stateRoot, binaryTrie); err != nil {
+		return nil, err
 	}
 
 	if err := batch.Write(); err != nil {
@@ -186,13 +206,18 @@ func WriteGenesisBlock(db ethdb.KeyValueStore, gen *genesis.Genesis, stateRoot c
 // snapshotGenerator mirrors the wire format of pathdb's unexported
 // journalGenerator. The field order, types, and naming must match
 // triedb/pathdb/journal.go exactly so RLP-encoded blobs round-trip.
+//
+// IsBintrie is rlp:"optional" upstream too: legacy v3 entries decode with
+// the field defaulted to false, which is the right answer for any merkle
+// database that wrote them.
 type snapshotGenerator struct {
-	Wiping   bool // deprecated, kept for backward compatibility
-	Done     bool
-	Marker   []byte
-	Accounts uint64
-	Slots    uint64
-	Storage  uint64
+	Wiping    bool // deprecated, kept for backward compatibility
+	Done      bool
+	Marker    []byte
+	Accounts  uint64
+	Slots     uint64
+	Storage   uint64
+	IsBintrie bool `rlp:"optional"`
 }
 
 // WriteCompletedSnapshotGenerator persists a SnapshotGenerator entry marking
@@ -206,10 +231,13 @@ type snapshotGenerator struct {
 //   - in binary trie mode (noBuild=true via isVerkle), prevents AccountIterator
 //     and SnapshotCompleted from succeeding.
 //
-// The generator's binary-trie-ness is encoded by writing under the "v"
-// (rawdb.VerklePrefix) namespace via a prefixWriter, not by a struct field.
-func WriteCompletedSnapshotGenerator(w ethdb.KeyValueWriter) error {
-	blob, err := rlp.EncodeToBytes(snapshotGenerator{Done: true})
+// The generator's binary-trie-ness is encoded both by writing under the "v"
+// (rawdb.VerklePrefix) namespace via a prefixWriter and by setting
+// IsBintrie=true in the RLP blob. pathdb/journal.go enforces a scheme match
+// on the IsBintrie field (triedb/pathdb/journal.go:163-171) and discards
+// generators whose flag does not match the opening database's mode.
+func WriteCompletedSnapshotGenerator(w ethdb.KeyValueWriter, isBintrie bool) error {
+	blob, err := rlp.EncodeToBytes(snapshotGenerator{Done: true, IsBintrie: isBintrie})
 	if err != nil {
 		return fmt.Errorf("encode snapshot generator: %w", err)
 	}

--- a/client/geth/genesis_block_test.go
+++ b/client/geth/genesis_block_test.go
@@ -316,3 +316,142 @@ func TestWriteGenesisBlockBinaryTrieNoMutation(t *testing.T) {
 			gen.Config.EnableVerkleAtGenesis, origVerkle)
 	}
 }
+
+// TestWriteGenesisBlockDatabaseVersionMPT pins the rawdb DatabaseVersion gate
+// that geth uses at startup to decide "is this DB initialized?". A nil value
+// causes geth --dev to silently overwrite the DB with a fresh dev genesis,
+// discarding everything state-actor wrote.
+//
+// DatabaseVersion is read before pathdb is constructed, so it must live at
+// the raw key (NOT under the "v" prefix) regardless of trie mode.
+func TestWriteGenesisBlockDatabaseVersionMPT(t *testing.T) {
+	db := rawdb.NewMemoryDatabase()
+	defer db.Close()
+
+	stateRoot := common.HexToHash("0x1212121212121212121212121212121212121212121212121212121212121212")
+	if _, err := WriteGenesisBlock(db, sampleGenesis(), stateRoot, false, ""); err != nil {
+		t.Fatalf("WriteGenesisBlock: %v", err)
+	}
+	assertDatabaseVersionAtRawKey(t, db)
+}
+
+// TestWriteGenesisBlockDatabaseVersionBinaryTrie is the bintrie counterpart:
+// even in bintrie mode, DatabaseVersion stays at the raw key — never under
+// "v" — because geth reads it before pathdb wraps the diskdb.
+func TestWriteGenesisBlockDatabaseVersionBinaryTrie(t *testing.T) {
+	db := rawdb.NewMemoryDatabase()
+	defer db.Close()
+
+	stateRoot := common.HexToHash("0x3434343434343434343434343434343434343434343434343434343434343434")
+	if _, err := WriteGenesisBlock(db, sampleGenesis(), stateRoot, true, ""); err != nil {
+		t.Fatalf("WriteGenesisBlock: %v", err)
+	}
+	assertDatabaseVersionAtRawKey(t, db)
+
+	// And it must NOT be present under the v-prefix — leaking it there would
+	// confuse a future reader and mask a missing raw-key write.
+	prefixed, err := db.Get(append([]byte("v"), []byte("DatabaseVersion")...))
+	if err == nil && len(prefixed) != 0 {
+		t.Errorf("DatabaseVersion unexpectedly present under v-prefix: %x", prefixed)
+	}
+}
+
+// TestSnapshotGeneratorIsBintrieRoundTripMPT pins IsBintrie=false in MPT
+// mode. pathdb/journal.go discards the generator unless IsBintrie matches
+// the opening database's mode, so a stray true here would trigger a full
+// snapshot regeneration.
+func TestSnapshotGeneratorIsBintrieRoundTripMPT(t *testing.T) {
+	db := rawdb.NewMemoryDatabase()
+	defer db.Close()
+
+	stateRoot := common.HexToHash("0x5656565656565656565656565656565656565656565656565656565656565656")
+	if _, err := WriteGenesisBlock(db, sampleGenesis(), stateRoot, false, ""); err != nil {
+		t.Fatalf("WriteGenesisBlock: %v", err)
+	}
+	gen := readSnapshotGeneratorEntry(t, db, nil)
+	if !gen.Done {
+		t.Error("SnapshotGenerator.Done = false, want true")
+	}
+	if gen.IsBintrie {
+		t.Error("SnapshotGenerator.IsBintrie = true in MPT mode, want false")
+	}
+}
+
+// TestSnapshotGeneratorIsBintrieRoundTripBinaryTrie pins IsBintrie=true in
+// bintrie mode and verifies it lives under the "v" prefix. The dual signal
+// (prefix + struct field) is required because pathdb checks both.
+func TestSnapshotGeneratorIsBintrieRoundTripBinaryTrie(t *testing.T) {
+	db := rawdb.NewMemoryDatabase()
+	defer db.Close()
+
+	stateRoot := common.HexToHash("0x7878787878787878787878787878787878787878787878787878787878787878")
+	if _, err := WriteGenesisBlock(db, sampleGenesis(), stateRoot, true, ""); err != nil {
+		t.Fatalf("WriteGenesisBlock: %v", err)
+	}
+	gen := readSnapshotGeneratorEntry(t, db, []byte("v"))
+	if !gen.Done {
+		t.Error("SnapshotGenerator.Done = false under v-prefix, want true")
+	}
+	if !gen.IsBintrie {
+		t.Error("SnapshotGenerator.IsBintrie = false in bintrie mode, want true")
+	}
+}
+
+// TestWritePathDBMetadataPrefixing verifies the full key layout produced by
+// WritePathDBMetadata in isolation, without depending on WriteGenesisBlock.
+func TestWritePathDBMetadataPrefixing(t *testing.T) {
+	stateRoot := common.HexToHash("0x9a9a9a9a9a9a9a9a9a9a9a9a9a9a9a9a9a9a9a9a9a9a9a9a9a9a9a9a9a9a9a9a")
+
+	for _, tc := range []struct {
+		name       string
+		binaryTrie bool
+		// pathdbKeys are read prefixed in bintrie mode, raw in MPT.
+		pathdbKeys []string
+	}{
+		{name: "MPT", binaryTrie: false, pathdbKeys: []string{"SnapshotRoot", "SnapshotGenerator"}},
+		{name: "BinaryTrie", binaryTrie: true, pathdbKeys: []string{"SnapshotRoot", "SnapshotGenerator"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db := rawdb.NewMemoryDatabase()
+			defer db.Close()
+
+			if err := WritePathDBMetadata(db, stateRoot, tc.binaryTrie); err != nil {
+				t.Fatalf("WritePathDBMetadata: %v", err)
+			}
+
+			assertDatabaseVersionAtRawKey(t, db)
+
+			for _, key := range tc.pathdbKeys {
+				rawVal, _ := db.Get([]byte(key))
+				prefixedVal, _ := db.Get(append([]byte("v"), []byte(key)...))
+
+				if tc.binaryTrie {
+					if len(rawVal) != 0 {
+						t.Errorf("key %q present at raw position in bintrie mode: %x", key, rawVal)
+					}
+					if len(prefixedVal) == 0 {
+						t.Errorf("key %q missing under v-prefix in bintrie mode", key)
+					}
+				} else {
+					if len(rawVal) == 0 {
+						t.Errorf("key %q missing at raw position in MPT mode", key)
+					}
+					if len(prefixedVal) != 0 {
+						t.Errorf("key %q unexpectedly present under v-prefix in MPT mode: %x", key, prefixedVal)
+					}
+				}
+			}
+		})
+	}
+}
+
+func assertDatabaseVersionAtRawKey(t *testing.T, db ethdb.KeyValueReader) {
+	t.Helper()
+	v := rawdb.ReadDatabaseVersion(db)
+	if v == nil {
+		t.Fatal("DatabaseVersion missing — geth will treat the DB as uninitialized and overwrite it")
+	}
+	if *v != pathdbSchemaVersion {
+		t.Errorf("DatabaseVersion = %d, want %d", *v, pathdbSchemaVersion)
+	}
+}

--- a/client/geth/writer.go
+++ b/client/geth/writer.go
@@ -7,7 +7,6 @@ import (
 	"sync/atomic"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -101,23 +100,16 @@ func (w *Writer) WriteCode(codeHash common.Hash, code []byte) error {
 	return w.bw.put(key, code, &w.codeBytes)
 }
 
-// SetStateRoot writes the snapshot root marker.
-func (w *Writer) SetStateRoot(root common.Hash) error {
-	if err := w.db.Put([]byte("SnapshotRoot"), root[:]); err != nil {
-		return err
-	}
-	// Write PathDB metadata so geth's pathdb.loadLayers() can find the state.
-	// When --genesis is provided, WriteGenesisBlock also writes this metadata
-	// (with proper prefix for binary trie mode). Writing it here too is
-	// idempotent and ensures non-genesis DBs have the metadata.
-	rawdb.WriteStateID(w.db, root, 0)
-	rawdb.WritePersistentStateID(w.db, 0)
-	rawdb.WriteSnapshotRoot(w.db, root)
-	// Mark the snapshot generator as Done so geth doesn't try to regenerate
-	// the snapshot from scratch on first open. See WriteCompletedSnapshotGenerator
-	// for the full rationale.
-	if err := WriteCompletedSnapshotGenerator(w.db); err != nil {
-		return fmt.Errorf("write snapshot generator: %w", err)
+// SetStateRoot writes the snapshot root marker and PathDB initialization
+// metadata. binaryTrie selects the namespace (raw vs "v"-prefixed) for the
+// pathdb keys; geth's pathdb wraps its diskdb under the "v" prefix in
+// bintrie mode (triedb/pathdb/database.go:168-170) so the writes have to
+// match. When --genesis is provided, WriteGenesisBlock writes the same
+// entries; doing it here too is idempotent and ensures non-genesis DBs
+// also boot cleanly.
+func (w *Writer) SetStateRoot(root common.Hash, binaryTrie bool) error {
+	if err := WritePathDBMetadata(w.db, root, binaryTrie); err != nil {
+		return fmt.Errorf("write pathdb metadata: %w", err)
 	}
 	return nil
 }

--- a/client/geth/writer_test.go
+++ b/client/geth/writer_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/holiman/uint256"
@@ -63,4 +64,96 @@ func TestWriterBasic(t *testing.T) {
 
 	t.Logf("geth writer stats: accounts=%d, storage=%d, code=%d",
 		stats.AccountBytes, stats.StorageBytes, stats.CodeBytes)
+}
+
+// TestSetStateRootMPT verifies the SetStateRoot writer-side metadata writes
+// for the MPT (non-bintrie) case: PathDB metadata at raw keys, no v-prefix
+// duplication, and DatabaseVersion present at the raw key.
+//
+// Without these, geth either treats the DB as uninitialized (missing
+// DatabaseVersion) or triggers a full snapshot regeneration on first open
+// (missing/mismatched SnapshotGenerator).
+func TestSetStateRootMPT(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "geth-writer-setroot-mpt-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	w, err := NewWriter(tmpDir, 1000, 4)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	defer w.Close()
+
+	root := common.HexToHash("0xabababababababababababababababababababababababababababababababab")
+	if err := w.SetStateRoot(root, false); err != nil {
+		t.Fatalf("SetStateRoot: %v", err)
+	}
+
+	db := w.DB()
+	for _, key := range []string{"SnapshotRoot", "SnapshotGenerator"} {
+		val, _ := db.Get([]byte(key))
+		if len(val) == 0 {
+			t.Errorf("key %q missing at raw position in MPT mode", key)
+		}
+		if prefixed, _ := db.Get(append([]byte("v"), []byte(key)...)); len(prefixed) != 0 {
+			t.Errorf("key %q unexpectedly present under v-prefix in MPT mode: %x", key, prefixed)
+		}
+	}
+
+	v := rawdb.ReadDatabaseVersion(db)
+	if v == nil {
+		t.Fatal("DatabaseVersion missing — geth will overwrite the DB on startup")
+	}
+	if *v != pathdbSchemaVersion {
+		t.Errorf("DatabaseVersion = %d, want %d", *v, pathdbSchemaVersion)
+	}
+}
+
+// TestSetStateRootBinaryTrie verifies the SetStateRoot writer-side metadata
+// writes for the bintrie case: PathDB metadata under the "v" prefix (so
+// pathdb's wrapped diskdb finds it), DatabaseVersion at the raw key (so
+// geth's pre-pathdb startup gate finds it), and no raw-key leakage of the
+// pathdb-namespaced entries.
+func TestSetStateRootBinaryTrie(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "geth-writer-setroot-bintrie-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	w, err := NewWriter(tmpDir, 1000, 4)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	defer w.Close()
+
+	root := common.HexToHash("0xcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd")
+	if err := w.SetStateRoot(root, true); err != nil {
+		t.Fatalf("SetStateRoot: %v", err)
+	}
+
+	db := w.DB()
+	for _, key := range []string{"SnapshotRoot", "SnapshotGenerator"} {
+		prefixed, _ := db.Get(append([]byte("v"), []byte(key)...))
+		if len(prefixed) == 0 {
+			t.Errorf("key %q missing under v-prefix in bintrie mode", key)
+		}
+		if raw, _ := db.Get([]byte(key)); len(raw) != 0 {
+			t.Errorf("key %q unexpectedly present at raw position in bintrie mode: %x", key, raw)
+		}
+	}
+
+	v := rawdb.ReadDatabaseVersion(db)
+	if v == nil {
+		t.Fatal("DatabaseVersion missing — geth will overwrite the DB on startup")
+	}
+	if *v != pathdbSchemaVersion {
+		t.Errorf("DatabaseVersion = %d, want %d", *v, pathdbSchemaVersion)
+	}
+	// DatabaseVersion lives at the raw key — never under v-prefix.
+	if prefixed, _ := db.Get(append([]byte("v"), []byte("DatabaseVersion")...)); len(prefixed) != 0 {
+		t.Errorf("DatabaseVersion unexpectedly present under v-prefix: %x", prefixed)
+	}
 }

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -321,27 +321,28 @@ func TestEndToEndWithGenesisBinaryTrie(t *testing.T) {
 	}
 	defer db.Close()
 
-	// Verify genesis accounts
-	for _, addr := range []common.Address{
-		common.HexToAddress("0x123463a4b065722e99115d6c222f267d9cabb524"),
-		common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
-	} {
-		addrHash := crypto.Keccak256Hash(addr[:])
-		key := append([]byte("a"), addrHash[:]...)
-		data, err := db.Get(key)
-		if err != nil {
-			t.Errorf("Account %s not found: %v", addr.Hex(), err)
-			continue
-		}
-		if len(data) == 0 {
-			t.Errorf("Account %s has empty data", addr.Hex())
-		}
+	// Verify state was actually written. Bintrie packs accounts into stem
+	// blobs under "vX"+stem(31), not into MPT-style "a"+addrHash rows, so a
+	// per-account lookup would need the Pedersen-tree-key derivation.
+	// Stem-blob count > 0 is a sufficient sentinel that generation populated
+	// the DB; the per-account correctness is covered by the generator's own
+	// tests against the golden state root.
+	stemIter := db.NewIterator([]byte("vX"), nil)
+	stemCount := 0
+	for stemIter.Next() {
+		stemCount++
+	}
+	stemIter.Release()
+	if stemCount == 0 {
+		t.Error("Expected stem blobs under vX prefix in bintrie mode, got 0")
 	}
 
-	// Verify SnapshotRoot
-	snapshotRoot, err := db.Get([]byte("SnapshotRoot"))
+	// Verify SnapshotRoot. In bintrie mode pathdb wraps its diskdb under
+	// the "v" (rawdb.VerklePrefix) namespace, so the snapshot root key
+	// lives at "v"+"SnapshotRoot".
+	snapshotRoot, err := db.Get(append([]byte("v"), []byte("SnapshotRoot")...))
 	if err != nil {
-		t.Errorf("SnapshotRoot not found: %v", err)
+		t.Errorf("SnapshotRoot not found under v-prefix: %v", err)
 	} else if common.BytesToHash(snapshotRoot) != stats.StateRoot {
 		t.Errorf("SnapshotRoot mismatch: got %x, want %s", snapshotRoot, stats.StateRoot.Hex())
 	}

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -729,7 +729,7 @@ func (g *Generator) generateStreamingMPT() (*Stats, error) {
 	stateRoot := accountTrie.Hash()
 	stats.StateRoot = stateRoot
 
-	if err := g.writer.SetStateRoot(stateRoot); err != nil {
+	if err := g.writer.SetStateRoot(stateRoot, false); err != nil {
 		return nil, fmt.Errorf("failed to write state root: %w", err)
 	}
 
@@ -1195,7 +1195,7 @@ func (g *Generator) generateStreamingBinary() (retStats *Stats, retErr error) {
 	stats.StateRoot = stateRoot
 
 	// Write state root via StateWriter
-	if err := g.writer.SetStateRoot(stateRoot); err != nil {
+	if err := g.writer.SetStateRoot(stateRoot, true); err != nil {
 		return nil, fmt.Errorf("failed to write snapshot root: %w", err)
 	}
 

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -465,8 +465,10 @@ func TestDatabaseContentBinaryTrie(t *testing.T) {
 	}
 	defer db.Close()
 
-	// Verify snapshot root
-	snapshotRootData, err := db.Get([]byte("SnapshotRoot"))
+	// Verify snapshot root. In bintrie mode pathdb wraps its diskdb under
+	// the "v" prefix (rawdb.VerklePrefix) at construction time, so all
+	// pathdb metadata — including SnapshotRoot — lives under that prefix.
+	snapshotRootData, err := db.Get(append([]byte("v"), []byte("SnapshotRoot")...))
 	if err != nil {
 		t.Fatalf("Failed to read snapshot root: %v", err)
 	}

--- a/generator/writer.go
+++ b/generator/writer.go
@@ -48,7 +48,10 @@ type Writer interface {
 
 	// SetStateRoot records the post-generation state root and any backend-specific
 	// metadata (geth: PathDB state ID, snapshot generator marker; nethermind: n/a).
-	SetStateRoot(root common.Hash) error
+	// binaryTrie selects the on-disk namespace for clients whose pathdb wraps
+	// its diskdb under a prefix in bintrie mode (geth uses "v"); backends that
+	// do not care may ignore the flag.
+	SetStateRoot(root common.Hash, binaryTrie bool) error
 
 	// Flush commits all pending writes and tears down the async pipeline.
 	// Shutdown-once: do not call mid-run.


### PR DESCRIPTION
## Summary

Three discrete metadata writes that any external DB-builder must perform for a bintrie+pathdb geth to recognise the DB as initialised. Any one missing is enough to make `geth --dev` silently overwrite the DB on first open, or trigger a full snapshot regeneration.

- **A.** `WriteDatabaseVersion(9)`. Geth reads `rawdb.databaseVersion` at startup *before* pathdb is constructed, treating nil as \"blank DB\". Lives at the raw key in both modes — never under the v-prefix.
- **B.** PathDB metadata under \"v\" prefix in `GethWriter.SetStateRoot`. PathDB wraps its diskdb under `rawdb.VerklePrefix` at construction (`triedb/pathdb/database.go:168-170`), so `StateID`, `PersistentStateID`, `SnapshotRoot`, and `SnapshotGenerator` must be written under that prefix in bintrie mode for pathdb to find them. `WriteGenesisBlock` already handled this; the writer-only path didn't.
- **C.** `IsBintrie=true` in the `SnapshotGenerator` RLP. `pathdb/journal.go:163-171` discards generators whose `IsBintrie` field doesn't match the opening database's mode. Default-false on legacy entries is correct for any merkle DB that wrote them, so the new field is `rlp:\"optional\"` — wire-safe both ways.

Refactored both call sites (`WriteGenesisBlock` and `GethWriter.SetStateRoot`) onto a shared `genesis.WritePathDBMetadata` helper so the raw-vs-prefixed asymmetry (DatabaseVersion raw, the others v-prefixed in bintrie mode) can't drift.

Also drops a now-redundant legacy `w.db.Put(\"SnapshotRoot\", root[:])` in `SetStateRoot` — `rawdb.WriteSnapshotRoot` writes the same key/value, and in bintrie mode the legacy raw write was polluting the wrong namespace.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -count=1 ./...` — all green
- New regression tests pin every fix:
  - [x] `TestWriteGenesisBlockDatabaseVersionMPT` / `…BinaryTrie` — DatabaseVersion at raw key in both modes; never under v-prefix
  - [x] `TestSnapshotGeneratorIsBintrieRoundTripMPT` / `…BinaryTrie` — IsBintrie matches mode after RLP round-trip
  - [x] `TestWritePathDBMetadataPrefixing` — table-driven: pathdb keys land in raw vs v-prefixed namespace per mode
  - [x] `TestSetStateRootMPT` / `TestSetStateRootBinaryTrie` — same coverage on the writer-only path
- Existing tests updated for the corrected layout:
  - `TestDatabaseContentBinaryTrie` reads `SnapshotRoot` under v-prefix (where pathdb actually finds it)
  - `TestEndToEndWithGenesisBinaryTrie` reads `SnapshotRoot` under v-prefix and replaces a pre-existing broken assertion (per-account `\"a\"+addrHash` lookup, which doesn't exist in bintrie mode — state is packed into stem blobs at `\"vX\"+stem(31)`) with a stem-blob count check
- End-to-end with geth-fork still pending — requires a built geth binary; recommend running locally before merge:
  ```sh
  ./state-actor --binary-trie --num-accounts 100 --num-contracts 50 --db-path /tmp/sa-test --genesis ./genesis.json
  geth --datadir /tmp/sa-test --dev --override.verkle=0 --networkid 1337 --nodiscover --maxpeers=0
  # confirm geth log does NOT say \"State snapshot generator is for a different scheme, discarding\"
  # and does NOT write a fresh genesis on top
  ```