### PR TITLE
refactor(cli): drop --genesis; expose --fork/--gas-limit/--timestamp/--extra-data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,12 @@ ACCOUNTS ?= 1000
 CONTRACTS ?= 100
 SEED ?= 42
 SA_DB ?= /tmp/sa-neth-smoke
+
+# Pre-funded smoke addresses. Mirrors the three accounts that used to come
+# from testdata/genesis-funded.json (deterministic dev keys 1, 2, 3 from
+# eth_sign / spamoor); state-actor now injects them via --inject-accounts
+# instead of consuming an external --genesis JSON.
+SMOKE_INJECT_ADDRS ?= 0x7e5f4552091a69125d5dfcb7b8c2659029395bdf,0x2b5ad5c4795c026514f8317c7a215e218dccd6cf,0x6813eb9362372eef6200f3b1dbc3f819671cba69
 smoke-nethermind: docker-nethermind
 	rm -rf $(SA_DB) && mkdir -p $(SA_DB)
 	docker run --rm \
@@ -101,7 +107,7 @@ smoke-nethermind: docker-nethermind
 	  state-actor-nethermind:latest \
 	  --client=nethermind --db=/data \
 	  --accounts=$(ACCOUNTS) --contracts=$(CONTRACTS) --seed=$(SEED) \
-	  --genesis=/test/genesis-funded.json --verbose
+	  --chain-id=1337 --inject-accounts=$(SMOKE_INJECT_ADDRS) --verbose
 	bash $(PWD)/client/nethermind/testdata/validate-big-db.sh $(SA_DB)
 
 ## smoke-nethermind-spamoor: Generate a DB, boot Nethermind 1.37.0, then run
@@ -118,7 +124,7 @@ smoke-nethermind-spamoor: docker-nethermind
 	  state-actor-nethermind:latest \
 	  --client=nethermind --db=/data \
 	  --accounts=$(ACCOUNTS) --contracts=$(CONTRACTS) --seed=$(SEED) \
-	  --genesis=/test/genesis-funded.json --verbose
+	  --chain-id=1337 --inject-accounts=$(SMOKE_INJECT_ADDRS) --verbose
 	docker rm -f neth-smoke-spamoor 2>/dev/null || true
 	docker run --rm -d --name neth-smoke-spamoor \
 	  -v $(PWD)/client/nethermind/testdata:/test:ro \
@@ -162,7 +168,7 @@ smoke-besu: docker-besu
 	  state-actor-besu:latest \
 	  --client=besu --db=/data \
 	  --accounts=$(ACCOUNTS) --contracts=$(CONTRACTS) --seed=$(SEED) \
-	  --genesis=/test/genesis-funded.json --verbose
+	  --chain-id=1337 --inject-accounts=$(SMOKE_INJECT_ADDRS) --verbose
 	bash $(PWD)/client/besu/testdata/validate-big-db-besu.sh $(SA_BESU_DB)
 
 ## smoke-besu-spamoor: Generate a DB, boot hyperledger/besu:25.11.0, then run
@@ -179,7 +185,7 @@ smoke-besu-spamoor: docker-besu
 	  state-actor-besu:latest \
 	  --client=besu --db=/data \
 	  --accounts=$(ACCOUNTS) --contracts=$(CONTRACTS) --seed=$(SEED) \
-	  --genesis=/test/genesis-funded.json --verbose
+	  --chain-id=1337 --inject-accounts=$(SMOKE_INJECT_ADDRS) --verbose
 	docker rm -f besu-smoke-spamoor 2>/dev/null || true
 	docker run --rm -d --name besu-smoke-spamoor \
 	  -v $(PWD)/client/besu/testdata:/test:ro \
@@ -249,7 +255,8 @@ smoke-geth: docker-geth
 example:
 	./$(BINARY) \
 		--db /tmp/example-chaindata \
-		--genesis examples/test-genesis.json \
+		--chain-id 1337 \
+		--inject-accounts $(SMOKE_INJECT_ADDRS) \
 		--accounts 1000 \
 		--contracts 500 \
 		--max-slots 100 \

--- a/client/besu/genesis_cgo.go
+++ b/client/besu/genesis_cgo.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	gethrlp "github.com/ethereum/go-ethereum/rlp"
 
+	"github.com/nerolation/state-actor/genesis"
 	"github.com/nerolation/state-actor/internal/besu/keys"
 )
 
@@ -75,24 +76,21 @@ func (b *besuDB) writeGenesisBlock(header *types.Header, totalDifficulty *big.In
 	return nil
 }
 
-// supportedFork returns nil if the genesis JSON's config block targets a
-// fork through Shanghai. Cancun+ configs (cancunTime / pragueTime /
-// shanghaiTime > 0 with subsequent forks) are rejected with a clear error so
-// users don't get a silent "wrong genesis hash" boot failure. Cancun+ support
-// is a possible future addition.
-func supportedFork(g *genesisJSONConfig) error {
-	if g == nil {
+// supportedForkChainConfig returns nil if the chain config targets a fork
+// through Shanghai. Cancun+ configs (cancunTime / pragueTime > 0) are
+// rejected with a clear error so users don't get a silent "wrong genesis
+// hash" boot failure. Cancun+ support is a possible future addition that
+// requires plumbing ParentBeaconRoot/ExcessBlobGas/BlobGasUsed/RequestsHash
+// through buildGenesisHeader.
+func supportedForkChainConfig(g *genesis.Genesis) error {
+	if g == nil || g.Config == nil {
 		return nil
 	}
-	// Shanghai is allowed (we just don't add a withdrawals list to the
-	// genesis body — see writeGenesisBlock). Cancun+ adds blob fields
-	// (excessBlobGas, blobGasUsed, parentBeaconBlockRoot) to the header
-	// that we'd need to plumb through.
-	if g.CancunTime != nil {
-		return fmt.Errorf("besu v1 supports through Shanghai; Cancun config (cancunTime=%d) requires v2 follow-up", *g.CancunTime)
+	if g.Config.CancunTime != nil {
+		return fmt.Errorf("besu v1 supports through Shanghai; Cancun config (cancunTime=%d) requires v2 follow-up", *g.Config.CancunTime)
 	}
-	if g.PragueTime != nil {
-		return fmt.Errorf("besu v1 supports through Shanghai; Prague config (pragueTime=%d) requires v2 follow-up", *g.PragueTime)
+	if g.Config.PragueTime != nil {
+		return fmt.Errorf("besu v1 supports through Shanghai; Prague config (pragueTime=%d) requires v2 follow-up", *g.Config.PragueTime)
 	}
 	return nil
 }

--- a/client/besu/run.go
+++ b/client/besu/run.go
@@ -37,19 +37,3 @@ func Run(ctx context.Context, cfg generator.Config, opts Options) (*generator.St
 	return runImpl(ctx, cfg, opts)
 }
 
-// GenesisFilePath / ChainIDOverride are package-level vars set from main.go
-// before Run is called, mirroring the nethermind pattern. They surface the
-// --genesis and --chain-id CLI flags into the package without threading
-// them through the Config struct.
-//
-// Declared here (no build tag) so both cgo and stub builds see them.
-// The cgo runImpl reads them; the stub runImpl ignores them.
-//
-// ChainIDOverride is warn-and-ignored at runtime: Besu reads chainId from
-// --genesis-file at boot, not from the DB. We accept the flag so users
-// scripting from the geth path don't get a hard rejection, but log a
-// warning so the no-effect-here behavior is visible.
-var (
-	GenesisFilePath string
-	ChainIDOverride int64
-)

--- a/client/besu/run_cgo.go
+++ b/client/besu/run_cgo.go
@@ -4,12 +4,8 @@ package besu
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
-	"fmt"
-	"log"
 	"math/big"
-	"os"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -33,20 +29,19 @@ func runImpl(ctx context.Context, cfg generator.Config, opts Options) (*generato
 	if cfg.DBPath == "" {
 		return nil, errors.New("besu: --db is required")
 	}
-
 	// Besu reads chainId from --genesis-file at boot, not from the DB.
-	if ChainIDOverride != 0 {
-		log.Printf(
-			"warning: --chain-id=%d is ignored for --client=besu — make sure it matches genesis JSON's config.chainId",
-			ChainIDOverride,
-		)
+	// B7 (chainID embedding via state-actor-written chainspec) is the
+	// follow-up that makes --chain-id take effect end-to-end.
+	//
+	// Tests can leave cfg.Genesis nil; we synthesize a Shanghai default
+	// (besu's writer ceiling — see genesis.MaxForkForClient("besu")) so
+	// the supportedForkChainConfig gate doesn't reject the global default.
+	g := cfg.Genesis
+	if g == nil {
+		g, _ = genesis.BuildSynthetic("shanghai", nil, 0, 0, nil)
 	}
-
-	genesisCfg, err := loadOrDefault(GenesisFilePath)
-	if err != nil {
-		return nil, err
-	}
-	if err := supportedFork(&genesisCfg.unstable); err != nil {
+	genesisCfg := besuGenesisFromConfig(g)
+	if err := supportedForkChainConfig(g); err != nil {
 		return nil, err
 	}
 
@@ -82,10 +77,9 @@ func runImpl(ctx context.Context, cfg generator.Config, opts Options) (*generato
 	return stats, nil
 }
 
-// loadOrDefault loads a genesis JSON from path (if non-empty) or returns
-// a minimal dev-default. The default chainId is 1337 with a London-frozen
-// fork schedule (londonBlock at Long.MAX so genesis is pre-London and we
-// don't need baseFeePerGas in the header).
+// besuGenesis holds the header fields besu's writer needs. Built from
+// the in-memory cfg.Genesis (synthesized by genesis.BuildSynthetic in
+// main.go); no JSON re-parsing required.
 type besuGenesis struct {
 	chainID    *big.Int
 	gasLimit   uint64
@@ -97,53 +91,30 @@ type besuGenesis struct {
 	parentHash common.Hash
 	nonce      uint64
 	baseFee    *big.Int // nil if pre-London; *big.Int if londonBlock <= 0
-	unstable   genesisJSONConfig
 }
 
-func loadOrDefault(path string) (*besuGenesis, error) {
-	if path == "" {
-		return &besuGenesis{
-			chainID:    big.NewInt(1337),
-			gasLimit:   30_000_000,
-			difficulty: big.NewInt(0),
-			timestamp:  0,
-		}, nil
+// besuGenesisFromConfig translates an in-memory *genesis.Genesis into the
+// flat besuGenesis struct the writer consumes.
+func besuGenesisFromConfig(g *genesis.Genesis) *besuGenesis {
+	gasLimit := uint64(g.GasLimit)
+	if gasLimit == 0 {
+		gasLimit = 30_000_000
 	}
-	g, err := genesis.LoadGenesis(path)
-	if err != nil {
-		return nil, fmt.Errorf("besu: load genesis: %w", err)
-	}
-
-	// Re-parse the raw JSON to inspect post-Shanghai timestamps that
-	// genesis.LoadGenesis doesn't surface in its struct.
-	raw, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("besu: re-read genesis: %w", err)
-	}
-	var top struct {
-		Config genesisJSONConfig `json:"config"`
-	}
-	_ = json.Unmarshal(raw, &top) // best-effort; missing fields are nil
-
-	var diff *big.Int
+	diff := big.NewInt(0)
 	if g.Difficulty != nil {
 		diff = g.Difficulty.ToInt()
-	} else {
-		diff = big.NewInt(0)
 	}
-	var chainID *big.Int
-	if g.Config != nil {
+	chainID := big.NewInt(1337)
+	if g.Config != nil && g.Config.ChainID != nil {
 		chainID = g.Config.ChainID
-	} else {
-		chainID = big.NewInt(1337)
 	}
 	var baseFee *big.Int
 	if g.BaseFee != nil {
 		baseFee = g.BaseFee.ToInt()
 	}
-	out := &besuGenesis{
+	return &besuGenesis{
 		chainID:    chainID,
-		gasLimit:   uint64(g.GasLimit),
+		gasLimit:   gasLimit,
 		difficulty: diff,
 		timestamp:  uint64(g.Timestamp),
 		extraData:  []byte(g.ExtraData),
@@ -152,9 +123,7 @@ func loadOrDefault(path string) (*besuGenesis, error) {
 		parentHash: g.ParentHash,
 		nonce:      uint64(g.Nonce),
 		baseFee:    baseFee,
-		unstable:   top.Config,
 	}
-	return out, nil
 }
 
 // buildGenesisHeader assembles a *types.Header for the genesis block from

--- a/client/geth/run.go
+++ b/client/geth/run.go
@@ -3,7 +3,6 @@ package geth
 import (
 	"context"
 	"fmt"
-	"math/big"
 	"path/filepath"
 
 	"github.com/nerolation/state-actor/generator"
@@ -15,17 +14,6 @@ import (
 // today the writer derives its tuning from defaults.
 type Options struct{}
 
-// GenesisFilePath / ChainIDOverride are package-level vars set from
-// main.go before Populate is called, mirroring the besu/nethermind
-// pattern. The MPT writer reads chain config from cfg.GenesisAccounts /
-// cfg.GenesisStorage / cfg.GenesisCode (already pre-loaded by the
-// CLI); these vars are kept for parity with the other clients but
-// aren't yet consumed here.
-var (
-	GenesisFilePath string
-	ChainIDOverride int64
-)
-
 // Populate is the public entry for `--client=geth` MPT mode. It
 // orchestrates the two-phase direct-Pebble writer:
 //
@@ -35,9 +23,9 @@ var (
 //     state root.
 //  3. Persist PathDB metadata (StateID, PersistentStateID, SnapshotRoot,
 //     completed-snapshot-generator marker) so geth boots cleanly.
-//  4. If a genesis config was loaded by the CLI (cfg.GenesisAccounts or
-//     a non-empty *genesis.Genesis loaded from --genesis), write the
-//     genesis block and chain config so the DB is fully self-bootable.
+//  4. Write the genesis block + chain config from cfg.Genesis (always
+//     non-nil after main.go's BuildSynthetic call) so the DB is
+//     fully self-bootable.
 //  5. Close the writer.
 //
 // Returns the same *generator.Stats shape as the legacy generator.New +
@@ -74,34 +62,14 @@ func Populate(ctx context.Context, cfg generator.Config, opts Options) (*generat
 		return nil, fmt.Errorf("client/geth.Populate: set state root: %w", err)
 	}
 
-	// Genesis block + chain config (only if the CLI loaded one).
-	if cfg.GenesisAccounts != nil || GenesisFilePath != "" {
-		if g, err := loadGenesisIfPresent(); err != nil {
-			return nil, fmt.Errorf("client/geth.Populate: load genesis: %w", err)
-		} else if g != nil {
-			ancientDir := filepath.Join(cfg.DBPath, "ancient")
-			if _, err := WriteGenesisBlock(w.DB(), g, stateRoot, false, ancientDir); err != nil {
-				return nil, fmt.Errorf("client/geth.Populate: write genesis block: %w", err)
-			}
-		}
+	// Genesis block + chain config from cfg.Genesis (synthesized by
+	// main.go via genesis.BuildSynthetic; tests can leave it nil and
+	// get the default chainspec).
+	g := genesis.OrDefault(cfg.Genesis)
+	ancientDir := filepath.Join(cfg.DBPath, "ancient")
+	if _, err := WriteGenesisBlock(w.DB(), g, stateRoot, false, ancientDir); err != nil {
+		return nil, fmt.Errorf("client/geth.Populate: write genesis block: %w", err)
 	}
 
 	return stats, nil
-}
-
-// loadGenesisIfPresent reads GenesisFilePath if set, applying the
-// ChainIDOverride if non-zero. Returns (nil, nil) when no genesis file
-// is configured — the caller should treat that as a state-only run.
-func loadGenesisIfPresent() (*genesis.Genesis, error) {
-	if GenesisFilePath == "" {
-		return nil, nil
-	}
-	g, err := genesis.LoadGenesis(GenesisFilePath)
-	if err != nil {
-		return nil, err
-	}
-	if ChainIDOverride != 0 && g.Config != nil {
-		g.Config.ChainID = big.NewInt(ChainIDOverride)
-	}
-	return g, nil
 }

--- a/client/nethermind/run.go
+++ b/client/nethermind/run.go
@@ -37,14 +37,3 @@ func Run(ctx context.Context, cfg generator.Config, opts Options) (*generator.St
 	return runImpl(ctx, cfg, opts)
 }
 
-// GenesisFilePath / ChainIDOverride are package-level vars set from main.go
-// before Run is called, mirroring the reth-branch pattern. They surface
-// the --genesis and --chain-id CLI flags into the package without
-// threading them through the Config struct.
-//
-// Declared here (no build tag) so both cgo and stub builds see them.
-// The cgo runImpl reads them; the stub runImpl ignores them.
-var (
-	GenesisFilePath string
-	ChainIDOverride int64
-)

--- a/client/nethermind/run_cgo.go
+++ b/client/nethermind/run_cgo.go
@@ -29,7 +29,6 @@ import (
 	"log"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/nerolation/state-actor/generator"
 	"github.com/nerolation/state-actor/genesis"
@@ -65,45 +64,20 @@ func runImpl(ctx context.Context, cfg generator.Config, opts Options) (*generato
 		return nil, errors.New("--db is required for --client=nethermind")
 	}
 
-	// Pull genesis fields. If the caller passed --genesis, use those values;
-	// otherwise default to a dev-mode-ish minimal genesis (chainId 1337,
-	// gasLimit 30M, empty extraData, timestamp 0).
-	chainID := int64(1337)
-	gasLimit := uint64(30_000_000)
-	var extraData []byte
-	var timestamp uint64
-	var loadedGenesis *genesis.Genesis
-	if GenesisFilePath != "" {
-		g, err := genesis.LoadGenesis(GenesisFilePath)
-		if err != nil {
-			return nil, fmt.Errorf("load genesis: %w", err)
-		}
-		loadedGenesis = g
-		if g.Config != nil && g.Config.ChainID != nil {
-			chainID = g.Config.ChainID.Int64()
-		}
-		if g.GasLimit != 0 {
-			gasLimit = uint64(g.GasLimit)
-		}
-		if len(g.ExtraData) > 0 {
-			extraData = g.ExtraData
-		}
-		timestamp = uint64(g.Timestamp)
+	// Pull genesis fields from cfg.Genesis. Production callers (main.go)
+	// always set this; tests can leave it nil and get the default chainspec.
+	g := genesis.OrDefault(cfg.Genesis)
+	gasLimit := uint64(g.GasLimit)
+	if gasLimit == 0 {
+		gasLimit = 30_000_000
 	}
-	if ChainIDOverride != 0 {
-		chainID = ChainIDOverride
-		// state-actor writes nothing that carries chainID: the genesis
-		// header has no chainID field, the state trie hashes are
-		// chainID-blind, and the genesis block has zero txs (so no
-		// EIP-155 fingerprints). chainID lives entirely in the
-		// chainspec Nethermind reads on boot — same DB can be served
-		// under any chainID without regeneration. Surface the
-		// no-effect-here behavior so users don't expect otherwise.
-		log.Printf("nethermind: --chain-id=%d is parsed but not embedded in the produced DB "+
-			"(chainID lives in the chainspec at boot time; the same DB serves any chainID). "+
-			"Set the chainID in your Nethermind chainspec/config instead.", chainID)
-	}
-	_ = chainID
+	extraData := []byte(g.ExtraData)
+	timestamp := uint64(g.Timestamp)
+	// chainID embedding is a B7 follow-up: nethermind reads chainID from
+	// the chainspec at boot, not the on-disk DB. Until state-actor writes
+	// a Parity chainspec under cfg.DBPath, the supplied chainID is recorded
+	// here for documentation and stays inert.
+	_ = g.Config.ChainID
 
 	dbs, err := openNethDBs(cfg.DBPath)
 	if err != nil {
@@ -119,31 +93,28 @@ func runImpl(ctx context.Context, cfg generator.Config, opts Options) (*generato
 	//   - genesis-alloc only (no synthetic) → writeGenesisAllocAccounts (a
 	//     simpler in-memory path without the temp Pebble round-trip).
 	//   - empty alloc → state stays empty; root = EmptyTreeHash.
+	// alloc walking is kept for tests (cfg.GenesisAccounts/Storage/Code).
+	// The CLI never sets these — production runs always go through
+	// writeSyntheticAccounts with empty alloc.
 	stateRoot := common.Hash(neth.EmptyTreeHash)
-	var allocAccounts map[common.Address]*types.StateAccount
-	var allocCodes map[common.Address][]byte
-	var allocStorages map[common.Address]map[common.Hash]common.Hash
-	if loadedGenesis != nil && len(loadedGenesis.Alloc) > 0 {
-		allocAccounts = loadedGenesis.ToStateAccounts()
-		allocCodes = loadedGenesis.GetAllocCode()
-		allocStorages = loadedGenesis.GetAllocStorage()
-	}
+	allocAccounts := cfg.GenesisAccounts
+	allocCodes := cfg.GenesisCode
+	allocStorages := cfg.GenesisStorage
 	switch {
 	case cfg.NumAccounts > 0 || cfg.NumContracts > 0:
-		// writeSyntheticAccounts doesn't yet thread genesis-alloc storage
-		// through the temp-Pebble pipeline. If the user supplied a --genesis
-		// whose alloc carries non-empty storage AND asked for synthetic
-		// accounts, those storage slots would silently disappear from the
-		// state root we write. Fail loud until storage threading lands —
-		// tracked at https://github.com/nerolation/state-actor/issues/22.
+		// writeSyntheticAccounts doesn't yet thread alloc storage through
+		// the temp-Pebble pipeline. If a test supplies cfg.GenesisStorage
+		// AND asks for synthetic accounts, those storage slots would
+		// silently disappear from the state root. Fail loud — tracked at
+		// https://github.com/nerolation/state-actor/issues/22.
 		if len(allocStorages) > 0 {
 			return nil, fmt.Errorf(
-				"--client=nethermind: --genesis with %d storage-bearing alloc account(s) is "+
-					"incompatible with --accounts/--contracts > 0. The synthetic-accounts path "+
-					"does not yet write genesis-alloc storage tries; using it now would silently "+
-					"drop your storage entries. Run again without --accounts/--contracts to use "+
-					"the genesis-alloc-only path, or remove storage from the alloc. "+
-					"Tracked at https://github.com/nerolation/state-actor/issues/22.",
+				"--client=nethermind: cfg.GenesisStorage with %d storage-bearing alloc account(s) "+
+					"is incompatible with --accounts/--contracts > 0. The synthetic-accounts path "+
+					"does not yet write alloc storage tries; using it now would silently drop your "+
+					"storage entries. Run with --accounts=0 --contracts=0 to use the alloc-only path, "+
+					"or remove storage from the alloc. Tracked at "+
+					"https://github.com/nerolation/state-actor/issues/22.",
 				len(allocStorages),
 			)
 		}
@@ -158,7 +129,7 @@ func runImpl(ctx context.Context, cfg generator.Config, opts Options) (*generato
 		}
 	}
 
-	header := buildEmptyAllocGenesisHeader(chainID, gasLimit, extraData, timestamp)
+	header := buildEmptyAllocGenesisHeader(g.Config.ChainID.Int64(), gasLimit, extraData, timestamp)
 	header.Root = stateRoot
 
 	hash, err := writeGenesisBlockToDBs(dbs, header)
@@ -170,8 +141,8 @@ func runImpl(ctx context.Context, cfg generator.Config, opts Options) (*generato
 		log.Printf("nethermind: genesis hash = %s", hash.Hex())
 		log.Printf("nethermind: state root  = %s", header.Root.Hex())
 		log.Printf("nethermind: 7 RocksDBs written under %s/", cfg.DBPath)
-		if loadedGenesis != nil && len(loadedGenesis.Alloc) > 0 {
-			log.Printf("nethermind: preallocated %d accounts from --genesis", len(loadedGenesis.Alloc))
+		if len(allocAccounts) > 0 {
+			log.Printf("nethermind: preallocated %d accounts from cfg.GenesisAccounts (test-only path)", len(allocAccounts))
 		}
 		if cfg.NumAccounts > 0 || cfg.NumContracts > 0 {
 			log.Printf("nethermind: synthesized %d EOAs + %d contracts", cfg.NumAccounts, cfg.NumContracts)
@@ -185,6 +156,3 @@ func runImpl(ctx context.Context, cfg generator.Config, opts Options) (*generato
 	}, nil
 }
 
-// GenesisFilePath / ChainIDOverride are declared in run.go (no build
-// tag) so main.go's assignments compile in both build modes. The cgo
-// build path reads them from runImpl above; the stub path ignores them.

--- a/client/reth/chainspec.go
+++ b/client/reth/chainspec.go
@@ -10,42 +10,29 @@ import (
 
 // writeChainSpec writes a Reth-compatible chainspec JSON to outPath.
 //
-// The chainspec carries only the chain config (chainID + hardfork timestamps)
+// The chainspec carries the chain config (chainID + hardfork timestamps)
 // and the header bits reth needs to derive the genesis header (gasLimit,
 // baseFeePerGas, difficulty, etc.). The `alloc` field is intentionally
 // emitted as an empty object: state-actor direct-writes the genesis state
 // into MDBX, and reth is launched with `--debug.skip-genesis-validation` so
 // it trusts the DB-resident state instead of recomputing the genesis hash
-// from alloc. This keeps chainspec.json size constant regardless of how many
-// accounts the run generates.
+// from alloc.
 //
-// `chainID` overrides `config.chainId` when non-zero. When genesisPath is
-// non-empty, every top-level field from that file EXCEPT alloc is copied in.
-func writeChainSpec(genesisPath, outPath string, chainID int64) error {
-	spec := buildChainSpec(chainID)
-
-	if genesisPath != "" {
-		raw, err := os.ReadFile(genesisPath)
-		if err != nil {
-			return fmt.Errorf("read genesis file: %w", err)
-		}
-		var src map[string]any
-		if err := json.Unmarshal(raw, &src); err != nil {
-			return fmt.Errorf("parse genesis JSON: %w", err)
-		}
-		for k, v := range src {
-			if k == "alloc" {
-				continue
-			}
-			spec[k] = v
-		}
-		if chainID != 0 {
-			if cfg, ok := spec["config"].(map[string]any); ok {
-				cfg["chainId"] = chainID
-			}
-		}
+// g is the in-memory *genesis.Genesis built by genesis.BuildSynthetic in
+// main.go. Its JSON tags already match reth's chainspec field names, so
+// a json.Marshal round-trip with alloc forced to empty is sufficient.
+func writeChainSpec(g *genesis.Genesis, outPath string) error {
+	if g == nil {
+		return fmt.Errorf("writeChainSpec: nil genesis")
 	}
-
+	raw, err := json.Marshal(g)
+	if err != nil {
+		return fmt.Errorf("marshal genesis: %w", err)
+	}
+	var spec map[string]any
+	if err := json.Unmarshal(raw, &spec); err != nil {
+		return fmt.Errorf("unmarshal genesis: %w", err)
+	}
 	// Empty object (not nil/missing) so alloy_genesis's parser reads it as
 	// "no genesis accounts in chainspec" rather than tripping on a missing
 	// required field.
@@ -59,68 +46,4 @@ func writeChainSpec(genesisPath, outPath string, chainID int64) error {
 		return fmt.Errorf("write chainspec: %w", err)
 	}
 	return nil
-}
-
-// buildChainSpec returns the default "dev-like" chainspec used when no
-// --genesis file is provided. All post-Merge hardforks are activated at
-// block 0 / timestamp 0 so the EVM supports current opcodes out of the box.
-func buildChainSpec(chainID int64) map[string]any {
-	if chainID == 0 {
-		chainID = 1337
-	}
-	return map[string]any{
-		"config": map[string]any{
-			"chainId":                 chainID,
-			"homesteadBlock":          0,
-			"eip150Block":             0,
-			"eip155Block":             0,
-			"eip158Block":             0,
-			"byzantiumBlock":          0,
-			"constantinopleBlock":     0,
-			"petersburgBlock":         0,
-			"istanbulBlock":           0,
-			"berlinBlock":             0,
-			"londonBlock":             0,
-			"mergeNetsplitBlock":      0,
-			"shanghaiTime":            0,
-			"cancunTime":              0,
-			"terminalTotalDifficulty": 0,
-		},
-		"nonce":         "0x0",
-		"timestamp":     "0x0",
-		"extraData":     "0x",
-		"gasLimit":      "0x1c9c380",
-		"difficulty":    "0x0",
-		"coinbase":      "0x0000000000000000000000000000000000000000",
-		"mixHash":       "0x0000000000000000000000000000000000000000000000000000000000000000",
-		"parentHash":    "0x0000000000000000000000000000000000000000000000000000000000000000",
-		"baseFeePerGas": "0x3b9aca00",
-		"blobGasUsed":   "0x0",
-		"excessBlobGas": "0x0",
-	}
-}
-
-// loadGenesisForReth wraps genesis.LoadGenesis. Kept as a thin indirection so
-// the signature anchors Reth-specific expectations.
-func loadGenesisForReth(path string) (*genesis.Genesis, error) {
-	if path == "" {
-		return nil, nil
-	}
-	g, err := genesis.LoadGenesis(path)
-	if err != nil {
-		return nil, fmt.Errorf("load genesis: %w", err)
-	}
-	return g, nil
-}
-
-// deriveChainID returns the chain ID that should be used for the Reth run.
-// Priority: explicit override > genesis config > default 1337.
-func deriveChainID(override int64, g *genesis.Genesis) int64 {
-	if override > 0 {
-		return override
-	}
-	if g != nil && g.Config != nil && g.Config.ChainID != nil {
-		return g.Config.ChainID.Int64()
-	}
-	return 1337
 }

--- a/client/reth/doc.go
+++ b/client/reth/doc.go
@@ -85,7 +85,7 @@
 //   - state_root.go / storage_root.go: HashBuilder-driven state-root
 //     computation (sliced + streaming variants)
 //   - temp_sort_cgo.go: Pebble-backed temp sorter for streaming Phase 4
-//   - chainspec.go: chainspec JSON + Genesis loading
+//   - chainspec.go: chainspec JSON writer (built from cfg.Genesis)
 //   - header.go: genesis header construction
-//   - options.go: Options struct + GenesisFilePath/ChainIDOverride globals
+//   - options.go: Options struct (reserved); buildInjectedAccount helper
 package reth

--- a/client/reth/options.go
+++ b/client/reth/options.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/holiman/uint256"
 
-	"github.com/nerolation/state-actor/generator"
 	"github.com/nerolation/state-actor/internal/entitygen"
 )
 
@@ -16,21 +15,6 @@ type Options struct {
 	// (No options exposed yet. Future candidates: bytecode-LRU capacity,
 	// commit-threshold override, scratch directory, etc.)
 }
-
-// GenesisFilePath and ChainIDOverride are set by main.go when --client=reth
-// is selected, threading the --genesis and --chain-id flag values into
-// RunCgo without expanding generator.Config.
-var (
-	GenesisFilePath string
-	ChainIDOverride int64
-)
-
-// genesisPathFromCfg and chainIDFromCfg are package-internal trampolines.
-// They ignore cfg today (the values come from the package globals above);
-// the cfg parameter is reserved so a future Config field can replace the
-// globals without changing call sites.
-func genesisPathFromCfg(_ generator.Config) string { return GenesisFilePath }
-func chainIDFromCfg(_ generator.Config) int64      { return ChainIDOverride }
 
 // buildInjectedAccount returns an entitygen.Account for a pre-funded EOA at
 // the supplied address. Used by RunCgo to honour cfg.InjectAddresses (e.g.

--- a/client/reth/run_cgo.go
+++ b/client/reth/run_cgo.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/nerolation/state-actor/generator"
+	"github.com/nerolation/state-actor/genesis"
 	"github.com/nerolation/state-actor/internal/entitygen"
 )
 
@@ -220,15 +221,14 @@ func RunCgo(ctx context.Context, cfg generator.Config, opts Options) (*generator
 	// chainspec is now alloc-free (just config + header bits) — reth boots
 	// with --debug.skip-genesis-validation and trusts the DB-resident
 	// genesis state. File size is constant in N, no longer the OOM ceiling.
-	genesisPath := genesisPathFromCfg(cfg)
-	gen, err := loadGenesisForReth(genesisPath)
-	if err != nil {
-		return nil, fmt.Errorf("RunCgo: loadGenesisForReth: %w", err)
+	gen := genesis.OrDefault(cfg.Genesis)
+	chainID := int64(1337)
+	if gen.Config != nil && gen.Config.ChainID != nil {
+		chainID = gen.Config.ChainID.Int64()
 	}
-	chainID := deriveChainID(chainIDFromCfg(cfg), gen)
 
 	chainspecPath := filepath.Join(cfg.DBPath, "chainspec.json")
-	if err := writeChainSpec(genesisPath, chainspecPath, chainID); err != nil {
+	if err := writeChainSpec(gen, chainspecPath); err != nil {
 		return nil, fmt.Errorf("RunCgo: writeChainSpec: %w", err)
 	}
 

--- a/generator/config.go
+++ b/generator/config.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 
+	"github.com/nerolation/state-actor/genesis"
 	"github.com/nerolation/state-actor/internal/entitygen"
 )
 
@@ -79,15 +80,23 @@ type Config struct {
 	// Defaults to TrieModeMPT if empty.
 	TrieMode TrieMode
 
-	// GenesisAccounts are pre-defined accounts from genesis.json alloc.
-	// These are included in state generation with their exact addresses.
+	// Genesis is the in-memory genesis configuration that drives chainID,
+	// fork selection, and the genesis-block header fields. Always non-nil
+	// after main.go's BuildSynthetic call. Each client's writer reads
+	// Genesis.Config (for IsLondon / IsShanghai / etc.) and Genesis's
+	// header fields (GasLimit, Timestamp, ExtraData, ...).
+	//
+	// Genesis.Alloc is intentionally always empty in the production path:
+	// pre-funded accounts come from --inject-accounts, not the genesis JSON.
+	Genesis *genesis.Genesis
+
+	// GenesisAccounts / GenesisStorage / GenesisCode are kept for tests
+	// (oracle differential tests construct an in-memory alloc programmatically
+	// and rely on the alloc-walking code paths in client/* writers). The
+	// production CLI never sets these — main.go does not touch them.
 	GenesisAccounts map[common.Address]*types.StateAccount
-
-	// GenesisStorage is the storage for genesis alloc accounts.
-	GenesisStorage map[common.Address]map[common.Hash]common.Hash
-
-	// GenesisCode is the code for genesis alloc accounts.
-	GenesisCode map[common.Address][]byte
+	GenesisStorage  map[common.Address]map[common.Hash]common.Hash
+	GenesisCode     map[common.Address][]byte
 
 	// CommitInterval is the number of accounts between binary trie commits
 	// to disk. Only used in TrieModeBinary. 0 means no intermediate commits

--- a/genesis/forks.go
+++ b/genesis/forks.go
@@ -1,0 +1,169 @@
+package genesis
+
+import (
+	"fmt"
+	"math/big"
+	"sort"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// DefaultFork is the fork-active-at-genesis when --fork is not set.
+//
+// "prague" is the safe default that geth and reth writers populate
+// structurally complete (RequestsHash etc.). Bump to "osaka"/"amsterdam"
+// once besu and nethermind writers cover post-Prague header fields (B7
+// in the unify-client-features plan).
+const DefaultFork = "prague"
+
+// Fork identifies a hard-fork by its lower-case canonical name. Activation
+// can be block-based (pre-Merge) or time-based (post-Merge). For genesis
+// synthesis the activation value is always 0 (active at block 0 / time 0)
+// — earlier forks are pinned to 0 as well so the resulting ChainConfig
+// satisfies all `IsX(0)` predicates up to and including the chosen fork.
+//
+// The order of the slice is the historical activation order; earlier in
+// the slice = earlier in mainnet history.
+type forkSpec struct {
+	name      string
+	timeBased bool
+	apply     func(cfg *params.ChainConfig)
+}
+
+// forks lists every fork state-actor knows how to synthesize. The list is
+// authoritative; --list-forks dumps it; BuildChainConfigForFork walks it
+// from the start and applies every entry up to and including the chosen
+// fork (so "prague" implies "shanghai" implies "london" implies …).
+var forks = []forkSpec{
+	{"homestead", false, func(c *params.ChainConfig) { c.HomesteadBlock = big.NewInt(0) }},
+	{"eip150", false, func(c *params.ChainConfig) { c.EIP150Block = big.NewInt(0) }},
+	{"eip155", false, func(c *params.ChainConfig) {
+		c.EIP155Block = big.NewInt(0)
+		c.EIP158Block = big.NewInt(0)
+	}},
+	{"byzantium", false, func(c *params.ChainConfig) { c.ByzantiumBlock = big.NewInt(0) }},
+	{"constantinople", false, func(c *params.ChainConfig) { c.ConstantinopleBlock = big.NewInt(0) }},
+	{"petersburg", false, func(c *params.ChainConfig) { c.PetersburgBlock = big.NewInt(0) }},
+	{"istanbul", false, func(c *params.ChainConfig) { c.IstanbulBlock = big.NewInt(0) }},
+	{"berlin", false, func(c *params.ChainConfig) { c.BerlinBlock = big.NewInt(0) }},
+	{"london", false, func(c *params.ChainConfig) { c.LondonBlock = big.NewInt(0) }},
+	{"arrowglacier", false, func(c *params.ChainConfig) { c.ArrowGlacierBlock = big.NewInt(0) }},
+	{"grayglacier", false, func(c *params.ChainConfig) { c.GrayGlacierBlock = big.NewInt(0) }},
+	{"merge", false, func(c *params.ChainConfig) {
+		c.TerminalTotalDifficulty = big.NewInt(0)
+		c.MergeNetsplitBlock = big.NewInt(0)
+	}},
+	{"shanghai", true, func(c *params.ChainConfig) { c.ShanghaiTime = newUint64Ptr(0) }},
+	{"cancun", true, func(c *params.ChainConfig) { c.CancunTime = newUint64Ptr(0) }},
+	{"prague", true, func(c *params.ChainConfig) { c.PragueTime = newUint64Ptr(0) }},
+	{"osaka", true, func(c *params.ChainConfig) { c.OsakaTime = newUint64Ptr(0) }},
+}
+
+// BuildChainConfigForFork synthesizes a *params.ChainConfig with the named
+// fork active at genesis (block 0 / time 0). All earlier forks in the
+// historical order are also activated at 0, so every IsX(0) predicate
+// returns true up to and including the chosen fork.
+//
+// chainID becomes the chain's only chainID (no override semantics — the
+// new --chain-id flag is the source of truth).
+//
+// Returns an error if name is empty or unknown. Use ListForks() for the
+// full set of accepted names; "latest" / "default" alias DefaultFork.
+func BuildChainConfigForFork(name string, chainID *big.Int) (*params.ChainConfig, error) {
+	if chainID == nil {
+		return nil, fmt.Errorf("genesis: chainID cannot be nil")
+	}
+	canonical := strings.ToLower(strings.TrimSpace(name))
+	if canonical == "" || canonical == "latest" || canonical == "default" {
+		canonical = DefaultFork
+	}
+	idx := -1
+	for i, f := range forks {
+		if f.name == canonical {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return nil, fmt.Errorf("genesis: unknown fork %q (use --list-forks to see valid names)", name)
+	}
+	cfg := &params.ChainConfig{ChainID: new(big.Int).Set(chainID)}
+	for i := 0; i <= idx; i++ {
+		forks[i].apply(cfg)
+	}
+	return cfg, nil
+}
+
+// LatestForkName returns the fork name state-actor defaults to when --fork
+// is not set. Tracks DefaultFork; exposed so the CLI help string can
+// reflect the current default without duplicating the constant.
+func LatestForkName() string { return DefaultFork }
+
+// ListForks returns the canonical fork names in historical activation
+// order. Backed directly by the forks slice so changes to the catalogue
+// flow through automatically.
+func ListForks() []string {
+	out := make([]string, len(forks))
+	for i, f := range forks {
+		out[i] = f.name
+	}
+	return out
+}
+
+// SortedForks returns ListForks() sorted alphabetically. Useful when
+// printing for human consumption (CLI --list-forks output).
+func SortedForks() []string {
+	out := ListForks()
+	sort.Strings(out)
+	return out
+}
+
+// MaxForkForClient returns the highest fork name state-actor's <client>
+// writer can faithfully produce at genesis. A --fork value past this
+// ceiling should be rejected at parse time so the resulting DB doesn't
+// boot with a "wrong genesis hash" mismatch.
+//
+// Today's ceilings:
+//   - geth, reth: prague (writers populate RequestsHash + blob fields)
+//   - besu: shanghai (genesis_cgo.supportedFork rejects Cancun+; writer
+//     lacks ParentBeaconRoot/ExcessBlobGas/BlobGasUsed/RequestsHash)
+//   - nethermind: merge (writer hardcodes a pre-Shanghai header — no
+//     WithdrawalsHash, no Cancun+ fields)
+//
+// Bump after the corresponding writer adds the missing header fields
+// (B7 / Stage C in the unify-client-features plan).
+func MaxForkForClient(client string) string {
+	switch client {
+	case "geth", "reth":
+		return DefaultFork
+	case "besu":
+		return "shanghai"
+	case "nethermind":
+		return "merge"
+	default:
+		return DefaultFork
+	}
+}
+
+// ForkAtLeast reports whether `a` is the same as or later than `b` in the
+// historical activation order. Returns false if either name is unknown.
+func ForkAtLeast(a, b string) bool {
+	a = strings.ToLower(strings.TrimSpace(a))
+	b = strings.ToLower(strings.TrimSpace(b))
+	ia, ib := -1, -1
+	for i, f := range forks {
+		if f.name == a {
+			ia = i
+		}
+		if f.name == b {
+			ib = i
+		}
+	}
+	if ia < 0 || ib < 0 {
+		return false
+	}
+	return ia >= ib
+}
+
+func newUint64Ptr(v uint64) *uint64 { return &v }

--- a/genesis/forks_test.go
+++ b/genesis/forks_test.go
@@ -1,0 +1,152 @@
+package genesis
+
+import (
+	"math/big"
+	"testing"
+)
+
+func TestBuildChainConfigForFork_PragueActive(t *testing.T) {
+	cfg, err := BuildChainConfigForFork("prague", big.NewInt(1337))
+	if err != nil {
+		t.Fatalf("BuildChainConfigForFork: %v", err)
+	}
+	if cfg.ChainID == nil || cfg.ChainID.Sign() == 0 || cfg.ChainID.Int64() != 1337 {
+		t.Fatalf("chainID = %v, want 1337", cfg.ChainID)
+	}
+
+	zero := big.NewInt(0)
+	if !cfg.IsHomestead(zero) {
+		t.Error("Homestead should be active at block 0")
+	}
+	if !cfg.IsLondon(zero) {
+		t.Error("London should be active at block 0")
+	}
+	if !cfg.IsShanghai(zero, 0) {
+		t.Error("Shanghai should be active at time 0")
+	}
+	if !cfg.IsCancun(zero, 0) {
+		t.Error("Cancun should be active at time 0")
+	}
+	if !cfg.IsPrague(zero, 0) {
+		t.Error("Prague should be active at time 0")
+	}
+	if cfg.IsOsaka(zero, 0) {
+		t.Error("Osaka should NOT be active when --fork=prague")
+	}
+}
+
+func TestBuildChainConfigForFork_ShanghaiOnlyActivatesShanghai(t *testing.T) {
+	cfg, err := BuildChainConfigForFork("shanghai", big.NewInt(1))
+	if err != nil {
+		t.Fatalf("BuildChainConfigForFork: %v", err)
+	}
+	zero := big.NewInt(0)
+	if !cfg.IsLondon(zero) {
+		t.Error("London should still be active for shanghai (earlier fork)")
+	}
+	if !cfg.IsShanghai(zero, 0) {
+		t.Error("Shanghai should be active")
+	}
+	if cfg.IsCancun(zero, 0) {
+		t.Error("Cancun must NOT be active when --fork=shanghai")
+	}
+}
+
+func TestBuildChainConfigForFork_AliasesResolveToDefault(t *testing.T) {
+	for _, alias := range []string{"", "latest", "default", "LATEST", "  prague  "} {
+		cfg, err := BuildChainConfigForFork(alias, big.NewInt(1))
+		if err != nil {
+			t.Fatalf("alias %q: %v", alias, err)
+		}
+		if !cfg.IsPrague(big.NewInt(0), 0) {
+			t.Errorf("alias %q: Prague should be active (DefaultFork=%q)", alias, DefaultFork)
+		}
+	}
+}
+
+func TestBuildChainConfigForFork_UnknownReturnsError(t *testing.T) {
+	if _, err := BuildChainConfigForFork("frontier-but-spelled-wrong", big.NewInt(1)); err == nil {
+		t.Fatal("expected error for unknown fork name")
+	}
+	if _, err := BuildChainConfigForFork("prague", nil); err == nil {
+		t.Fatal("expected error for nil chainID")
+	}
+}
+
+func TestListForks_ContainsCanonicalNames(t *testing.T) {
+	got := ListForks()
+	want := map[string]bool{
+		"homestead": true, "london": true, "merge": true,
+		"shanghai": true, "cancun": true, "prague": true, "osaka": true,
+	}
+	have := make(map[string]bool, len(got))
+	for _, n := range got {
+		have[n] = true
+	}
+	for w := range want {
+		if !have[w] {
+			t.Errorf("ListForks() missing %q", w)
+		}
+	}
+}
+
+func TestLatestForkName_StableAndKnown(t *testing.T) {
+	name := LatestForkName()
+	if name != DefaultFork {
+		t.Errorf("LatestForkName() = %q, want DefaultFork=%q", name, DefaultFork)
+	}
+	cfg, err := BuildChainConfigForFork(name, big.NewInt(1))
+	if err != nil {
+		t.Fatalf("LatestForkName() = %q is not buildable: %v", name, err)
+	}
+	if !cfg.IsPrague(big.NewInt(0), 0) {
+		t.Errorf("LatestForkName() = %q does not activate Prague", name)
+	}
+}
+
+func TestBuildSynthetic_PrimitivesPlumbed(t *testing.T) {
+	g, err := BuildSynthetic("prague", big.NewInt(7), 25_000_000, 999, []byte{0xde, 0xad})
+	if err != nil {
+		t.Fatalf("BuildSynthetic: %v", err)
+	}
+	if g.Config == nil || g.Config.ChainID.Int64() != 7 {
+		t.Errorf("ChainID lost: %v", g.Config)
+	}
+	if uint64(g.GasLimit) != 25_000_000 {
+		t.Errorf("GasLimit = %d, want 25_000_000", g.GasLimit)
+	}
+	if uint64(g.Timestamp) != 999 {
+		t.Errorf("Timestamp = %d, want 999", g.Timestamp)
+	}
+	if len(g.ExtraData) != 2 || g.ExtraData[0] != 0xde || g.ExtraData[1] != 0xad {
+		t.Errorf("ExtraData = %x, want deadX2", g.ExtraData)
+	}
+	if (*big.Int)(g.Difficulty).Sign() != 0 {
+		t.Errorf("Difficulty = %v, want 0 (post-Merge)", g.Difficulty)
+	}
+	if g.BaseFee == nil || (*big.Int)(g.BaseFee).Sign() == 0 {
+		t.Error("BaseFee should be set (London active under prague fork)")
+	}
+	if len(g.Alloc) != 0 {
+		t.Errorf("Alloc should be empty, got %d entries", len(g.Alloc))
+	}
+}
+
+func TestBuildSynthetic_DefaultsApplied(t *testing.T) {
+	g, err := BuildSynthetic("", nil, 0, 0, nil)
+	if err != nil {
+		t.Fatalf("BuildSynthetic with zero values: %v", err)
+	}
+	if g.Config.ChainID.Int64() != 1337 {
+		t.Errorf("default chainID = %d, want 1337", g.Config.ChainID.Int64())
+	}
+	if uint64(g.GasLimit) != 30_000_000 {
+		t.Errorf("default GasLimit = %d, want 30_000_000", g.GasLimit)
+	}
+	if g.ExtraData == nil {
+		t.Error("ExtraData should be empty slice not nil")
+	}
+	if !g.Config.IsPrague(big.NewInt(0), 0) {
+		t.Error("default fork should be prague")
+	}
+}

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -58,7 +58,9 @@ type GenesisAccount struct {
 	Nonce   hexutil.Uint64              `json:"nonce,omitempty"`
 }
 
-// LoadGenesis loads a genesis configuration from a JSON file.
+// LoadGenesis loads a genesis configuration from a JSON file. Used by
+// tests; the production CLI no longer accepts --genesis (state-actor
+// builds genesis itself via BuildSynthetic).
 func LoadGenesis(path string) (*Genesis, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -71,6 +73,65 @@ func LoadGenesis(path string) (*Genesis, error) {
 	}
 
 	return &genesis, nil
+}
+
+// OrDefault returns g if non-nil, otherwise builds a default *Genesis with
+// DefaultFork active and chainID 1337. Tests that exercise client Run
+// paths use this so they don't need to call BuildSynthetic explicitly;
+// production callers always set Config.Genesis via main.go and never see
+// the default branch.
+func OrDefault(g *Genesis) *Genesis {
+	if g != nil {
+		return g
+	}
+	out, _ := BuildSynthetic("", nil, 0, 0, nil)
+	return out
+}
+
+// BuildSynthetic constructs an in-memory *Genesis with the named fork
+// active at genesis (block 0 / time 0) and the supplied header knobs.
+// Replaces the LoadGenesis-from-disk path: state-actor's CLI no longer
+// accepts --genesis; the four header fields users actually need to vary
+// (chainID, gasLimit, timestamp, extraData) are exposed as flags.
+//
+// Defaults applied when fields are zero:
+//   - fork == "" → DefaultFork ("prague")
+//   - chainID == nil → 1337 (devnet convention)
+//   - gasLimit == 0 → 30_000_000
+//   - timestamp == 0 → 0 (genesis epoch)
+//   - extraData == nil → empty slice
+//
+// Difficulty is fixed at 0 (post-Merge); BaseFee is set to
+// params.InitialBaseFee when London is active in the resolved
+// ChainConfig (so London+ headers are structurally complete). Alloc is
+// always empty — pre-funded accounts come from --inject-accounts.
+func BuildSynthetic(fork string, chainID *big.Int, gasLimit uint64, timestamp uint64, extraData []byte) (*Genesis, error) {
+	if chainID == nil {
+		chainID = big.NewInt(1337)
+	}
+	cfg, err := BuildChainConfigForFork(fork, chainID)
+	if err != nil {
+		return nil, err
+	}
+	if gasLimit == 0 {
+		gasLimit = 30_000_000
+	}
+	if extraData == nil {
+		extraData = []byte{}
+	}
+	g := &Genesis{
+		Config:     cfg,
+		Nonce:      0,
+		Timestamp:  hexutil.Uint64(timestamp),
+		ExtraData:  hexutil.Bytes(extraData),
+		GasLimit:   hexutil.Uint64(gasLimit),
+		Difficulty: (*hexutil.Big)(big.NewInt(0)),
+		Alloc:      GenesisAlloc{},
+	}
+	if cfg.IsLondon(big.NewInt(0)) {
+		g.BaseFee = (*hexutil.Big)(big.NewInt(params.InitialBaseFee))
+	}
+	return g, nil
 }
 
 // ToStateAccounts converts the genesis alloc to types.StateAccount format

--- a/main.go
+++ b/main.go
@@ -54,10 +54,17 @@ var (
 	// Target size
 	targetSize = flag.String("target-size", "", "Target total DB size on disk (e.g. '5GB', '500MB'). Stop condition only — set --accounts/--contracts/--min-slots/--max-slots explicitly. Honored by geth and besu; ignored by nethermind; rejected by reth.")
 
-	// Genesis integration
-	genesisPath    = flag.String("genesis", "", "Path to genesis.json file (optional)")
-	injectAccounts = flag.String("inject-accounts", "", "Comma-separated hex addresses to inject with 999999999 ETH (e.g. 0xf39F...2266)")
-	chainID        = flag.Int64("chain-id", 0, "Override genesis chainId (0 = use value from genesis.json)")
+	// Synthetic genesis configuration. state-actor builds the genesis
+	// itself — no --genesis path. The four header knobs users actually
+	// vary are exposed as flags below; everything else takes a sensible
+	// default (Difficulty=0, Coinbase=0x0, Mixhash=0x0, Alloc empty).
+	fork           = flag.String("fork", "", "Hard fork active at genesis. Empty (default) resolves to the latest fork the chosen --client can write. Use --list-forks to see all values.")
+	listForks      = flag.Bool("list-forks", false, "Print the list of accepted --fork values and exit.")
+	injectAccounts = flag.String("inject-accounts", "", "Comma-separated hex addresses to inject with 999999999 ETH (e.g. 0xf39F...2266). Use this instead of a --genesis alloc.")
+	chainID        = flag.Int64("chain-id", 1337, "Chain ID embedded in the synthesized genesis chainspec (default 1337, the devnet convention).")
+	gasLimit       = flag.Uint64("gas-limit", 30_000_000, "Genesis block gas limit (default 30M).")
+	timestamp      = flag.Uint64("timestamp", 0, "Genesis block timestamp (unix seconds, default 0).")
+	extraData      = flag.String("extra-data", "", "Genesis block extraData as hex (default empty).")
 
 	// Binary trie group depth
 	groupDepth = flag.Int("group-depth", 8, "Binary trie group depth (1-8, default 8). Controls serialization unit size.")
@@ -72,6 +79,14 @@ var (
 
 func main() {
 	flag.Parse()
+
+	if *listForks {
+		fmt.Println("Supported --fork values (default = latest):")
+		for _, f := range genesis.SortedForks() {
+			fmt.Printf("  %s\n", f)
+		}
+		os.Exit(0)
+	}
 
 	if *dbPath == "" {
 		fmt.Fprintln(os.Stderr, "Error: -db flag is required")
@@ -194,29 +209,37 @@ func main() {
 		GroupDepth:      *groupDepth,
 	}
 
-	// Load genesis if provided
-	var genesisConfig *genesis.Genesis
-	if *genesisPath != "" {
-		var err error
-		genesisConfig, err = genesis.LoadGenesis(*genesisPath)
+	// Synthesize the genesis chainspec from CLI flags. state-actor no
+	// longer accepts an external --genesis file; the four header knobs
+	// users actually vary (--chain-id / --fork / --gas-limit /
+	// --timestamp / --extra-data) drive an in-memory *Genesis here, and
+	// each client's writer reads it via config.Genesis.
+	extraDataBytes := []byte{}
+	if *extraData != "" {
+		decoded, err := decodeHex(*extraData)
 		if err != nil {
-			log.Fatalf("Failed to load genesis: %v", err)
+			log.Fatalf("--extra-data must be hex (with or without 0x prefix): %v", err)
 		}
+		extraDataBytes = decoded
+	}
+	chosenFork := *fork
+	if chosenFork == "" {
+		chosenFork = genesis.MaxForkForClient(*client)
+	} else if !genesis.ForkAtLeast(genesis.MaxForkForClient(*client), chosenFork) {
+		log.Fatalf("--fork=%s is past --client=%s's writer ceiling (%s); "+
+			"pass --fork=%s or earlier, or use a different --client",
+			chosenFork, *client, genesis.MaxForkForClient(*client),
+			genesis.MaxForkForClient(*client))
+	}
+	genesisConfig, err := genesis.BuildSynthetic(chosenFork, big.NewInt(*chainID), *gasLimit, *timestamp, extraDataBytes)
+	if err != nil {
+		log.Fatalf("--fork %q: %v", chosenFork, err)
+	}
+	config.Genesis = genesisConfig
 
-		// Extract accounts from genesis alloc
-		config.GenesisAccounts = genesisConfig.ToStateAccounts()
-		config.GenesisStorage = genesisConfig.GetAllocStorage()
-		config.GenesisCode = genesisConfig.GetAllocCode()
-
-		// Override chain ID if requested
-		if *chainID != 0 {
-			genesisConfig.Config.ChainID = big.NewInt(*chainID)
-		}
-
-		if *verbose {
-			log.Printf("Loaded genesis with %d alloc accounts (chainId=%s)",
-				len(config.GenesisAccounts), genesisConfig.Config.ChainID)
-		}
+	if *verbose {
+		log.Printf("Synthesized genesis: fork=%s chainID=%s gasLimit=%d timestamp=%d extraData=%dB",
+			chosenFork, genesisConfig.Config.ChainID, uint64(genesisConfig.GasLimit), uint64(genesisConfig.Timestamp), len(genesisConfig.ExtraData))
 	}
 
 	if *verbose {
@@ -237,9 +260,9 @@ func main() {
 		if config.TargetSize > 0 {
 			log.Printf("  Target Size:  %s", formatBytes(config.TargetSize))
 		}
-		if *genesisPath != "" {
-			log.Printf("  Genesis:      %s", *genesisPath)
-		}
+		log.Printf("  Fork:         %s", chosenFork)
+		log.Printf("  Chain ID:     %d", *chainID)
+		log.Printf("  Gas Limit:    %d", *gasLimit)
 	}
 
 	start := time.Now()
@@ -251,15 +274,13 @@ func main() {
 	var stats *generator.Stats
 	switch *client {
 	case "geth":
-		// MPT mode goes through the new direct-Pebble pipeline in
-		// client/geth/ (entitygen → temp Pebble → keccak-sorted writes
-		// to production). Binary-trie mode still routes through the
-		// legacy generator.New().Generate() path because
-		// generator/binary_stack_trie.go is intentionally untouched per
-		// the design doc.
+		// MPT mode routes through client/geth/Populate (the new
+		// direct-Pebble pipeline added in PR #38; reads cfg.Genesis
+		// directly and writes the genesis block as part of Populate).
+		// Binary-trie mode still uses the legacy generator.New /
+		// gen.Generate / geth.WriteGenesisBlock path because
+		// generator/binary_stack_trie.go is intentionally untouched.
 		if config.TrieMode == generator.TrieModeMPT {
-			geth.GenesisFilePath = *genesisPath
-			geth.ChainIDOverride = *chainID
 			var err error
 			stats, err = geth.Populate(context.Background(), config, geth.Options{})
 			if err != nil {
@@ -281,38 +302,31 @@ func main() {
 				log.Fatalf("Failed to generate state: %v", err)
 			}
 
-			// Update live stats with final state
 			if liveStats != nil {
 				liveStats.AddBytes(int64(stats.AccountBytes), int64(stats.StorageBytes), int64(stats.CodeBytes))
 				liveStats.SetStateRoot(stats.StateRoot.Hex())
 			}
 
-			// Write genesis block if genesis was provided (binary-trie path).
-			if genesisConfig != nil {
-				if *verbose {
-					log.Printf("Writing genesis block with state root: %s", stats.StateRoot.Hex())
-				}
-
-				ancientDir := filepath.Join(config.DBPath, "ancient")
-				block, err := geth.WriteGenesisBlock(gen.DB(), genesisConfig, stats.StateRoot, true, ancientDir)
-				if err != nil {
-					log.Fatalf("Failed to write genesis block: %v", err)
-				}
-
-				if *verbose {
-					log.Printf("Genesis block hash: %s", block.Hash().Hex())
-					log.Printf("Genesis block number: %d", block.NumberU64())
-				}
+			// Write genesis block (binary-trie path). genesisConfig is
+			// always non-nil now that main.go synthesizes it via
+			// genesis.BuildSynthetic.
+			if *verbose {
+				log.Printf("Writing genesis block with state root: %s", stats.StateRoot.Hex())
+			}
+			ancientDir := filepath.Join(config.DBPath, "ancient")
+			block, err := geth.WriteGenesisBlock(gen.DB(), genesisConfig, stats.StateRoot, true, ancientDir)
+			if err != nil {
+				log.Fatalf("Failed to write genesis block: %v", err)
+			}
+			if *verbose {
+				log.Printf("Genesis block hash: %s", block.Hash().Hex())
+				log.Printf("Genesis block number: %d", block.NumberU64())
 			}
 		}
 
 	case "nethermind":
-		// Nethermind path: the writer in client/nethermind/ owns the full
-		// pipeline (entitygen → trie.Builder → grocksdb). Phase A
-		// (empty-alloc genesis only) lands behind the cgo_neth build tag;
-		// vanilla local builds get a stub redirecting users at Docker.
-		nethermind.GenesisFilePath = *genesisPath
-		nethermind.ChainIDOverride = *chainID
+		// Nethermind path: writer in client/nethermind/ reads
+		// config.Genesis directly (no package globals).
 		var err error
 		stats, err = nethermind.Run(context.Background(), config, nethermind.Options{})
 		if err != nil {
@@ -323,13 +337,7 @@ func main() {
 		}
 
 	case "besu":
-		// Besu path: writer in client/besu/ owns the full pipeline
-		// (entitygen → Phase 1 temp Pebble → Phase 2 sorted iter →
-		// Bonsai trie.Builder → single grocksdb instance with 8 column
-		// families). Behind the cgo_besu build tag; vanilla local builds
-		// get a stub redirecting users at Docker.
-		besu.GenesisFilePath = *genesisPath
-		besu.ChainIDOverride = *chainID
+		// Besu path: same — writer reads config.Genesis directly.
 		var err error
 		stats, err = besu.Run(context.Background(), config, besu.Options{})
 		if err != nil {
@@ -340,12 +348,7 @@ func main() {
 		}
 
 	case "reth":
-		// Reth path writes a complete v2 datadir directly via mdbx-go +
-		// grocksdb (cgo). Without -tags cgo_reth, RunCgo returns a clear
-		// error pointing at Dockerfile.reth — local builds without
-		// libmdbx/librocksdb cannot exercise this path.
-		reth.GenesisFilePath = *genesisPath
-		reth.ChainIDOverride = *chainID
+		// Reth path: same — writer reads config.Genesis directly.
 		var err error
 		stats, err = reth.RunCgo(context.Background(), config, reth.Options{})
 		if err != nil {
@@ -482,6 +485,40 @@ func parseSize(s string) (uint64, error) {
 		return 0, fmt.Errorf("invalid size format %q (use e.g. '5GB', '500MB')", s)
 	}
 	return val, nil
+}
+
+// decodeHex parses a 0x-prefixed-or-bare hex string into bytes.
+func decodeHex(s string) ([]byte, error) {
+	s = strings.TrimSpace(s)
+	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
+		s = s[2:]
+	}
+	if s == "" {
+		return []byte{}, nil
+	}
+	out := make([]byte, len(s)/2)
+	if len(s)%2 != 0 {
+		return nil, fmt.Errorf("odd-length hex string %q", s)
+	}
+	for i := 0; i < len(out); i++ {
+		var b byte
+		for j := 0; j < 2; j++ {
+			c := s[i*2+j]
+			b <<= 4
+			switch {
+			case c >= '0' && c <= '9':
+				b |= c - '0'
+			case c >= 'a' && c <= 'f':
+				b |= c - 'a' + 10
+			case c >= 'A' && c <= 'F':
+				b |= c - 'A' + 10
+			default:
+				return nil, fmt.Errorf("invalid hex char %q at offset %d", c, i*2+j)
+			}
+		}
+		out[i] = b
+	}
+	return out, nil
 }
 
 // dirSize returns the total size of all files in a directory tree.


### PR DESCRIPTION
## Summary

PR-CLI-1 from the unify-client-features plan. State-actor no longer accepts an external \`--genesis\` JSON: the four header knobs users actually vary (chain ID, fork, gas limit, timestamp, extraData) become flags, and \`main.go\` synthesizes an in-memory \`*genesis.Genesis\` via \`genesis.BuildSynthetic()\`. Each client's writer reads it from \`config.Genesis\` directly, replacing the package-level \`GenesisFilePath\`/\`ChainIDOverride\` trampolines (early T1.1 unification work).

## CLI surface changes

- **New**: \`--fork\` — auto-resolves to the latest fork the chosen \`--client\` can write (geth/reth = prague, besu = shanghai, nethermind = merge). \`genesis.MaxForkForClient(client)\` is the source of truth.
- **New**: \`--list-forks\` dumps the supported set (homestead through osaka).
- **New**: \`--gas-limit\` (default 30M), \`--timestamp\` (default 0), \`--extra-data\` (hex; default empty).
- **Removed**: \`--genesis\`. With no external file, \`--client=nethermind\`'s synthetic+alloc-with-storage rejection becomes vacuous and is rephrased to fire only when tests programmatically set \`cfg.GenesisStorage\`.
- \`--chain-id\` now sets the chain's ChainID directly (previously was an "override" of a genesis file). Default 1337.

## Internal moves

- \`genesis/forks.go\` (new): \`BuildChainConfigForFork(name, chainID)\` synthesizes a \`*params.ChainConfig\` with the named fork active at block/time 0; earlier forks pinned to 0. \`ListForks\`/\`SortedForks\`/\`MaxForkForClient\`/\`ForkAtLeast\`/\`DefaultFork\` exported for \`main.go\` consumption.
- \`genesis/genesis.go\`: \`BuildSynthetic\` builds an in-memory \`*Genesis\` from primitives. \`OrDefault(g)\` returns \`g\` or a freshly-built default — used by client \`Run\` paths so tests don't have to call \`BuildSynthetic\` themselves.
- \`generator.Config\` gains a \`*genesis.Genesis\` field (creates a new \`generator → genesis\` import). The legacy \`GenesisAccounts\`/\`Storage\`/\`Code\` fields are kept (oracle differential tests still set them); production CLI flow leaves them nil.
- \`client/{nethermind,besu,reth}\`: drop \`GenesisFilePath\`/\`ChainIDOverride\` package globals. Each client's runImpl reads \`cfg.Genesis\` directly via \`genesis.OrDefault\`. besu's \`loadOrDefault(path)\` is replaced with \`besuGenesisFromConfig(g)\`; \`supportedFork\` moves to inspect \`Config.CancunTime\`/\`PragueTime\` via the \`params\` struct.
- \`client/reth/chainspec.go\`: \`writeChainSpec(g, outPath)\` marshals the in-memory genesis directly (its JSON tags already match reth's chainspec field names), forces alloc to \`{}\`.

## Smoke / Make targets

Makefile \`smoke-{nethermind,besu}{,-spamoor}\` targets and the \`example\` target use \`--chain-id=1337\` + \`--inject-accounts=<3 dev addrs>\` instead of \`--genesis=/test/genesis-funded.json\`. \`SMOKE_INJECT_ADDRS\` encodes the three addresses that used to live in \`testdata/genesis-funded.json\`.

## Stacks on

#28 (\`feat/reth-direct-mdbx\`) and PR-CLI-2 (just-reopened). Marked draft until both merge; after that the diff cleans up.

## Test plan

- [x] \`go vet ./...\`, \`go build ./...\`, \`go test -count=1 ./...\` — all 17 packages green.
- [x] Cgo tests in Docker: \`cgo_reth\`, \`cgo_besu\`, \`cgo_neth\` — all green. Reth golden state-root (canonical entitygen MPT, \`0xddbfa7c1...\`) still pinned and passes.
- [x] \`genesis\` package gets new test coverage (forks_test.go): \`BuildChainConfigForFork\` alias resolution / fork-ordering / Prague defaulting; \`BuildSynthetic\` primitive plumbing + zero-value default fill-in.
- [ ] Reviewer: \`state-actor --list-forks\` prints the catalogue.
- [ ] Reviewer: \`state-actor --client=besu --fork=cancun ...\` errors at parse with a clear "ceiling shanghai" message.
- [ ] Reviewer: \`state-actor --client=geth --fork=prague --chain-id=31337 --inject-accounts=0xf39F... --accounts=100 --contracts=10\` produces a geth-bootable DB.

## Out of scope (follow-up)

- B7: write besu/nethermind chainspec next to the DB so \`--chain-id\` takes effect at boot.
- C2 (Tier 1 #4): centralize per-(flag, client) policy, currently scattered across \`main.go\` and client \`runImpl\`.
- Smoke shell scripts under \`client/besu/testdata/*.sh\` that still reference \`--genesis\` directly.