### PR TITLE
fix(main): unbreak `go build ./...` on origin/main

### DIFF
--- a/client/geth/run.go
+++ b/client/geth/run.go
@@ -23,16 +23,9 @@ type Options struct{}
 //     state root.
 //  3. Persist PathDB metadata (StateID, PersistentStateID, SnapshotRoot,
 //     completed-snapshot-generator marker) so geth boots cleanly.
-<<<<<<< feat/cli-chainid-embedding
-//  4. Write the genesis block + chain config from cfg.Genesis so the DB
-//     is fully self-bootable. cfg.Genesis is always non-nil in the
-//     production CLI flow (main.go's BuildSynthetic); tests that omit
-//     it fall through to genesis.OrDefault.
-=======
 //  4. Write the genesis block + chain config from cfg.Genesis (always
 //     non-nil after main.go's BuildSynthetic call) so the DB is
 //     fully self-bootable.
->>>>>>> main
 //  5. Close the writer.
 //
 // Returns the same *generator.Stats shape as the legacy generator.New +
@@ -68,15 +61,9 @@ func Populate(ctx context.Context, cfg generator.Config, opts Options) (*generat
 		return nil, fmt.Errorf("client/geth.Populate: set state root: %w", err)
 	}
 
-<<<<<<< feat/cli-chainid-embedding
-	// Genesis block + chain config. cfg.Genesis is the canonical surface
-	// (main.go's BuildSynthetic always populates it); genesis.OrDefault
-	// gives tests a sensible fallback chainspec without the boilerplate.
-=======
 	// Genesis block + chain config from cfg.Genesis (synthesized by
 	// main.go via genesis.BuildSynthetic; tests can leave it nil and
 	// get the default chainspec).
->>>>>>> main
 	g := genesis.OrDefault(cfg.Genesis)
 	ancientDir := filepath.Join(cfg.DBPath, "ancient")
 	if _, err := WriteGenesisBlock(w.DB(), g, stateRoot, false, ancientDir); err != nil {

--- a/internal/clientpolicy/policy.go
+++ b/internal/clientpolicy/policy.go
@@ -21,10 +21,9 @@ import (
 // validated by the flag parser itself (--db required, --extra-data hex
 // well-formed, ...).
 type FlagValues struct {
-	BinaryTrie         bool   // --binary-trie
-	DeepBranchAccounts int    // --deep-branch-accounts (>0 means active)
-	TargetSize         string // --target-size (non-empty means active)
-	Fork               string // --fork (canonical fork name; "" means "auto")
+	BinaryTrie bool   // --binary-trie
+	TargetSize string // --target-size (non-empty means active)
+	Fork       string // --fork (canonical fork name; "" means "auto")
 }
 
 // ValidateForClient returns nil when every flag in fv is compatible with
@@ -34,10 +33,10 @@ type FlagValues struct {
 //
 // Two layers:
 //  1. Client recognition: erigon → not-yet-implemented; unknown → reject.
-//  2. Per-client compatibility: --binary-trie / --deep-branch-accounts
-//     are geth-only (the others lack EIP-7864 support); --target-size is
-//     incompatible with reth; --fork is clamped at each client's writer
-//     ceiling (see genesis.MaxForkForClient).
+//  2. Per-client compatibility: --binary-trie is geth-only (the others
+//     lack EIP-7864 support); --target-size is incompatible with reth;
+//     --fork is clamped at each client's writer ceiling (see
+//     genesis.MaxForkForClient).
 func ValidateForClient(client string, fv FlagValues) error {
 	switch client {
 	case "geth", "nethermind", "besu", "reth":
@@ -57,17 +56,6 @@ func ValidateForClient(client string, fv FlagValues) error {
 			return fmt.Errorf("--binary-trie is not supported with --client=besu (Besu does not implement EIP-7864)")
 		case "reth":
 			return fmt.Errorf("--binary-trie is not supported with --client=reth (Reth does not implement EIP-7864)")
-		}
-	}
-
-	// Deep-branch — geth-only (binary-trie experiment using its own
-	// Pebble layout).
-	if fv.DeepBranchAccounts > 0 && client != "geth" {
-		switch client {
-		case "nethermind", "besu":
-			return fmt.Errorf("--deep-branch-accounts is geth-specific and not supported with --client=%s", client)
-		case "reth":
-			return fmt.Errorf("--deep-branch-accounts is not yet supported with --client=reth")
 		}
 	}
 

--- a/internal/clientpolicy/policy_test.go
+++ b/internal/clientpolicy/policy_test.go
@@ -39,18 +39,6 @@ func TestValidateForClient_BinaryTrieGethOnly(t *testing.T) {
 	}
 }
 
-func TestValidateForClient_DeepBranchGethOnly(t *testing.T) {
-	if err := ValidateForClient("geth", FlagValues{DeepBranchAccounts: 5}); err != nil {
-		t.Errorf("geth + --deep-branch-accounts should be allowed: %v", err)
-	}
-	for _, c := range []string{"nethermind", "besu", "reth"} {
-		err := ValidateForClient(c, FlagValues{DeepBranchAccounts: 5})
-		if err == nil {
-			t.Errorf("%s + --deep-branch-accounts should reject", c)
-		}
-	}
-}
-
 func TestValidateForClient_TargetSizeRejectsReth(t *testing.T) {
 	for _, c := range []string{"geth", "nethermind", "besu"} {
 		if err := ValidateForClient(c, FlagValues{TargetSize: "5GB"}); err != nil {

--- a/main.go
+++ b/main.go
@@ -52,11 +52,6 @@ var (
 	benchmark    = flag.Bool("benchmark", false, "Run in benchmark mode (print detailed stats)")
 	binaryTrie   = flag.Bool("binary-trie", false, "Generate state for binary trie mode (EIP-7864)")
 
-	// Deep-branch accounts
-	deepBranchAccounts   = flag.Int("deep-branch-accounts", 0, "Number of additional contracts with deep storage tries (0 = disabled)")
-	deepBranchDepth      = flag.Int("deep-branch-depth", 64, "Branch depth per deep slot in nibbles (1-64)")
-	deepBranchKnownSlots = flag.Int("deep-branch-known-slots", 1, "Legitimate storage slots with known preimages per deep-branch account")
-
 	// Target size
 	targetSize = flag.String("target-size", "", "Target total DB size on disk (e.g. '5GB', '500MB'). Stop condition only — set --accounts/--contracts/--min-slots/--max-slots explicitly. Honored by geth and besu; ignored by nethermind; rejected by reth.")
 
@@ -109,10 +104,9 @@ func main() {
 	// runs fail fast instead of burning minutes producing a wrong output.
 	// Rules live in internal/clientpolicy/ as one source-of-truth table.
 	if err := clientpolicy.ValidateForClient(*client, clientpolicy.FlagValues{
-		BinaryTrie:         *binaryTrie,
-		DeepBranchAccounts: *deepBranchAccounts,
-		TargetSize:         *targetSize,
-		Fork:               *fork,
+		BinaryTrie: *binaryTrie,
+		TargetSize: *targetSize,
+		Fork:       *fork,
 	}); err != nil {
 		log.Fatalf("%v", err)
 	}
@@ -169,16 +163,6 @@ func main() {
 	// raw-byte cap; nethermind currently no-ops; reth rejects the flag at
 	// parse time.
 
-	// Validate deep-branch flags
-	if *deepBranchAccounts > 0 {
-		if *deepBranchDepth < 1 || *deepBranchDepth > 64 {
-			log.Fatalf("--deep-branch-depth must be 1-64, got %d", *deepBranchDepth)
-		}
-		if *deepBranchKnownSlots < 1 {
-			log.Fatalf("--deep-branch-known-slots must be >= 1, got %d", *deepBranchKnownSlots)
-		}
-	}
-
 	config := generator.Config{
 		DBPath:          *dbPath,
 		NumAccounts:     *accounts,
@@ -196,13 +180,8 @@ func main() {
 		WriteTrieNodes:  true, // Always write trie nodes — DB is unusable without them
 		InjectAddresses: injectAddrs,
 		TargetSize:      parsedTargetSize,
-		DeepBranch: generator.DeepBranchConfig{
-			NumAccounts: *deepBranchAccounts,
-			Depth:       *deepBranchDepth,
-			KnownSlots:  *deepBranchKnownSlots,
-		},
-		LiveStats:  liveStats,
-		GroupDepth: *groupDepth,
+		LiveStats:       liveStats,
+		GroupDepth:      *groupDepth,
 	}
 
 	// Synthesize the genesis chainspec from CLI flags. state-actor no
@@ -252,10 +231,6 @@ func main() {
 		}
 		if config.TargetSize > 0 {
 			log.Printf("  Target Size:  %s", formatBytes(config.TargetSize))
-		}
-		if config.DeepBranch.Enabled() {
-			log.Printf("  Deep Branch:  %d accounts, depth=%d, known_slots=%d",
-				config.DeepBranch.NumAccounts, config.DeepBranch.Depth, config.DeepBranch.KnownSlots)
 		}
 		log.Printf("  Fork:         %s", chosenFork)
 		log.Printf("  Chain ID:     %d", *chainID)

--- a/main.go
+++ b/main.go
@@ -310,19 +310,20 @@ func main() {
 				liveStats.SetStateRoot(stats.StateRoot.Hex())
 			}
 
-		// Write genesis block (geth-specific). Always runs now that the
-		// synthesized config.Genesis is always present.
-		if *verbose {
-			log.Printf("Writing genesis block with state root: %s", stats.StateRoot.Hex())
-		}
-		ancientDir := filepath.Join(config.DBPath, "ancient")
-		block, err := geth.WriteGenesisBlock(gen.DB(), genesisConfig, stats.StateRoot, config.TrieMode == generator.TrieModeBinary, ancientDir)
-		if err != nil {
-			log.Fatalf("Failed to write genesis block: %v", err)
-		}
-		if *verbose {
-			log.Printf("Genesis block hash: %s", block.Hash().Hex())
-			log.Printf("Genesis block number: %d", block.NumberU64())
+			// Write genesis block (binary-trie path only — the MPT
+			// path's geth.Populate writes its own genesis block).
+			if *verbose {
+				log.Printf("Writing genesis block with state root: %s", stats.StateRoot.Hex())
+			}
+			ancientDir := filepath.Join(config.DBPath, "ancient")
+			block, err := geth.WriteGenesisBlock(gen.DB(), genesisConfig, stats.StateRoot, true, ancientDir)
+			if err != nil {
+				log.Fatalf("Failed to write genesis block: %v", err)
+			}
+			if *verbose {
+				log.Printf("Genesis block hash: %s", block.Hash().Hex())
+				log.Printf("Genesis block number: %d", block.NumberU64())
+			}
 		}
 
 	case "nethermind":


### PR DESCRIPTION
## Summary

`origin/main` doesn't currently build (`go build ./...`). Three independent breakages, all fallout from PRs #33–#38 merging in a 30-minute window without `go build` between merges.

This PR fixes all three so D1/D2 (oracle hex helpers + RPC-probe extraction) can rebase on a green main.

## What's broken on main right now

```
$ go build ./...
# github.com/nerolation/state-actor/client/geth
client/geth/run.go:26:1: syntax error: non-declaration statement outside function body
client/geth/run.go:71:1: syntax error: unexpected <<, expected }
# (after fixing those)
# github.com/nerolation/state-actor
./main.go:328:2: syntax error: unexpected keyword case, expected }
# (after fixing that)
./main.go:199:3: unknown field DeepBranch in struct literal of type generator.Config
./main.go:199:25: undefined: generator.DeepBranchConfig
./main.go:256:13: config.DeepBranch undefined
```

## Two commits

### Commit 1 — `fix: resolve unmerged conflict markers + close orphaned else block`

Two structural problems, one in each file:

- **`client/geth/run.go`** — PR #35 left two `<<<<<<< / ======= / >>>>>>>` blocks committed inside `Populate`'s doc comment. Both alternatives were reworded versions of the same comment; kept the `main`-side wording.
- **`main.go`** — PR #37 deleted comment-only lines that lived inside the PR #35 conflict region but failed to re-close the surrounding `else` block. The binary-trie genesis-block-write code (lines 313–326, `gen.DB()` callers) ended up dedented to 2 tabs without a matching `}`, so the parser hit `case "nethermind":` while still inside the `else`. Re-indented to 3 tabs (consistent with surrounding else-content) and added the missing `\t\t}`. The "Always runs" comment was misleading too — `gen` is only in scope inside the else, so this code path is binary-trie-only; the MPT path's `geth.Populate` writes its own genesis block.

### Commit 2 — `refactor: complete deep-branch removal started by PR #38`

PR #38 intentionally dropped `cfg.DeepBranch` and `generator.DeepBranchConfig` (its commit message: "Drops cfg.DeepBranch and Config.DeepBranchConfig type"), and its diff removed the matching `main.go` references. PRs #33–#37 were branched off pre-#38 main; when merged on top of already-merged #38 they silently re-introduced the references via mismerge.

This commit finishes the removal:

- `main.go` — drop `--deep-branch-accounts` / `--deep-branch-depth` / `--deep-branch-known-slots` flag definitions, the validation block, the `DeepBranch:` struct-literal field, the verbose-log block, and the `DeepBranchAccounts:` field from the `clientpolicy.FlagValues{}` literal.
- `internal/clientpolicy/policy.go` — drop `FlagValues.DeepBranchAccounts` and the per-client deep-branch rejection rule. `ValidateForClient` doc comment updated.
- `internal/clientpolicy/policy_test.go` — drop `TestValidateForClient_DeepBranchGethOnly`.

**UX impact**: `--deep-branch-*` flags no longer parse. Anyone passing them gets a louder `flag provided but not defined` error instead of a silent no-op (the previous half-removed state would have parsed the flag and ignored it). The storage-trie functionality itself was already gone after PR #38.

## Why no behavior change on the geth/main.go fix?

The `else` block fix re-creates the indentation/brace structure PR #34 had before PR #35 introduced the conflict region. `gen` is declared with `:=` in the else, so `gen.DB()` callers were always meant to be inside the else — the dedent was an artifact of mismerge, not intent.

## Test plan

- [x] `go build ./...` — green (was failing in 5 places)
- [x] `go vet ./...` — clean
- [x] `go test -count=1 ./...` — all 19 packages green

## Follow-up worth considering (out of scope here)

A 3-line GitHub Actions workflow running `go vet ./...; go build ./...; go test -count=1 ./...` on every PR would have caught all three issues at review time.