### PR TITLE
ci: add Tier-1 per-PR regression gate (5 parallel jobs covering all 4 clients)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,134 @@
+# CI — Tier 1: per-PR regression gate.
+#
+# Five jobs run in parallel on every PR + push to main:
+#
+#   default       — go vet/build/test under the default tag set. Catches the
+#                   compile + non-cgo regression class (the kind that broke
+#                   main in nerolation/state-actor#39).
+#   reth-cgo      — make test-reth-cgo. cgo_reth-tagged unit tests including
+#                   client/reth/golden_test.go (canonical state-root pin).
+#   besu-oracle   — make test-besu-oracle. Differential oracle pinned to
+#                   Besu's GenesisStateTest.java fixture hashes — byte-level
+#                   encoding gate.
+#   neth-oracle   — make test-nethermind-oracle. Differential oracle pinned
+#                   to Nethermind's GenesisBuilderTests.cs Parity chainspec
+#                   hashes.
+#   reth-oracle   — make test-reth-oracle. reth db stats against state-actor
+#                   MDBX layout — schema-drift gate. Mounts the host docker
+#                   socket (DinD via socket mount) so the test can spawn the
+#                   pinned upstream reth container.
+#
+# Real-node boot tests (test-geth-boot, smoke-geth, test-reth-boot) live
+# behind a Tier 2 follow-up workflow, gated to schedule + opt-in PR label —
+# their cold-cache runtime is too long to justify on every PR. Tier 1 alone
+# closes the regression window for every bug class fixed in PRs #39, #40,
+# #41, #44.
+
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# One run per branch — supersede stale runs when a PR gets new pushes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  default:
+    name: vet · build · test (default tags)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - run: go vet ./...
+      - run: go build ./...
+      - run: go test -count=1 -timeout=10m ./...
+
+  reth-cgo:
+    name: reth · cgo writer + golden hash
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      # Build (and cache) state-actor-reth's builder stage. RocksDB 10.10.1
+      # source-build dominates runtime — ~12-15 min cold, <30s warm. The
+      # GHA cache scope is shared with reth-oracle below so they don't fight
+      # for the same layer.
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.reth
+          target: builder
+          tags: state-actor-reth:latest
+          load: true
+          cache-from: type=gha,scope=reth-builder
+          cache-to: type=gha,scope=reth-builder,mode=max
+      # `make test-reth-cgo`'s image-reth prereq finds the just-loaded image
+      # and skips the rebuild. The test itself runs in <10s post-build.
+      - run: make test-reth-cgo
+
+  besu-oracle:
+    name: besu · differential oracle
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.besu
+          target: builder
+          tags: state-actor-besu-builder:latest
+          load: true
+          cache-from: type=gha,scope=besu-builder
+          cache-to: type=gha,scope=besu-builder,mode=max
+      - run: make test-besu-oracle
+
+  neth-oracle:
+    name: nethermind · differential oracle
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.nethermind
+          target: builder
+          tags: state-actor-nethermind-builder:latest
+          load: true
+          cache-from: type=gha,scope=neth-builder
+          cache-to: type=gha,scope=neth-builder,mode=max
+      - run: make test-nethermind-oracle
+
+  reth-oracle:
+    name: reth · db stats oracle (DinD)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      # Same builder-stage build + cache as reth-cgo (shared scope). The
+      # test then mounts /var/run/docker.sock and spawns the pinned upstream
+      # reth container (ghcr.io/cperezz/reth — amd64-only; OK on
+      # ubuntu-latest, blocked on arm64 per nerolation/state-actor#45).
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.reth
+          target: builder
+          tags: state-actor-reth:latest
+          load: true
+          cache-from: type=gha,scope=reth-builder
+          cache-to: type=gha,scope=reth-builder,mode=max
+      - run: make test-reth-oracle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,17 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [main]
+    # No branch filter: triggers on every push.
+    #
+    # Default protection (`branches: [main]`) created a bootstrap problem
+    # for THIS PR — a fork-to-upstream PR uses the upstream's main copy of
+    # the workflow, but main hasn't seen the workflow yet (this is the PR
+    # that adds it), so nothing fires. Widening the trigger lets feature
+    # branches validate themselves on the contributor's fork before merge.
+    #
+    # Post-merge, the side effect is that maintainer pushes to any branch
+    # of the upstream repo also trigger CI — desirable, since maintainers
+    # mostly push via PRs and direct pushes are usually intentional.
 
 # One run per branch — supersede stale runs when a PR gets new pushes.
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,28 +1,34 @@
 # CI — Tier 1: per-PR regression gate.
 #
-# Five jobs run in parallel on every PR + push to main:
+# Five jobs run in parallel on every PR + push:
 #
 #   default       — go vet/build/test under the default tag set. Catches the
 #                   compile + non-cgo regression class (the kind that broke
 #                   main in nerolation/state-actor#39).
-#   reth-cgo      — make test-reth-cgo. cgo_reth-tagged unit tests including
-#                   client/reth/golden_test.go (canonical state-root pin).
-#   besu-oracle   — make test-besu-oracle. Differential oracle pinned to
-#                   Besu's GenesisStateTest.java fixture hashes — byte-level
-#                   encoding gate.
-#   neth-oracle   — make test-nethermind-oracle. Differential oracle pinned
-#                   to Nethermind's GenesisBuilderTests.cs Parity chainspec
-#                   hashes.
-#   reth-oracle   — make test-reth-oracle. reth db stats against state-actor
-#                   MDBX layout — schema-drift gate. Mounts the host docker
-#                   socket (DinD via socket mount) so the test can spawn the
-#                   pinned upstream reth container.
+#   reth-cgo      — cgo_reth-tagged unit tests including the canonical
+#                   state-root pin in client/reth/golden_test.go.
+#   besu-oracle   — Differential oracle pinned to Besu's GenesisStateTest.java
+#                   fixture hashes — byte-level encoding gate.
+#   neth-oracle   — Differential oracle pinned to Nethermind's
+#                   GenesisBuilderTests.cs Parity chainspec hashes.
+#   reth-oracle   — `reth db stats` against state-actor's MDBX layout —
+#                   schema-drift gate. Mounts the host docker socket (DinD)
+#                   so the test can spawn the pinned upstream reth container.
 #
 # Real-node boot tests (test-geth-boot, smoke-geth, test-reth-boot) live
-# behind a Tier 2 follow-up workflow, gated to schedule + opt-in PR label —
-# their cold-cache runtime is too long to justify on every PR. Tier 1 alone
-# closes the regression window for every bug class fixed in PRs #39, #40,
-# #41, #44.
+# behind a Tier 2 follow-up workflow, gated to schedule + opt-in PR label.
+#
+# ---
+#
+# Why we don't `make test-<X>-oracle` directly: each oracle Makefile target
+# depends on a `docker-<X>-test` prereq that unconditionally re-runs
+# `docker build`. The docker/build-push-action above already populates the
+# GHA buildx cache and loads the image into the local daemon, but Make's
+# `docker build` doesn't know about the GHA cache backend — so it would
+# re-build RocksDB from scratch (~15 min, almost the entire 30-min job
+# timeout). Inlining the `docker run` step skips Make's prereq and uses
+# the just-loaded image directly. Local dev still uses `make` normally;
+# the workflow is the only place this duplication matters.
 
 name: CI
 
@@ -69,9 +75,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
       # Build (and cache) state-actor-reth's builder stage. RocksDB 10.10.1
-      # source-build dominates runtime — ~12-15 min cold, <30s warm. The
-      # GHA cache scope is shared with reth-oracle below so they don't fight
-      # for the same layer.
+      # source-build dominates runtime — ~15 min cold, <30s warm. Cache
+      # scope is shared with reth-oracle below so they don't fight for the
+      # same layer.
       - uses: docker/build-push-action@v5
         with:
           context: .
@@ -81,9 +87,9 @@ jobs:
           load: true
           cache-from: type=gha,scope=reth-builder
           cache-to: type=gha,scope=reth-builder,mode=max
-      # `make test-reth-cgo`'s image-reth prereq finds the just-loaded image
-      # and skips the rebuild. The test itself runs in <10s post-build.
-      - run: make test-reth-cgo
+      # Inlined from `make test-reth-cgo` minus its image-reth Make prereq
+      # (which would re-build RocksDB; see file-level note above).
+      - run: docker run --rm state-actor-reth go test -tags cgo_reth -timeout 10m ./client/reth/...
 
   besu-oracle:
     name: besu · differential oracle
@@ -101,7 +107,11 @@ jobs:
           load: true
           cache-from: type=gha,scope=besu-builder
           cache-to: type=gha,scope=besu-builder,mode=max
-      - run: make test-besu-oracle
+      # Inlined from `make test-besu-oracle` minus its docker-besu-test
+      # Make prereq.
+      - run: |
+          docker run --rm --entrypoint bash state-actor-besu-builder:latest \
+            -c 'cd /app && go test -tags cgo_besu -run TestDifferentialOracle -v -timeout 10m ./client/besu/...'
 
   neth-oracle:
     name: nethermind · differential oracle
@@ -119,7 +129,11 @@ jobs:
           load: true
           cache-from: type=gha,scope=neth-builder
           cache-to: type=gha,scope=neth-builder,mode=max
-      - run: make test-nethermind-oracle
+      # Inlined from `make test-nethermind-oracle` minus its
+      # docker-nethermind-test Make prereq.
+      - run: |
+          docker run --rm --entrypoint bash state-actor-nethermind-builder:latest \
+            -c 'cd /app && go test -tags cgo_neth -run TestDifferentialOracle -v -timeout 10m ./client/nethermind/...'
 
   reth-oracle:
     name: reth · db stats oracle (DinD)
@@ -128,8 +142,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
-      # Same builder-stage build + cache as reth-cgo (shared scope). The
-      # test then mounts /var/run/docker.sock and spawns the pinned upstream
+      # Same builder-stage build + cache as reth-cgo (shared scope). Test
+      # then mounts /var/run/docker.sock and spawns the pinned upstream
       # reth container (ghcr.io/cperezz/reth — amd64-only; OK on
       # ubuntu-latest, blocked on arm64 per nerolation/state-actor#45).
       - uses: docker/build-push-action@v5
@@ -141,4 +155,16 @@ jobs:
           load: true
           cache-from: type=gha,scope=reth-builder
           cache-to: type=gha,scope=reth-builder,mode=max
-      - run: make test-reth-oracle
+      # Inlined from `make test-reth-oracle` minus its image-reth Make
+      # prereq. Volume cleanup before + after; --rm on the test container.
+      - run: |
+          ORACLE_VOL=reth-oracle-datadir
+          docker volume rm -f "$ORACLE_VOL" >/dev/null 2>&1 || true
+          docker volume create "$ORACLE_VOL"
+          docker run --rm \
+            -v "$ORACLE_VOL":/oracle-data \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -e RETH_ORACLE_DATADIR=/oracle-data \
+            -e RETH_ORACLE_VOL="$ORACLE_VOL" \
+            state-actor-reth go test -tags 'cgo_reth oracle' ./client/reth/ -run TestRethDbStats -v -timeout 15m
+          docker volume rm -f "$ORACLE_VOL" >/dev/null 2>&1 || true


### PR DESCRIPTION
First CI for state-actor. Catches the regression classes fixed in #39 / #40 / #41 / #44 at PR-time before they reach main.

## What this is

Five parallel jobs on every PR + push to main:

| Job | Target | What it gates |
|---|---|---|
| `default` | `go vet`/`build`/`test` (default tags) | Compile + non-cgo regression. The class fixed in #39 (conflict markers, unclosed braces, dead refs after refactor). |
| `reth-cgo` | `make test-reth-cgo` | reth writer (cgo_reth) including `client/reth/golden_test.go` — pinned canonical state root. Bit-flip in entitygen ⇒ this fails. |
| `besu-oracle` | `make test-besu-oracle` | Differential oracle pinned to Besu's `GenesisStateTest.java` fixture hashes. Byte-level encoding gate against upstream Besu's own reference fixtures. |
| `neth-oracle` | `make test-nethermind-oracle` | Same shape, against Nethermind's `GenesisBuilderTests.cs` Parity chainspec hashes. |
| `reth-oracle` | `make test-reth-oracle` | Mounts `/var/run/docker.sock`, spawns the pinned upstream reth container, runs `reth db stats` against state-actor's MDBX layout. Schema-drift gate. |

## What's NOT here

Real-node boot tests (`test-geth-boot`, `smoke-geth`, `test-reth-boot`) — Tier 2, separate PR. Cold-cache cost is too high to justify on every PR (~30 min for `test-reth-boot` alone). They'll land behind a `schedule:` cron + opt-in `full-ci` PR label, with the same caching strategy this PR establishes.

## Caching

- `actions/setup-go@v5` with `cache: true` ⇒ Go build + module cache for the `default` job.
- `docker/build-push-action@v5` with `cache-from`/`cache-to: type=gha,mode=max` for the cgo image builds. Each Dockerfile source-builds **RocksDB 10.10.1** (~12–15 min cold per image); warm cache reduces that step to <30s.
- Cache scopes per cgo image (`reth-builder`, `besu-builder`, `neth-builder`) so they don't evict each other.
- `reth-cgo` and `reth-oracle` deliberately **share** `reth-builder` scope — same Dockerfile, same builder stage.

## Concurrency

One CI run per branch. New pushes cancel in-flight runs via `concurrency.cancel-in-progress: true`.

## Branch protection (manual, post-merge)

After this lands, mark these as required checks on `main`:
- `vet · build · test (default tags)`
- `reth · cgo writer + golden hash`
- `besu · differential oracle`
- `nethermind · differential oracle`
- `reth · db stats oracle (DinD)`

(5 jobs. They run in parallel, so total wall time = max(any one) ≈ 30–45 min cold / <12 min warm.)

## Validation

- [x] `actionlint .github/workflows/ci.yml` — clean.
- [ ] **End-to-end:** this PR's own CI run is the live verification. Cold-cache the first push will take ~30–45 min (RocksDB builds dominate); warm-cache subsequent pushes <12 min. If anything fails, I'll iterate in follow-up commits before requesting review.

## Related

- Closes the gap that caused #39, #40, #41, #44 to ship via manual reviewer eyeballs only.
- #45 (Rosetta+MDBX on Apple Silicon) is unaffected — `ubuntu-latest` runners are amd64-native, no emulation involved.
- Tier 2 (real-node boot tests) is the natural follow-up PR.