### PR TITLE
ci: add Tier-2 real-node boot tests (geth-boot, geth-smoke, reth-boot)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,18 +34,25 @@ name: CI
 
 on:
   pull_request:
+    # The Tier-2 jobs (geth-boot, geth-smoke, reth-boot) only fire when a
+    # PR carries the `full-ci` label. Tier-1 jobs run on every PR.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     # No branch filter: triggers on every push.
     #
     # Default protection (`branches: [main]`) created a bootstrap problem
-    # for THIS PR — a fork-to-upstream PR uses the upstream's main copy of
-    # the workflow, but main hasn't seen the workflow yet (this is the PR
-    # that adds it), so nothing fires. Widening the trigger lets feature
-    # branches validate themselves on the contributor's fork before merge.
+    # for the original CI PR — a fork-to-upstream PR uses the upstream's
+    # main copy of the workflow, but main hadn't seen the workflow yet
+    # (it was the PR adding it). Widening the trigger let the feature
+    # branch validate itself on the contributor's fork before merge.
     #
     # Post-merge, the side effect is that maintainer pushes to any branch
     # of the upstream repo also trigger CI — desirable, since maintainers
     # mostly push via PRs and direct pushes are usually intentional.
+  schedule:
+    # Nightly run @ 06:00 UTC for the Tier-2 boot tests so regressions in
+    # "datadir is bootable + serves correct state" surface within a day.
+    - cron: '0 6 * * *'
 
 # One run per branch — supersede stale runs when a PR gets new pushes.
 concurrency:
@@ -168,3 +175,97 @@ jobs:
             -e RETH_ORACLE_VOL="$ORACLE_VOL" \
             state-actor-reth go test -tags 'cgo_reth oracle' ./client/reth/ -run TestRethDbStats -v -timeout 15m
           docker volume rm -f "$ORACLE_VOL" >/dev/null 2>&1 || true
+
+  # ---------------------------------------------------------------------------
+  # Tier 2 — Real-node boot tests.
+  #
+  # Boot a real client binary against a state-actor-produced datadir and
+  # probe via JSON-RPC. This is the regression class that nerolation/
+  # state-actor#42 was — Tier-1 oracle tests caught snapshot-side
+  # encoding bugs but missed "datadir compiles, state RPCs return
+  # historical state … is not available".
+  #
+  # Gated to `schedule:` (nightly) + opt-in `full-ci` PR label only.
+  # Per-job cold runtime is in the 10-30 min range, too long to justify
+  # on every PR; the label gives risky-looking PRs an opt-in run.
+  # ---------------------------------------------------------------------------
+
+  geth-boot:
+    name: geth · real-node boot oracle
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-ci'))
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      # `make test-geth-boot` is just a `go test -tags oracle` invocation —
+      # no Make-side docker build prereq, no RocksDB, pure-Go state-actor.
+      # The test itself spawns ethereum/client-go via `docker run` (the
+      # daemon is pre-installed on ubuntu-latest).
+      - run: make test-geth-boot
+
+  geth-smoke:
+    name: geth · smoke (real geth + RPC probe)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-ci'))
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      # Dockerfile.geth is pure Go — no RocksDB build, ~2-3 min cold,
+      # <30s warm. Cache scope `geth` keeps this from interfering with
+      # other GHA cache scopes.
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.geth
+          tags: state-actor-geth:latest
+          load: true
+          cache-from: type=gha,scope=geth
+          cache-to: type=gha,scope=geth,mode=max
+      # validate-big-db-geth.sh uses curl + jq; not preinstalled on
+      # ubuntu-latest minimal images. (`curl` actually is, but `jq` isn't
+      # always — installing both is cheap.)
+      - run: sudo apt-get update && sudo apt-get install -y curl jq
+      # `make smoke-geth` re-runs `docker build -f Dockerfile.geth` via its
+      # docker-geth Make prereq, but with the local Docker layer cache
+      # warmed by the buildx --load above, the rebuild is ~10s (BuildKit
+      # reuses the loaded image's layers). Tolerable.
+      - run: make smoke-geth
+
+  reth-boot:
+    name: reth · real-node boot oracle (DinD)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-ci'))
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      # Same builder-stage build + cache as Tier-1's reth-cgo and
+      # reth-oracle (shared scope).
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.reth
+          target: builder
+          tags: state-actor-reth:latest
+          load: true
+          cache-from: type=gha,scope=reth-builder
+          cache-to: type=gha,scope=reth-builder,mode=max
+      # Inlined from `make test-reth-boot` minus the image-reth Make
+      # prereq (would re-build RocksDB; see file-level note above the
+      # Tier-1 reth-cgo job).
+      - run: |
+          BOOT_VOL=reth-boot-datadir
+          docker volume rm -f "$BOOT_VOL" >/dev/null 2>&1 || true
+          docker volume create "$BOOT_VOL"
+          docker run --rm \
+            -v "$BOOT_VOL":/oracle-data \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -e RETH_ORACLE_DATADIR=/oracle-data \
+            -e RETH_ORACLE_VOL="$BOOT_VOL" \
+            state-actor-reth go test -tags 'cgo_reth oracle' ./client/reth/ -run TestRethNodeBoot -v -timeout 30m
+          docker volume rm -f "$BOOT_VOL" >/dev/null 2>&1 || true

--- a/client/geth/node_boot_test.go
+++ b/client/geth/node_boot_test.go
@@ -171,9 +171,17 @@ func TestGethNodeBoot(t *testing.T) {
 	containerName := "state-actor-geth-boot-" + randSuffix(8)
 	hostPort := freeTCPPort(t)
 
+	// Run geth as the test process's UID/GID so any files it writes to
+	// the bind-mounted /data stay owned by the test user. Without this,
+	// on native Linux (e.g. GHA runners), geth's default-root container
+	// would write root-owned files into datadir, and t.TempDir's cleanup
+	// (running as the test user) would fail with "permission denied".
+	// Docker Desktop for Mac masks this via filesystem-layer UID mapping;
+	// the test still passed locally pre-fix.
 	runArgs := append([]string{"run", "-d"}, dockerPlatformArgs()...)
 	runArgs = append(runArgs,
 		"--name", containerName,
+		"--user", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
 		"-v", datadir+":/data",
 		"-p", fmt.Sprintf("127.0.0.1:%d:8545", hostPort),
 		gethImageRef(),


### PR DESCRIPTION
Builds on #46. Adds three real-node boot tests gated to `schedule:` (nightly UTC) + opt-in `full-ci` PR label.

Closes the gap left by Tier-1: oracle/cgo gates catch byte-level encoding drift, but they don't catch "the datadir compiles AND geth/reth boot AND state RPCs serve correct values" — exactly the bug class that produced #42.

## What's added

| Job | Target | What it gates |
|---|---|---|
| `geth-boot` | `make test-geth-boot` | Spawns `ethereum/client-go:v1.17.2` via `docker run`, probes EOA balances + contract code + storage slots via JSON-RPC. Pure-Go state-actor. |
| `geth-smoke` | `make smoke-geth` | Builds `Dockerfile.geth` (state-actor pure-Go image), generates a small DB, boots upstream geth, runs `validate-big-db-geth.sh` (curl + jq probes). |
| `reth-boot` | `make test-reth-boot` (inlined) | Boots `ghcr.io/cperezz/reth` via DinD, full RNG-replay assertion against EOA balances / contract code / storage slots. |

## Triggers

- `schedule:` `cron '0 6 * * *'` — nightly UTC. Regressions on `main` surface within 24h.
- `pull_request:` fires only when the PR carries the `full-ci` label. Added `labeled` / `unlabeled` to the PR event types so toggling the label re-evaluates the `if:` and starts/stops Tier-2 jobs.

Tier-1 jobs (default, reth-cgo, besu-oracle, neth-oracle, reth-oracle) are **unchanged** — they run on every PR + push as before.

## Caching

- `geth-smoke` uses cache scope `geth` (Dockerfile.geth is pure Go, no RocksDB — caching is an optimization, not a necessity).
- `reth-boot` shares scope `reth-builder` with the Tier-1 reth jobs. Warm-cache reth boot's image step goes from ~17 min to ~5 min.

## Why label-gated and not on every PR

Cold-cache `reth-boot` is ~30–45 min; warm-cache ~10–15 min. Even warm, adding ~10 min to every PR's CI is too much friction when Tier-1 already gates byte-level correctness. Nightly + `full-ci` label gives:

- Automatic regression detection on main within 24h.
- On-demand "exercise the full path" before merging risky PRs.

## How to validate this PR

I'll add the `full-ci` label after opening to trigger the three new jobs. Tier-1 jobs run unconditionally and should pass (they're unchanged from #46).

## Out of scope

- besu/nethermind real-node boot tests — both clients only have differential-oracle tests today (Tier-1). Adding boot tests mirrors the geth/reth pattern using `internal/rpcprobe`; separate PR.

Validated: `actionlint .github/workflows/ci.yml` — clean.