### PR TITLE
ci: drop geth-smoke from Tier-2 (big-db is local-only, redundant with test-geth-boot)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ name: CI
 
 on:
   pull_request:
-    # The Tier-2 jobs (geth-boot, geth-smoke, reth-boot) only fire when a
-    # PR carries the `full-ci` label. Tier-1 jobs run on every PR.
+    # The Tier-2 jobs (geth-boot, reth-boot) only fire when a PR carries
+    # the `full-ci` label. Tier-1 jobs run on every PR.
     types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     # No branch filter: triggers on every push.
@@ -206,35 +206,6 @@ jobs:
       # The test itself spawns ethereum/client-go via `docker run` (the
       # daemon is pre-installed on ubuntu-latest).
       - run: make test-geth-boot
-
-  geth-smoke:
-    name: geth · smoke (real geth + RPC probe)
-    runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-ci'))
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      # Dockerfile.geth is pure Go — no RocksDB build, ~2-3 min cold,
-      # <30s warm. Cache scope `geth` keeps this from interfering with
-      # other GHA cache scopes.
-      - uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: Dockerfile.geth
-          tags: state-actor-geth:latest
-          load: true
-          cache-from: type=gha,scope=geth
-          cache-to: type=gha,scope=geth,mode=max
-      # validate-big-db-geth.sh uses curl + jq; not preinstalled on
-      # ubuntu-latest minimal images. (`curl` actually is, but `jq` isn't
-      # always — installing both is cheap.)
-      - run: sudo apt-get update && sudo apt-get install -y curl jq
-      # `make smoke-geth` re-runs `docker build -f Dockerfile.geth` via its
-      # docker-geth Make prereq, but with the local Docker layer cache
-      # warmed by the buildx --load above, the rebuild is ~10s (BuildKit
-      # reuses the loaded image's layers). Tolerable.
-      - run: make smoke-geth
 
   reth-boot:
     name: reth · real-node boot oracle (DinD)


### PR DESCRIPTION
Per the user's call-out: big-db smoke (1000 accounts + validate-big-db-geth.sh tx round-trips) belongs locally, not in CI. `test-geth-boot` already gates the same regression class (datadir bootable + state-RPCs serve correct values) deterministically with 10 EOAs + 3 contracts, in <30s warm cache.

## What this drops

The `geth-smoke` Tier-2 job. The Makefile target `smoke-geth` is unchanged — local exploratory use is still supported.

## What's still gated in Tier-2

- `geth-boot` — real `ethereum/client-go` + JSON-RPC probe of every synthetic EOA balance / contract code / storage slot
- `reth-boot` — real `ghcr.io/cperezz/reth` + JSON-RPC probe (same shape)

Both keep the schedule + `full-ci` label trigger.

## Follow-ups (separate PRs)

- **PR-B** — Add `client/besu/node_boot_test.go` + `client/nethermind/node_boot_test.go` mirroring the geth/reth pattern (using `internal/rpcprobe`); restructure Tier-2 as a per-client matrix `boot.matrix.client = [besu, geth, nethermind, reth]`. Closes the "boot is only 2 clients" gap.
- **PR-C** — Spamoor-based bloat + RPC progression matrix for all 4 clients. Requires installing spamoor in CI and unhardcoding `Makefile:178`'s `SPAMOOR ?= /Users/.../spamoor/bin/spamoor`. Adds the missing `smoke-{geth,reth}-spamoor` Makefile targets.

## Validation

- [x] `actionlint .github/workflows/ci.yml` — clean
- [ ] CI on this PR exercises the remaining Tier-1 + Tier-2 jobs as before