### PR TITLE
ci: symmetric boot matrix for all 4 clients (besu, geth, nethermind, reth)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ name: CI
 
 on:
   pull_request:
-    # The Tier-2 jobs (geth-boot, reth-boot) only fire when a PR carries
-    # the `full-ci` label. Tier-1 jobs run on every PR.
+    # The Tier-2 boot matrix (besu, geth, nethermind, reth) only fires
+    # when a PR carries the `full-ci` label. Tier-1 jobs run on every PR.
     types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     # No branch filter: triggers on every push.
@@ -190,34 +190,62 @@ jobs:
   # on every PR; the label gives risky-looking PRs an opt-in run.
   # ---------------------------------------------------------------------------
 
-  geth-boot:
-    name: geth · real-node boot oracle
-    runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-ci'))
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-          cache: true
-      # `make test-geth-boot` is just a `go test -tags oracle` invocation —
-      # no Make-side docker build prereq, no RocksDB, pure-Go state-actor.
-      # The test itself spawns ethereum/client-go via `docker run` (the
-      # daemon is pre-installed on ubuntu-latest).
-      - run: make test-geth-boot
-
-  reth-boot:
-    name: reth · real-node boot oracle (DinD)
+  # Matrix: one job per client, all 4 boot tests run in parallel. Failures
+  # are independent (`fail-fast: false`) so e.g. a flaky reth doesn't mask
+  # a real besu regression. Each job builds its client's cgo builder image
+  # (where applicable — geth is pure Go) with a per-client GHA cache scope.
+  boot:
+    name: ${{ matrix.client }} · real-node boot oracle
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-ci'))
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        client: [besu, geth, nethermind, reth]
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      # Same builder-stage build + cache as Tier-1's reth-cgo and
-      # reth-oracle (shared scope).
-      - uses: docker/build-push-action@v5
+
+      # geth path is pure Go — uses `actions/setup-go` and runs the test
+      # directly on the runner. The test itself spawns
+      # ethereum/client-go:v1.17.2 via `docker run`.
+      - if: matrix.client == 'geth'
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # Non-geth paths need cgo (librocksdb / libmdbx). We build the
+      # client's `builder`-stage Docker image (which has the toolchain +
+      # cgo deps + state-actor source compiled with the right tag), then
+      # run the boot test inside that image via DinD.
+      - if: matrix.client != 'geth'
+        uses: docker/setup-buildx-action@v3
+
+      - if: matrix.client == 'besu'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.besu
+          target: builder
+          tags: state-actor-besu-builder:latest
+          load: true
+          cache-from: type=gha,scope=besu-builder
+          cache-to: type=gha,scope=besu-builder,mode=max
+
+      - if: matrix.client == 'nethermind'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.nethermind
+          target: builder
+          tags: state-actor-nethermind-builder:latest
+          load: true
+          cache-from: type=gha,scope=neth-builder
+          cache-to: type=gha,scope=neth-builder,mode=max
+
+      - if: matrix.client == 'reth'
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile.reth
@@ -226,10 +254,43 @@ jobs:
           load: true
           cache-from: type=gha,scope=reth-builder
           cache-to: type=gha,scope=reth-builder,mode=max
-      # Inlined from `make test-reth-boot` minus the image-reth Make
-      # prereq (would re-build RocksDB; see file-level note above the
-      # Tier-1 reth-cgo job).
-      - run: |
+
+      # Per-client test invocation. Inlined from each Make target's body
+      # (minus the docker-build prereq that would force a redundant
+      # RocksDB rebuild on cgo paths — same fix as Tier-1's job inlining).
+      - if: matrix.client == 'geth'
+        run: make test-geth-boot
+
+      - if: matrix.client == 'besu'
+        run: |
+          BOOT_VOL=besu-boot-datadir
+          docker volume rm -f "$BOOT_VOL" >/dev/null 2>&1 || true
+          docker volume create "$BOOT_VOL"
+          docker run --rm \
+            -v "$BOOT_VOL":/oracle-data \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -e BESU_ORACLE_DATADIR=/oracle-data \
+            -e BESU_ORACLE_VOL="$BOOT_VOL" \
+            --entrypoint bash state-actor-besu-builder:latest \
+            -c 'cd /app && go test -tags '"'"'cgo_besu oracle'"'"' ./client/besu/ -run TestBesuNodeBoot -v -timeout 30m'
+          docker volume rm -f "$BOOT_VOL" >/dev/null 2>&1 || true
+
+      - if: matrix.client == 'nethermind'
+        run: |
+          BOOT_VOL=neth-boot-datadir
+          docker volume rm -f "$BOOT_VOL" >/dev/null 2>&1 || true
+          docker volume create "$BOOT_VOL"
+          docker run --rm \
+            -v "$BOOT_VOL":/oracle-data \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -e NETH_ORACLE_DATADIR=/oracle-data \
+            -e NETH_ORACLE_VOL="$BOOT_VOL" \
+            --entrypoint bash state-actor-nethermind-builder:latest \
+            -c 'cd /app && go test -tags '"'"'cgo_neth oracle'"'"' ./client/nethermind/ -run TestNethermindNodeBoot -v -timeout 30m'
+          docker volume rm -f "$BOOT_VOL" >/dev/null 2>&1 || true
+
+      - if: matrix.client == 'reth'
+        run: |
           BOOT_VOL=reth-boot-datadir
           docker volume rm -f "$BOOT_VOL" >/dev/null 2>&1 || true
           docker volume create "$BOOT_VOL"

--- a/Dockerfile.besu
+++ b/Dockerfile.besu
@@ -56,6 +56,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libzstd-dev \
     libbz2-dev \
     zlib1g-dev \
+    gnupg \
+    # docker-ce-cli is needed by `make test-besu-boot` — the boot test
+    # runs inside this builder image and spawns hyperledger/besu via DinD
+    # (host docker socket mount). Without the docker CLI in PATH the
+    # test fails at exec.Command("docker", …). Same setup as
+    # Dockerfile.reth (the Docker apt repo's bookworm stable channel).
+    && install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg \
+       | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+    && chmod a+r /etc/apt/keyrings/docker.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+       https://download.docker.com/linux/debian bookworm stable" \
+       > /etc/apt/sources.list.d/docker.list \
+    && apt-get update && apt-get install -y --no-install-recommends docker-ce-cli \
     && rm -rf /var/lib/apt/lists/*
 
 # Build RocksDB from source. -j2 keeps peak memory under ~4GB; rocksdb's

--- a/Dockerfile.nethermind
+++ b/Dockerfile.nethermind
@@ -37,6 +37,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libzstd-dev \
     libbz2-dev \
     zlib1g-dev \
+    gnupg \
+    # docker-ce-cli is needed by `make test-nethermind-boot` — the boot
+    # test runs inside this builder image and spawns
+    # nethermind/nethermind via DinD (host docker socket mount). Without
+    # the docker CLI in PATH the test fails at
+    # exec.Command("docker", …). Same setup as Dockerfile.reth.
+    && install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg \
+       | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+    && chmod a+r /etc/apt/keyrings/docker.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+       https://download.docker.com/linux/debian bookworm stable" \
+       > /etc/apt/sources.list.d/docker.list \
+    && apt-get update && apt-get install -y --no-install-recommends docker-ce-cli \
     && rm -rf /var/lib/apt/lists/*
 
 # Build RocksDB from source. -j2 keeps peak memory under ~4GB; rocksdb's

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: all build test clean docker install lint fmt help \
 	image-reth test-reth-cgo test-reth-oracle test-reth-boot \
-	docker-nethermind docker-nethermind-test test-nethermind-oracle \
+	docker-nethermind docker-nethermind-test test-nethermind-oracle test-nethermind-boot \
 	smoke-nethermind smoke-nethermind-spamoor \
-	docker-besu docker-besu-test test-besu-oracle \
+	docker-besu docker-besu-test test-besu-oracle test-besu-boot \
 	smoke-besu smoke-besu-spamoor \
 	docker-geth smoke-geth test-geth-boot
 
@@ -87,6 +87,27 @@ test-nethermind-oracle: docker-nethermind-test
 	docker run --rm --entrypoint bash state-actor-nethermind-builder:latest \
 	  -c 'cd /app && go test -tags cgo_neth -run TestDifferentialOracle -v ./client/nethermind/...'
 
+## test-nethermind-boot: Boot upstream Nethermind against a state-actor datadir and verify via JSON-RPC.
+##   Mirrors test-reth-boot: builds the cgo_neth builder image (which has
+##   librocksdb + the Go toolchain), runs the `cgo_neth oracle`-tagged
+##   boot test inside it via DinD, which then spawns
+##   nethermind/nethermind:1.37.0 against state-actor's RocksDB datadir
+##   and probes EOA balances / contract code / storage slots via
+##   internal/rpcprobe.
+NETH_BOOT_VOL ?= neth-boot-datadir
+test-nethermind-boot: docker-nethermind-test
+	docker volume rm -f $(NETH_BOOT_VOL) >/dev/null 2>&1 || true
+	docker volume create $(NETH_BOOT_VOL)
+	docker run --rm \
+	  -v $(NETH_BOOT_VOL):/oracle-data \
+	  -v /var/run/docker.sock:/var/run/docker.sock \
+	  -e NETH_ORACLE_DATADIR=/oracle-data \
+	  -e NETH_ORACLE_VOL=$(NETH_BOOT_VOL) \
+	  -e NETH_DOCKER_PLATFORM \
+	  --entrypoint bash state-actor-nethermind-builder:latest \
+	  -c 'cd /app && go test -tags '\''cgo_neth oracle'\'' ./client/nethermind/ -run TestNethermindNodeBoot -v -timeout 1800s'
+	docker volume rm -f $(NETH_BOOT_VOL) >/dev/null 2>&1 || true
+
 ## smoke-nethermind: End-to-end smoke — generate a small DB, boot Nethermind 1.37.0, send 100 dev-mode txs
 ##   Usage: make smoke-nethermind ACCOUNTS=1000 CONTRACTS=100
 ACCOUNTS ?= 1000
@@ -156,6 +177,27 @@ docker-besu-test:
 test-besu-oracle: docker-besu-test
 	docker run --rm --entrypoint bash state-actor-besu-builder:latest \
 	  -c 'cd /app && go test -tags cgo_besu -run TestDifferentialOracle -v ./client/besu/...'
+
+## test-besu-boot: Boot upstream Besu against a state-actor datadir and verify via JSON-RPC.
+##   Mirrors test-reth-boot: builds the cgo_besu builder image (which has
+##   librocksdb + the Go toolchain), runs the `cgo_besu oracle`-tagged
+##   boot test inside it via DinD, which then spawns
+##   hyperledger/besu:25.11.0 against state-actor's BONSAI datadir and
+##   probes EOA balances / contract code / storage slots via
+##   internal/rpcprobe.
+BESU_BOOT_VOL ?= besu-boot-datadir
+test-besu-boot: docker-besu-test
+	docker volume rm -f $(BESU_BOOT_VOL) >/dev/null 2>&1 || true
+	docker volume create $(BESU_BOOT_VOL)
+	docker run --rm \
+	  -v $(BESU_BOOT_VOL):/oracle-data \
+	  -v /var/run/docker.sock:/var/run/docker.sock \
+	  -e BESU_ORACLE_DATADIR=/oracle-data \
+	  -e BESU_ORACLE_VOL=$(BESU_BOOT_VOL) \
+	  -e BESU_DOCKER_PLATFORM \
+	  --entrypoint bash state-actor-besu-builder:latest \
+	  -c 'cd /app && go test -tags '\''cgo_besu oracle'\'' ./client/besu/ -run TestBesuNodeBoot -v -timeout 1800s'
+	docker volume rm -f $(BESU_BOOT_VOL) >/dev/null 2>&1 || true
 
 ## smoke-besu: End-to-end smoke — generate a small DB, boot hyperledger/besu:25.11.0, send 100 dev-mode txs
 ##   Usage: make smoke-besu ACCOUNTS=1000 CONTRACTS=100

--- a/client/besu/chainspec.go
+++ b/client/besu/chainspec.go
@@ -28,6 +28,14 @@ const ChainSpecFileName = "besu-chainspec.json"
 //   - alloc: always {} — state-actor writes the state directly to RocksDB
 //     and the smoke scripts pass `--genesis-state-hash-cache-enabled` so
 //     Besu trusts the DB-resident state instead of recomputing from alloc.
+//
+// CRITICAL: every field written here must match what
+// genesis_cgo.buildGenesisHeader encodes into the DB. Besu's cached path
+// (BesuControllerBuilder.getGenesisState → GenesisState.fromStorage)
+// rebuilds the genesis header from chainspec + cached stateRoot, then
+// compares its hash against VARIABLES["chainHeadHash"]. Any field
+// divergence produces "Supplied genesis block does not match chain data
+// stored" at boot.
 func writeChainSpec(dbPath string, g *genesis.Genesis) (string, error) {
 	if g == nil {
 		return "", fmt.Errorf("besu writeChainSpec: nil genesis")
@@ -48,6 +56,14 @@ func writeChainSpec(dbPath string, g *genesis.Genesis) (string, error) {
 	if g.BaseFee != nil {
 		baseFeeHex = (*g.BaseFee).String()
 	}
+	// Difficulty MUST match what besuGenesisFromConfig flows into the
+	// stored header (run_cgo.go:111-114 → diff = g.Difficulty.ToInt()).
+	// BuildSynthetic emits Difficulty=0; older hand-written genesis JSONs
+	// used 0x10000. Either is OK as long as both sides agree.
+	diffHex := "0x0"
+	if g.Difficulty != nil {
+		diffHex = fmt.Sprintf("0x%x", g.Difficulty.ToInt())
+	}
 
 	cfg := map[string]any{
 		"chainId":           chainID,
@@ -63,7 +79,7 @@ func writeChainSpec(dbPath string, g *genesis.Genesis) (string, error) {
 		"timestamp":  fmt.Sprintf("0x%x", uint64(g.Timestamp)),
 		"extraData":  extraDataHex,
 		"gasLimit":   fmt.Sprintf("0x%x", gasLimit),
-		"difficulty": "0x10000", // matches besu testdata; ethash.fixeddifficulty actually controls
+		"difficulty": diffHex,
 		"mixHash":    "0x0000000000000000000000000000000000000000000000000000000000000000",
 		"coinbase":   "0x0000000000000000000000000000000000000000",
 		"alloc":      map[string]any{},

--- a/client/besu/node_boot_test.go
+++ b/client/besu/node_boot_test.go
@@ -1,0 +1,293 @@
+//go:build cgo_besu && oracle
+
+package besu
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/big"
+	mrand "math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	stategenesis "github.com/nerolation/state-actor/genesis"
+	"github.com/nerolation/state-actor/generator"
+	"github.com/nerolation/state-actor/internal/entitygen"
+	"github.com/nerolation/state-actor/internal/rpcprobe"
+)
+
+// pinnedBesuImage is the upstream Besu Docker tag the boot test pins
+// against. Override with BESU_IMAGE=hyperledger/besu:vX.Y.Z to test a
+// pre-release version. Matches the default in
+// client/besu/testdata/validate-big-db-besu.sh so smoke + oracle tests
+// exercise the same release.
+const pinnedBesuImage = "hyperledger/besu:25.11.0"
+
+func besuImageRef() string {
+	if v := os.Getenv("BESU_IMAGE"); v != "" {
+		return v
+	}
+	return pinnedBesuImage
+}
+
+// dockerPlatformArgs returns ["--platform", $BESU_DOCKER_PLATFORM] when the
+// env var is set, otherwise nil. Mirrors the reth + geth platform-override
+// pattern (see nerolation/state-actor#43).
+func dockerPlatformArgs() []string {
+	if v := os.Getenv("BESU_DOCKER_PLATFORM"); v != "" {
+		return []string{"--platform", v}
+	}
+	return nil
+}
+
+// randSuffix returns a random lower-hex suffix of length n for unique
+// container names.
+func randSuffix(n int) string {
+	const chars = "abcdef0123456789"
+	r := mrand.New(mrand.NewSource(time.Now().UnixNano()))
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = chars[r.Intn(len(chars))]
+	}
+	return string(b)
+}
+
+// safePrefix returns the first n bytes of b, or all of b if len(b) < n.
+func safePrefix(b []byte, n int) []byte {
+	if len(b) <= n {
+		return b
+	}
+	return b[:n]
+}
+
+// inspectContainerIP returns the bridge-network IP of a running container.
+// In DinD mode (test runs inside a container with /var/run/docker.sock
+// mounted) the spawned besu container's host-port mapping is on the Docker
+// host VM, not on the test container's network — but both containers share
+// the Docker daemon's default bridge network, so they can reach each other
+// by bridge IP.
+func inspectContainerIP(containerName string) (string, error) {
+	out, err := exec.Command("docker", "inspect",
+		"--format", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}",
+		containerName,
+	).Output()
+	if err != nil {
+		return "", fmt.Errorf("docker inspect %s: %w", containerName, err)
+	}
+	ip := strings.TrimSpace(string(out))
+	if ip == "" {
+		return "", fmt.Errorf("container %s has no bridge IP (not yet started?)", containerName)
+	}
+	return ip, nil
+}
+
+// oracleDatadir holds paths for an oracle test's datadir. Mirrors the
+// reth-side struct in client/reth/oracle_test.go.
+type oracleDatadir struct {
+	hostPath         string
+	volMount         string
+	containerDatadir string
+}
+
+// acquireOracleDatadir returns an oracleDatadir for the calling test and a
+// cleanup function. Honours BESU_ORACLE_DATADIR / BESU_ORACLE_VOL env vars
+// that `make test-besu-boot` injects when running inside Docker (DinD via
+// socket mount). Falls back to t.TempDir() for direct host runs.
+func acquireOracleDatadir(t *testing.T) (oracleDatadir, func()) {
+	t.Helper()
+	baseDir := os.Getenv("BESU_ORACLE_DATADIR")
+	if baseDir == "" {
+		datadir := t.TempDir()
+		return oracleDatadir{
+			hostPath:         datadir,
+			volMount:         datadir + ":/data",
+			containerDatadir: "/data",
+		}, func() {}
+	}
+	subName := strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())
+	hostPath := baseDir + "/" + subName
+	if err := os.MkdirAll(hostPath, 0o755); err != nil {
+		t.Fatalf("acquireOracleDatadir: mkdir %s: %v", hostPath, err)
+	}
+	t.Logf("using datadir=%s", hostPath)
+
+	vol := os.Getenv("BESU_ORACLE_VOL")
+	volMount := hostPath + ":/data"
+	containerDatadir := "/data"
+	if vol != "" {
+		volMount = vol + ":/data"
+		containerDatadir = "/data/" + subName
+	}
+	return oracleDatadir{
+		hostPath:         hostPath,
+		volMount:         volMount,
+		containerDatadir: containerDatadir,
+	}, func() {}
+}
+
+// TestBesuNodeBoot generates a small state-actor datadir (10 EOAs +
+// 3 contracts) via Run, boots upstream hyperledger/besu against it, and
+// probes via JSON-RPC to confirm:
+//
+//   - eth_getBalance matches every EOA's generated balance
+//   - eth_getCode matches every contract's bytecode
+//   - eth_getStorageAt matches every contract's storage slots
+//
+// Uses the same canonical RNG draw order (entitygen.GenerateContractRoll)
+// the writer uses, so the reproduced contracts match the persisted ones.
+//
+// Build-tagged `cgo_besu && oracle`. Run via `make test-besu-boot`; not
+// included in plain `go test`.
+func TestBesuNodeBoot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle boot test skipped in short mode")
+	}
+
+	const (
+		seed         = int64(42)
+		numAccounts  = 10
+		numContracts = 3
+		codeSize     = 256
+		minSlots     = 2
+		maxSlots     = 2
+	)
+
+	// Pin --fork=shanghai. state-actor's BuildSynthetic does not emit a
+	// BlobSchedule, which Besu requires once Cancun or Prague are active
+	// at the genesis chain config. Shanghai is besu's writer ceiling
+	// today (genesis.MaxForkForClient("besu") == "shanghai").
+	g, err := stategenesis.BuildSynthetic("shanghai", big.NewInt(1337), 30_000_000, 0, nil)
+	if err != nil {
+		t.Fatalf("BuildSynthetic: %v", err)
+	}
+
+	dd, cleanup := acquireOracleDatadir(t)
+	defer cleanup()
+
+	cfg := generator.Config{
+		DBPath:       dd.hostPath,
+		NumAccounts:  numAccounts,
+		NumContracts: numContracts,
+		CodeSize:     codeSize,
+		MinSlots:     minSlots,
+		MaxSlots:     maxSlots,
+		Seed:         seed,
+		BatchSize:    1000,
+		Workers:      1,
+		TrieMode:     generator.TrieModeMPT,
+		Genesis:      g,
+	}
+
+	if _, err := Run(context.Background(), cfg, Options{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Reproduce the RNG sequence state-actor's besu Phase 1 used so we
+	// know the expected balances/code/storage. Goes through
+	// entitygen.GenerateContractRoll — same canonical draw order
+	// (slot-count then contract) the writer uses.
+	rng := mrand.New(mrand.NewSource(seed))
+	eoas := make([]*entitygen.Account, numAccounts)
+	for i := 0; i < numAccounts; i++ {
+		eoas[i] = entitygen.GenerateEOA(rng)
+	}
+	contracts := make([]*entitygen.Account, numContracts)
+	for i := 0; i < numContracts; i++ {
+		contracts[i] = entitygen.GenerateContractRoll(rng, cfg.Distribution, codeSize, minSlots, maxSlots)
+	}
+
+	// Boot upstream Besu. --genesis-state-hash-cache-enabled tells Besu to
+	// trust the stored stateRoot rather than recompute it from the small
+	// genesis JSON's alloc — necessary because state-actor writes
+	// synthetic state separately from what the chainspec's alloc would
+	// produce. Same pattern validate-big-db-besu.sh uses.
+	imageRef := besuImageRef()
+	containerName := "state-actor-besu-boot-" + randSuffix(8)
+	chainspecPath := dd.containerDatadir + "/" + ChainSpecFileName
+	runArgs := append([]string{"run", "-d"}, dockerPlatformArgs()...)
+	runArgs = append(runArgs,
+		"--name", containerName,
+		"-v", dd.volMount,
+		imageRef,
+		"--data-path", dd.containerDatadir,
+		"--genesis-file", chainspecPath,
+		"--network-id", "1337",
+		"--data-storage-format", "BONSAI",
+		"--genesis-state-hash-cache-enabled",
+		"--rpc-http-enabled",
+		"--rpc-http-host", "0.0.0.0",
+		"--rpc-http-port", "8545",
+		"--rpc-http-api", "ETH,NET,WEB3",
+		"--rpc-http-cors-origins", "*",
+		"--host-allowlist", "*",
+		"--logging", "INFO",
+	)
+	runOut, err := exec.Command("docker", runArgs...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("docker run: %s\n%v", runOut, err)
+	}
+	t.Logf("besu container started: %s", strings.TrimSpace(string(runOut)))
+
+	t.Cleanup(func() {
+		logs, _ := exec.Command("docker", "logs", containerName).CombinedOutput()
+		t.Logf("besu container logs:\n%s", logs)
+		exec.Command("docker", "stop", containerName).Run()    //nolint:errcheck
+		exec.Command("docker", "rm", "-f", containerName).Run() //nolint:errcheck
+	})
+
+	containerIP, err := inspectContainerIP(containerName)
+	if err != nil {
+		logs, _ := exec.Command("docker", "logs", containerName).CombinedOutput()
+		t.Fatalf("inspectContainerIP: %v\nbesu logs:\n%s", err, logs)
+	}
+	rpcURL := "http://" + containerIP + ":8545"
+	t.Logf("besu JSON-RPC: %s", rpcURL)
+
+	// Besu's JVM startup is slower than geth's Go startup — give it 180s.
+	if err := rpcprobe.WaitForRPC(rpcURL, 180*time.Second); err != nil {
+		t.Fatalf("RPC never came up (logs captured in t.Cleanup):\nerr: %v", err)
+	}
+
+	// ---- EOA assertions ----
+	for _, eoa := range eoas {
+		got, err := rpcprobe.EthGetBalance(rpcURL, eoa.Address, "latest")
+		if err != nil {
+			t.Errorf("eth_getBalance %s: %v", eoa.Address.Hex(), err)
+			continue
+		}
+		want := eoa.StateAccount.Balance.ToBig()
+		if got.Cmp(want) != 0 {
+			t.Errorf("eth_getBalance %s: got %s want %s",
+				eoa.Address.Hex(), got.String(), want.String())
+		}
+	}
+
+	// ---- contract assertions ----
+	for _, c := range contracts {
+		gotCode, err := rpcprobe.EthGetCode(rpcURL, c.Address, "latest")
+		if err != nil {
+			t.Errorf("eth_getCode %s: %v", c.Address.Hex(), err)
+		} else if !bytes.Equal(gotCode, c.Code) {
+			t.Errorf("eth_getCode %s: len got=%d want=%d (first 32 bytes: got=%x want=%x)",
+				c.Address.Hex(), len(gotCode), len(c.Code),
+				safePrefix(gotCode, 32), safePrefix(c.Code, 32))
+		}
+
+		for _, slot := range c.Storage {
+			got, err := rpcprobe.EthGetStorageAt(rpcURL, c.Address, slot.Key, "latest")
+			if err != nil {
+				t.Errorf("eth_getStorageAt %s slot %s: %v",
+					c.Address.Hex(), slot.Key.Hex(), err)
+				continue
+			}
+			if got != slot.Value {
+				t.Errorf("eth_getStorageAt %s slot %s: got %s want %s",
+					c.Address.Hex(), slot.Key.Hex(), got.Hex(), slot.Value.Hex())
+			}
+		}
+	}
+}

--- a/client/besu/node_boot_test.go
+++ b/client/besu/node_boot_test.go
@@ -222,8 +222,17 @@ func TestBesuNodeBoot(t *testing.T) {
 		"--rpc-http-host", "0.0.0.0",
 		"--rpc-http-port", "8545",
 		"--rpc-http-api", "ETH,NET,WEB3",
-		"--rpc-http-cors-origins", "*",
-		"--host-allowlist", "*",
+		// `--host-allowlist=all` literally accepts any Host: header. We
+		// don't pass `*` because the besu Docker image's entrypoint script
+		// expands unquoted `$@`, which globs `*` against /opt/besu's
+		// directory contents (README.md, bin, lib, …) — first run failed
+		// with "Unmatched arguments from index 18: 'README.md', …". `all`
+		// has no glob characters so it survives intact. Per besu docs
+		// (`--host-allowlist=...`), "all" and "*" are equivalent literals.
+		"--host-allowlist", "all",
+		// CORS not needed for our localhost RPC probes; omitting the
+		// `--rpc-http-cors-origins` flag avoids another `*` that would
+		// be shell-globbed in the entrypoint.
 		"--logging", "INFO",
 	)
 	runOut, err := exec.Command("docker", runArgs...).CombinedOutput()

--- a/client/besu/node_boot_test.go
+++ b/client/besu/node_boot_test.go
@@ -230,9 +230,17 @@ func TestBesuNodeBoot(t *testing.T) {
 		// has no glob characters so it survives intact. Per besu docs
 		// (`--host-allowlist=...`), "all" and "*" are equivalent literals.
 		"--host-allowlist", "all",
-		// CORS not needed for our localhost RPC probes; omitting the
-		// `--rpc-http-cors-origins` flag avoids another `*` that would
-		// be shell-globbed in the entrypoint.
+		// Miner / dev-mode flags. Required for besu 25.11.0 to accept a
+		// chainspec with ethash.fixeddifficulty (state-actor's
+		// chainspec.go writes that stanza to enable
+		// post-london-no-CL block production). Without --miner-enabled +
+		// --miner-coinbase, besu rejects the chainspec at the
+		// "Supplied genesis block does not match chain data stored"
+		// check even with --genesis-state-hash-cache-enabled. Same flag
+		// set client/besu/testdata/validate-big-db-besu.sh uses.
+		"--min-gas-price", "0",
+		"--miner-enabled",
+		"--miner-coinbase", "0x0000000000000000000000000000000000000000",
 		"--logging", "INFO",
 	)
 	runOut, err := exec.Command("docker", runArgs...).CombinedOutput()

--- a/client/besu/state_writer_cgo.go
+++ b/client/besu/state_writer_cgo.go
@@ -227,19 +227,28 @@ func writeStateAndCollectRoot(
 					return kvs[i].slotHash.Big().Cmp(kvs[j].slotHash.Big()) < 0
 				})
 				for _, e := range kvs {
-					valueRLP := besurlp.EncodeStorageValue(e.value)
-					if err := sb.AddSlot(e.slotHash, valueRLP); err != nil {
+					// Trie and flat-db use DIFFERENT encodings for the same
+					// slot value (BonsaiWorldState.java:182-183):
+					//   trie  → encodeTrieValue = RLP(trim(value))    (≤33 bytes)
+					//   flat  → raw trim(value)                       (≤32 bytes)
+					// Flat-db reads go through UInt256.fromBytes which
+					// rejects > 32 bytes, so writing the RLP-wrapped form
+					// to flat fatals at first eth_getStorageAt:
+					//   "Expected at most 32 bytes but got 33"
+					valueTrieRLP := besurlp.EncodeStorageValue(e.value)
+					valueFlat := besurlp.TrimStorageValue(e.value)
+					if err := sb.AddSlot(e.slotHash, valueTrieRLP); err != nil {
 						iter.Close()
 						pdb.Close()
 						return common.Hash{}, nil, nil, err
 					}
-					if err := sink.PutFlatStorage(addrHash, e.slotHash, valueRLP); err != nil {
+					if err := sink.PutFlatStorage(addrHash, e.slotHash, valueFlat); err != nil {
 						iter.Close()
 						pdb.Close()
 						return common.Hash{}, nil, nil, err
 					}
 					stats.StorageSlotsCreated++
-					stats.StorageBytes += uint64(64 + len(valueRLP))
+					stats.StorageBytes += uint64(64 + len(valueTrieRLP) + len(valueFlat))
 				}
 				root, err := sb.Commit()
 				if err != nil {

--- a/client/nethermind/node_boot_test.go
+++ b/client/nethermind/node_boot_test.go
@@ -125,19 +125,24 @@ func acquireOracleDatadir(t *testing.T) (oracleDatadir, func()) {
 	}, func() {}
 }
 
-// nethermindBootConfig is the minimal Nethermind config for booting in
-// passive read-only mode against a state-actor datadir. Mirrors
+// nethermindBootConfigTemplate is the minimal Nethermind config for booting
+// in passive read-only mode against a state-actor datadir. Mirrors
 // client/nethermind/testdata/configs/sa-dev-v2.json but inlined here so the
-// test is self-contained — the test writes this to <datadir>/boot.cfg and
-// passes --config=/data/boot.cfg, avoiding the need to bind-mount the
-// state-actor source tree (which is a DinD path-translation hazard).
-const nethermindBootConfig = `{
+// test is self-contained — written into the datadir at runtime with the
+// chainspec / DB paths plugged in, so DinD mode (where the test container
+// places state-actor data at /data/<testName>/) and direct mode (/data)
+// both resolve correctly.
+//
+// Two %s placeholders, in order:
+//   1. ChainSpecPath  — full path to state-actor's parity-chainspec.json
+//   2. BaseDbPath     — full path to the per-test datadir
+const nethermindBootConfigTemplate = `{
   "Init": {
     "EnableUnsecuredDevWallet": false,
     "DiscoveryEnabled": false,
     "PeerManagerEnabled": false,
-    "ChainSpecPath": "/data/parity-chainspec.json",
-    "BaseDbPath": "/data",
+    "ChainSpecPath": "%s",
+    "BaseDbPath": "%s",
     "MemoryHint": 256000000
   },
   "Sync": {
@@ -208,10 +213,17 @@ func TestNethermindNodeBoot(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	// Write the minimal nethermind config into the datadir so we don't
-	// need a separate bind-mount for the source-tree config.
+	// Write the minimal nethermind config into the datadir, with paths
+	// resolved against the *container-side* layout (dd.containerDatadir),
+	// not the host-side path. In DinD mode they differ — the test
+	// container's filesystem and the spawned nethermind container's
+	// filesystem only share the named volume, mounted at /data on each;
+	// the per-test sub-directory is /data/<testName>.
 	cfgPath := filepath.Join(dd.hostPath, "boot.cfg")
-	if err := os.WriteFile(cfgPath, []byte(nethermindBootConfig), 0o644); err != nil {
+	chainSpecPath := dd.containerDatadir + "/" + ChainSpecFileName
+	baseDbPath := dd.containerDatadir
+	cfgContent := fmt.Sprintf(nethermindBootConfigTemplate, chainSpecPath, baseDbPath)
+	if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o644); err != nil {
 		t.Fatalf("write boot.cfg: %v", err)
 	}
 

--- a/client/nethermind/node_boot_test.go
+++ b/client/nethermind/node_boot_test.go
@@ -1,0 +1,304 @@
+//go:build cgo_neth && oracle
+
+package nethermind
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/big"
+	mrand "math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	stategenesis "github.com/nerolation/state-actor/genesis"
+	"github.com/nerolation/state-actor/generator"
+	"github.com/nerolation/state-actor/internal/entitygen"
+	"github.com/nerolation/state-actor/internal/rpcprobe"
+)
+
+// pinnedNethImage is the upstream Nethermind Docker tag the boot test pins
+// against. Override with NETH_IMAGE=nethermind/nethermind:vX.Y.Z to test a
+// pre-release version. Matches the default in
+// client/nethermind/testdata/validate-big-db.sh.
+const pinnedNethImage = "nethermind/nethermind:1.37.0"
+
+func nethImageRef() string {
+	if v := os.Getenv("NETH_IMAGE"); v != "" {
+		return v
+	}
+	return pinnedNethImage
+}
+
+// dockerPlatformArgs returns ["--platform", $NETH_DOCKER_PLATFORM] when the
+// env var is set, otherwise nil. Mirrors reth + besu + geth platform-override
+// pattern (see nerolation/state-actor#43).
+func dockerPlatformArgs() []string {
+	if v := os.Getenv("NETH_DOCKER_PLATFORM"); v != "" {
+		return []string{"--platform", v}
+	}
+	return nil
+}
+
+// randSuffix returns a random lower-hex suffix of length n for unique
+// container names.
+func randSuffix(n int) string {
+	const chars = "abcdef0123456789"
+	r := mrand.New(mrand.NewSource(time.Now().UnixNano()))
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = chars[r.Intn(len(chars))]
+	}
+	return string(b)
+}
+
+// safePrefix returns the first n bytes of b, or all of b if len(b) < n.
+func safePrefix(b []byte, n int) []byte {
+	if len(b) <= n {
+		return b
+	}
+	return b[:n]
+}
+
+// inspectContainerIP returns the bridge-network IP of a running container.
+// Used so the test can reach the spawned nethermind container by IP rather
+// than by host port mapping (which doesn't work in DinD mode).
+func inspectContainerIP(containerName string) (string, error) {
+	out, err := exec.Command("docker", "inspect",
+		"--format", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}",
+		containerName,
+	).Output()
+	if err != nil {
+		return "", fmt.Errorf("docker inspect %s: %w", containerName, err)
+	}
+	ip := strings.TrimSpace(string(out))
+	if ip == "" {
+		return "", fmt.Errorf("container %s has no bridge IP (not yet started?)", containerName)
+	}
+	return ip, nil
+}
+
+// oracleDatadir holds paths for an oracle test's datadir.
+type oracleDatadir struct {
+	hostPath         string
+	volMount         string
+	containerDatadir string
+}
+
+// acquireOracleDatadir returns an oracleDatadir for the calling test and a
+// cleanup function. Honours NETH_ORACLE_DATADIR / NETH_ORACLE_VOL env vars
+// that `make test-nethermind-boot` injects when running inside Docker
+// (DinD via socket mount). Falls back to t.TempDir() for direct host runs.
+func acquireOracleDatadir(t *testing.T) (oracleDatadir, func()) {
+	t.Helper()
+	baseDir := os.Getenv("NETH_ORACLE_DATADIR")
+	if baseDir == "" {
+		datadir := t.TempDir()
+		return oracleDatadir{
+			hostPath:         datadir,
+			volMount:         datadir + ":/data",
+			containerDatadir: "/data",
+		}, func() {}
+	}
+	subName := strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())
+	hostPath := baseDir + "/" + subName
+	if err := os.MkdirAll(hostPath, 0o755); err != nil {
+		t.Fatalf("acquireOracleDatadir: mkdir %s: %v", hostPath, err)
+	}
+	t.Logf("using datadir=%s", hostPath)
+
+	vol := os.Getenv("NETH_ORACLE_VOL")
+	volMount := hostPath + ":/data"
+	containerDatadir := "/data"
+	if vol != "" {
+		volMount = vol + ":/data"
+		containerDatadir = "/data/" + subName
+	}
+	return oracleDatadir{
+		hostPath:         hostPath,
+		volMount:         volMount,
+		containerDatadir: containerDatadir,
+	}, func() {}
+}
+
+// nethermindBootConfig is the minimal Nethermind config for booting in
+// passive read-only mode against a state-actor datadir. Mirrors
+// client/nethermind/testdata/configs/sa-dev-v2.json but inlined here so the
+// test is self-contained — the test writes this to <datadir>/boot.cfg and
+// passes --config=/data/boot.cfg, avoiding the need to bind-mount the
+// state-actor source tree (which is a DinD path-translation hazard).
+const nethermindBootConfig = `{
+  "Init": {
+    "EnableUnsecuredDevWallet": false,
+    "DiscoveryEnabled": false,
+    "PeerManagerEnabled": false,
+    "ChainSpecPath": "/data/parity-chainspec.json",
+    "BaseDbPath": "/data",
+    "MemoryHint": 256000000
+  },
+  "Sync": {
+    "NetworkingEnabled": false,
+    "SynchronizationEnabled": false
+  },
+  "Network": {
+    "ActivePeersMaxCount": 0
+  },
+  "JsonRpc": {
+    "Enabled": true,
+    "Timeout": 20000,
+    "Host": "0.0.0.0",
+    "Port": 8545,
+    "EnabledModules": ["Eth", "Net", "Web3"]
+  },
+  "Metrics": {"Enabled": false},
+  "Merge": {"Enabled": false},
+  "Mining": {"Enabled": false}
+}`
+
+// TestNethermindNodeBoot generates a small state-actor datadir (10 EOAs +
+// 3 contracts) via Run, boots upstream nethermind/nethermind against it,
+// and probes via JSON-RPC to confirm balances / code / storage.
+//
+// Build-tagged `cgo_neth && oracle`. Run via `make test-nethermind-boot`;
+// not included in plain `go test`.
+func TestNethermindNodeBoot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle boot test skipped in short mode")
+	}
+
+	const (
+		seed         = int64(42)
+		numAccounts  = 10
+		numContracts = 3
+		codeSize     = 256
+		minSlots     = 2
+		maxSlots     = 2
+	)
+
+	// Pin --fork=merge. Nethermind's writer ceiling today is "merge"
+	// (genesis.MaxForkForClient("nethermind") == "merge"); going past
+	// that is rejected at parse time in main.go.
+	g, err := stategenesis.BuildSynthetic("merge", big.NewInt(1337), 30_000_000, 0, nil)
+	if err != nil {
+		t.Fatalf("BuildSynthetic: %v", err)
+	}
+
+	dd, cleanup := acquireOracleDatadir(t)
+	defer cleanup()
+
+	cfg := generator.Config{
+		DBPath:       dd.hostPath,
+		NumAccounts:  numAccounts,
+		NumContracts: numContracts,
+		CodeSize:     codeSize,
+		MinSlots:     minSlots,
+		MaxSlots:     maxSlots,
+		Seed:         seed,
+		BatchSize:    1000,
+		Workers:      1,
+		TrieMode:     generator.TrieModeMPT,
+		Genesis:      g,
+	}
+
+	if _, err := Run(context.Background(), cfg, Options{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Write the minimal nethermind config into the datadir so we don't
+	// need a separate bind-mount for the source-tree config.
+	cfgPath := filepath.Join(dd.hostPath, "boot.cfg")
+	if err := os.WriteFile(cfgPath, []byte(nethermindBootConfig), 0o644); err != nil {
+		t.Fatalf("write boot.cfg: %v", err)
+	}
+
+	// Reproduce the RNG sequence state-actor's neth Phase 1 used.
+	rng := mrand.New(mrand.NewSource(seed))
+	eoas := make([]*entitygen.Account, numAccounts)
+	for i := 0; i < numAccounts; i++ {
+		eoas[i] = entitygen.GenerateEOA(rng)
+	}
+	contracts := make([]*entitygen.Account, numContracts)
+	for i := 0; i < numContracts; i++ {
+		contracts[i] = entitygen.GenerateContractRoll(rng, cfg.Distribution, codeSize, minSlots, maxSlots)
+	}
+
+	imageRef := nethImageRef()
+	containerName := "state-actor-neth-boot-" + randSuffix(8)
+	containerCfgPath := dd.containerDatadir + "/boot.cfg"
+	runArgs := append([]string{"run", "-d"}, dockerPlatformArgs()...)
+	runArgs = append(runArgs,
+		"--name", containerName,
+		"-v", dd.volMount,
+		imageRef,
+		"--config", containerCfgPath,
+		"--log", "Info",
+	)
+	runOut, err := exec.Command("docker", runArgs...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("docker run: %s\n%v", runOut, err)
+	}
+	t.Logf("nethermind container started: %s", strings.TrimSpace(string(runOut)))
+
+	t.Cleanup(func() {
+		logs, _ := exec.Command("docker", "logs", containerName).CombinedOutput()
+		t.Logf("nethermind container logs:\n%s", logs)
+		exec.Command("docker", "stop", containerName).Run()    //nolint:errcheck
+		exec.Command("docker", "rm", "-f", containerName).Run() //nolint:errcheck
+	})
+
+	containerIP, err := inspectContainerIP(containerName)
+	if err != nil {
+		logs, _ := exec.Command("docker", "logs", containerName).CombinedOutput()
+		t.Fatalf("inspectContainerIP: %v\nnethermind logs:\n%s", err, logs)
+	}
+	rpcURL := "http://" + containerIP + ":8545"
+	t.Logf("nethermind JSON-RPC: %s", rpcURL)
+
+	// Nethermind's .NET startup is comparable to Besu; allow 180s.
+	if err := rpcprobe.WaitForRPC(rpcURL, 180*time.Second); err != nil {
+		t.Fatalf("RPC never came up (logs captured in t.Cleanup):\nerr: %v", err)
+	}
+
+	// ---- EOA assertions ----
+	for _, eoa := range eoas {
+		got, err := rpcprobe.EthGetBalance(rpcURL, eoa.Address, "latest")
+		if err != nil {
+			t.Errorf("eth_getBalance %s: %v", eoa.Address.Hex(), err)
+			continue
+		}
+		want := eoa.StateAccount.Balance.ToBig()
+		if got.Cmp(want) != 0 {
+			t.Errorf("eth_getBalance %s: got %s want %s",
+				eoa.Address.Hex(), got.String(), want.String())
+		}
+	}
+
+	// ---- contract assertions ----
+	for _, c := range contracts {
+		gotCode, err := rpcprobe.EthGetCode(rpcURL, c.Address, "latest")
+		if err != nil {
+			t.Errorf("eth_getCode %s: %v", c.Address.Hex(), err)
+		} else if !bytes.Equal(gotCode, c.Code) {
+			t.Errorf("eth_getCode %s: len got=%d want=%d (first 32 bytes: got=%x want=%x)",
+				c.Address.Hex(), len(gotCode), len(c.Code),
+				safePrefix(gotCode, 32), safePrefix(c.Code, 32))
+		}
+
+		for _, slot := range c.Storage {
+			got, err := rpcprobe.EthGetStorageAt(rpcURL, c.Address, slot.Key, "latest")
+			if err != nil {
+				t.Errorf("eth_getStorageAt %s slot %s: %v",
+					c.Address.Hex(), slot.Key.Hex(), err)
+				continue
+			}
+			if got != slot.Value {
+				t.Errorf("eth_getStorageAt %s slot %s: got %s want %s",
+					c.Address.Hex(), slot.Key.Hex(), got.Hex(), slot.Value.Hex())
+			}
+		}
+	}
+}

--- a/internal/besu/rlp/storage.go
+++ b/internal/besu/rlp/storage.go
@@ -5,29 +5,46 @@ import (
 	gethrlp "github.com/ethereum/go-ethereum/rlp"
 )
 
-// EncodeStorageValue encodes a 32-byte storage slot value for the Besu Bonsai
-// ACCOUNT_STORAGE_STORAGE column family.
+// TrimStorageValue returns the leading-zero-trimmed big-endian bytes of a
+// 32-byte storage slot value. This is the encoding Besu's Bonsai flat-db
+// uses for the ACCOUNT_STORAGE_STORAGE column family — values are read
+// back via UInt256.fromBytes which rejects > 32 bytes, so flat-db must
+// NEVER carry the RLP wrapper.
 //
-// Algorithm (mirrors PathBasedWorldView.encodeTrieValue at PathBasedWorldView.java:53-57):
-//  1. Trim leading zero bytes from the big-endian 32-byte representation.
-//  2. RLP-encode the trimmed byte slice as a byte string.
+// Mirrors the call at BonsaiWorldState.java:182 →
+// putStorageValueBySlotHash(addrHash, slotHash, updatedStorage) where
+// `updatedStorage` is the raw trimmed bytes (NOT encodeTrieValue).
+//
+// Edge cases:
+//   - All-zero value: returns empty slice (zero slots are typically not
+//     written at all; callers should check before persisting).
+//   - Single non-zero byte: returns 1-byte slice.
+//   - 32 non-zero bytes: returns the full 32-byte slice.
+func TrimStorageValue(value common.Hash) []byte {
+	raw := value[:]
+	start := 0
+	for start < len(raw) && raw[start] == 0x00 {
+		start++
+	}
+	return raw[start:]
+}
+
+// EncodeStorageValue RLP-encodes a 32-byte storage slot value for the
+// trie-side write path. Mirrors PathBasedWorldView.encodeTrieValue
+// (PathBasedWorldView.java:43-47): trim leading zeros then RLP-encode as
+// a byte string. The trie's hash function reads this exact encoding when
+// computing nodes, so the storage trie root matches what Besu would
+// compute for the same slot set.
 //
 // Edge cases:
 //   - Zero value (all 32 bytes = 0x00): trimmed = []byte{}, RLP([]) = 0x80.
 //   - Single non-zero byte x where x <= 0x7f: RLP = byte x itself (self-encoded).
 //   - Single non-zero byte x where x > 0x7f: RLP = 0x81 ++ x.
 //   - N-byte value (N > 1): RLP = (0x80+N) ++ bytes.
+//
+// Do NOT use this for flat-db writes — see TrimStorageValue.
 func EncodeStorageValue(value common.Hash) []byte {
-	// Trim leading zeros from the 32-byte big-endian representation.
-	raw := value[:]
-	start := 0
-	for start < len(raw) && raw[start] == 0x00 {
-		start++
-	}
-	trimmed := raw[start:] // may be empty (zero slot)
-
-	// gethrlp.EncodeToBytes on a []byte encodes as an RLP byte string.
-	// Empty byte slice → 0x80 (RLP null), matching PathBasedWorldView behaviour.
+	trimmed := TrimStorageValue(value)
 	encoded, err := gethrlp.EncodeToBytes(trimmed)
 	if err != nil {
 		// gethrlp.EncodeToBytes on a []byte never returns an error.

--- a/internal/besu/rlp/storage_test.go
+++ b/internal/besu/rlp/storage_test.go
@@ -84,3 +84,40 @@ func TestEncodeStorageValue_MaxU256(t *testing.T) {
 		}
 	}
 }
+
+// TestTrimStorageValue_FlatDbContract — the flat-db variant must NEVER
+// exceed 32 bytes (besu's UInt256.fromBytes rejects >32). Lock the
+// contract: trimmed all-0xff is exactly 32 bytes; trimmed value 1 is 1
+// byte; trimmed zero is 0 bytes. Mirrors the
+// BonsaiWorldState.java:182 putStorageValueBySlotHash arg shape.
+func TestTrimStorageValue_FlatDbContract(t *testing.T) {
+	t.Run("zero", func(t *testing.T) {
+		got := TrimStorageValue(common.Hash{})
+		if len(got) != 0 {
+			t.Fatalf("zero: got len=%d, want 0", len(got))
+		}
+	})
+	t.Run("one", func(t *testing.T) {
+		var h common.Hash
+		h[31] = 0x01
+		got := TrimStorageValue(h)
+		if !bytes.Equal(got, []byte{0x01}) {
+			t.Fatalf("one: got %x, want 01", got)
+		}
+	})
+	t.Run("max", func(t *testing.T) {
+		var h common.Hash
+		for i := range h {
+			h[i] = 0xff
+		}
+		got := TrimStorageValue(h)
+		if len(got) != 32 {
+			t.Fatalf("max: got len=%d, want 32 (must be ≤32 for UInt256.fromBytes)", len(got))
+		}
+		for i, b := range got {
+			if b != 0xff {
+				t.Fatalf("max byte[%d]: got %x, want ff", i, b)
+			}
+		}
+	})
+}


### PR DESCRIPTION
Closes the "boot is only 2 clients" gap from the user's audit. After this lands, the Tier-2 boot oracle is symmetric across all four clients.

## What's new

| File | Purpose |
|---|---|
| `client/besu/node_boot_test.go` | `TestBesuNodeBoot` — boot `hyperledger/besu:25.11.0`, RNG-replay-probe via `internal/rpcprobe` |
| `client/nethermind/node_boot_test.go` | `TestNethermindNodeBoot` — boot `nethermind/nethermind:1.37.0`, same shape |
| `Makefile` | `test-besu-boot`, `test-nethermind-boot` targets (DinD via Docker socket + named volume, mirror `test-reth-boot`) |
| `.github/workflows/ci.yml` | Tier-2 collapsed into a single matrix `boot` job over `[besu, geth, nethermind, reth]` |

## Test shape (identical across clients)

Each `TestXxxNodeBoot`:
1. `genesis.BuildSynthetic(<client's max fork>, 1337, …)` — shanghai for besu/geth/reth, merge for nethermind (per its writer ceiling)
2. Generate small datadir (10 EOAs + 3 contracts, seed=42, codeSize=256, slots=2)
3. Reproduce RNG sequence via `entitygen.GenerateContractRoll` (same canonical draw all writers use)
4. Boot the upstream client container against the datadir (DinD socket-mount, named volume)
5. `WaitForRPC`, then probe via `internal/rpcprobe`:
   - `eth_getBalance` per EOA → compare to generated balance
   - `eth_getCode` per contract → compare to generated bytecode
   - `eth_getStorageAt` per slot → compare to generated value

## CI matrix

```yaml
boot:
  strategy:
    fail-fast: false   # independent per-client outcomes
    matrix:
      client: [besu, geth, nethermind, reth]
  if: schedule || (PR + full-ci label)
```

Per-client conditional steps build the cgo builder image (besu/neth/reth) with its own GHA cache scope; geth is pure Go and skips the docker build. Test invocation is inlined per client (avoids Make's `docker build` prereq re-building RocksDB — same fix Tier-1 already uses).
