### PR TITLE
fix(nethermind): Ethash chainspec + EngineDriver mock CL; fork-gated EIPs

### DIFF
--- a/client/besu/e2e_test.go
+++ b/client/besu/e2e_test.go
@@ -4,7 +4,6 @@ package besu
 
 import (
 	"context"
-	"errors"
 	"math/big"
 	"os"
 	"os/exec"
@@ -166,28 +165,9 @@ func TestE2ESuite(t *testing.T) {
 	}
 
 	// Mock CL: drive block production via engine API. Modeled after besu's
-	// own PragueAcceptanceTestHelper.java. Runs as a goroutine for the
+	// own PragueAcceptanceTestHelper.java. The goroutine runs for the
 	// rest of the test so spamoor's txs (Phase 5) get included in blocks.
-	driver := &oracle.EngineDriver{
-		EngineURL: "http://" + containerIP + ":8551",
-		EthRPCURL: rpcURL,
-		BlockTime: time.Second,
-		Fork:      oracle.ForkOsaka,
-	}
-	driverCtx, driverCancel := context.WithCancel(context.Background())
-	t.Cleanup(driverCancel)
-	go func() {
-		if err := driver.DriveLoop(driverCtx); err != nil && !errors.Is(err, context.Canceled) {
-			// Goroutine context — use t.Errorf (not t.Fatalf, which is
-			// not safe outside the test goroutine). DriveLoop only
-			// returns non-context-Canceled errors when something is
-			// permanently wrong (fetchLatestBlock at startup, or K
-			// consecutive Step failures); surfacing it loud lets the
-			// suite fail with the right diagnostic instead of timing
-			// out on spamoor's deadline.
-			t.Errorf("EngineDriver exited: %v", err)
-		}
-	}()
+	oracle.StartEngineDriver(t, containerIP, rpcURL, oracle.ForkOsaka)
 
 	// Phases 3-7: shared via internal/oracle.RunSuitePhases.
 	oracle.RunSuitePhases(t, oracle.SuitePhasesCfg{

--- a/client/nethermind/chainspec.go
+++ b/client/nethermind/chainspec.go
@@ -19,73 +19,34 @@ const ChainSpecFileName = "parity-chainspec.json"
 //go:embed testdata/chainspecs/sa-dev.json
 var paritySpecTemplate []byte
 
-// nethEIPsByFork groups Parity EIP-transition keys by fork. The embedded
-// template ships every key with timestamp 0x0; the writer strips entries
-// for forks not active in g.Config. Shanghai EIPs (eip3651/eip3855/eip3860/
-// eip4895) are unconditional — genesis.BuildChainConfigForFork rejects pre-
-// Prague, so Shanghai is always active. Source: Nethermind release notes
-// cross-checked against
+// osakaParamKeys lists the Parity EIP-transition and system-contract keys
+// the writer strips from the embedded template when --fork is below Osaka.
+// genesis.BuildChainConfigForFork rejects pre-Prague, so cancun + prague
+// + shanghai keys are always active and stay in the template unconditionally.
+// Source: Nethermind release notes cross-checked against
 // src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs.
-var nethEIPsByFork = map[string][]string{
-	"cancun": {
-		"eip4788TransitionTimestamp",
-		"eip4844TransitionTimestamp",
-		"eip1153TransitionTimestamp",
-		"eip5656TransitionTimestamp",
-		"eip6780TransitionTimestamp",
-	},
-	"prague": {
-		"eip2537TransitionTimestamp",
-		"eip2935TransitionTimestamp",
-		"eip6110TransitionTimestamp",
-		"eip7002TransitionTimestamp",
-		"eip7251TransitionTimestamp",
-		"eip7623TransitionTimestamp",
-		"eip7702TransitionTimestamp",
-	},
-	"osaka": {
-		"eip7594TransitionTimestamp",
-		"eip7823TransitionTimestamp",
-		"eip7825TransitionTimestamp",
-		"eip7883TransitionTimestamp",
-		"eip7918TransitionTimestamp",
-		"eip7934TransitionTimestamp",
-		"eip7939TransitionTimestamp",
-		"eip7951TransitionTimestamp",
-	},
-}
-
-// nethSystemContractAddressesByFork groups Parity system-contract-address
-// keys by fork. Stripped from params when the corresponding fork is inactive
-// in g.Config. depositContractAddress is grouped with Prague because EIP-6110
-// (validator deposits via EL system contract) activates at Prague.
-var nethSystemContractAddressesByFork = map[string][]string{
-	"prague": {
-		"depositContractAddress",
-		"eip7002ContractAddress",
-		"eip7251ContractAddress",
-	},
+var osakaParamKeys = []string{
+	"eip7594TransitionTimestamp",
+	"eip7823TransitionTimestamp",
+	"eip7825TransitionTimestamp",
+	"eip7883TransitionTimestamp",
+	"eip7918TransitionTimestamp",
+	"eip7934TransitionTimestamp",
+	"eip7939TransitionTimestamp",
+	"eip7951TransitionTimestamp",
 }
 
 // writeChainSpec emits the embedded sa-dev Parity chainspec to
-// <dbPath>/<ChainSpecFileName>, parameterized by g.Config:
-//
-//   - chainID + networkID flow from g.Config.ChainID.
-//   - EIP transition timestamps + system-contract addresses are gated by
-//     fork-active timestamps (g.Config.{Cancun,Prague,Osaka}Time != nil).
-//     Inactive-fork keys are removed from params so Nethermind doesn't see
-//     them as active-at-genesis.
+// <dbPath>/<ChainSpecFileName>, with chainID + networkID overridden from
+// g.Config.ChainID and Osaka-only keys stripped if g.Config.OsakaTime is
+// unset.
 //
 // Engine is Ethash + terminalTotalDifficulty=0 — the Kiln/Kintsugi merge-
 // from-genesis recipe. MergePlugin wraps EthashPlugin and routes every
 // block through the engine API; EthashPlugin's PoW path never runs because
-// TTD=0 means post-merge from block 0. NethDev was removed because it's
-// not in MergePlugin's SealEngineType allowlist (cf. state-actor#56).
-//
-// State-actor only supports prague+osaka today (pre-Prague is EOL in
-// genesis.BuildChainConfigForFork), so the cancun/prague gates have no
-// observable effect — they're structural future-proofing matching the
-// pattern in client/besu/chainspec.go.
+// TTD=0 means post-merge from block 0. MergePlugin's SealEngineType
+// allowlist is {BeaconChain, Clique, Ethash}, which is why we don't use
+// NethDev here.
 func writeChainSpec(dbPath string, g *genesis.Genesis) (string, error) {
 	if g == nil {
 		return "", fmt.Errorf("nethermind writeChainSpec: nil genesis")
@@ -110,19 +71,8 @@ func writeChainSpec(dbPath string, g *genesis.Genesis) (string, error) {
 	params["chainID"] = hex
 	params["networkID"] = hex
 
-	forkActive := map[string]bool{
-		"cancun": g.Config.CancunTime != nil,
-		"prague": g.Config.PragueTime != nil,
-		"osaka":  g.Config.OsakaTime != nil,
-	}
-	for fork, active := range forkActive {
-		if active {
-			continue
-		}
-		for _, k := range nethEIPsByFork[fork] {
-			delete(params, k)
-		}
-		for _, k := range nethSystemContractAddressesByFork[fork] {
+	if g.Config.OsakaTime == nil {
+		for _, k := range osakaParamKeys {
 			delete(params, k)
 		}
 	}

--- a/client/nethermind/chainspec.go
+++ b/client/nethermind/chainspec.go
@@ -19,17 +19,82 @@ const ChainSpecFileName = "parity-chainspec.json"
 //go:embed testdata/chainspecs/sa-dev.json
 var paritySpecTemplate []byte
 
+// nethEIPsByFork groups Parity EIP-transition keys by fork. The embedded
+// template ships every key with timestamp 0x0; the writer strips entries
+// for forks not active in g.Config. Shanghai EIPs (eip3651/eip3855/eip3860/
+// eip4895) are unconditional — genesis.BuildChainConfigForFork rejects pre-
+// Prague, so Shanghai is always active. Source: Nethermind release notes
+// cross-checked against
+// src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs.
+var nethEIPsByFork = map[string][]string{
+	"cancun": {
+		"eip4788TransitionTimestamp",
+		"eip4844TransitionTimestamp",
+		"eip1153TransitionTimestamp",
+		"eip5656TransitionTimestamp",
+		"eip6780TransitionTimestamp",
+	},
+	"prague": {
+		"eip2537TransitionTimestamp",
+		"eip2935TransitionTimestamp",
+		"eip6110TransitionTimestamp",
+		"eip7002TransitionTimestamp",
+		"eip7251TransitionTimestamp",
+		"eip7623TransitionTimestamp",
+		"eip7702TransitionTimestamp",
+	},
+	"osaka": {
+		"eip7594TransitionTimestamp",
+		"eip7823TransitionTimestamp",
+		"eip7825TransitionTimestamp",
+		"eip7883TransitionTimestamp",
+		"eip7918TransitionTimestamp",
+		"eip7934TransitionTimestamp",
+		"eip7939TransitionTimestamp",
+		"eip7951TransitionTimestamp",
+	},
+}
+
+// nethSystemContractAddressesByFork groups Parity system-contract-address
+// keys by fork. Stripped from params when the corresponding fork is inactive
+// in g.Config. depositContractAddress is grouped with Prague because EIP-6110
+// (validator deposits via EL system contract) activates at Prague.
+var nethSystemContractAddressesByFork = map[string][]string{
+	"prague": {
+		"depositContractAddress",
+		"eip7002ContractAddress",
+		"eip7251ContractAddress",
+	},
+}
+
 // writeChainSpec emits the embedded sa-dev Parity chainspec to
-// <dbPath>/<ChainSpecFileName> with chainID + networkID overridden from
-// cfg.Genesis.Config.ChainID. The template's EIP-transition timestamps
-// remain at 0 (Shanghai-active) — Nethermind currently has no post-Merge
-// header writer here so going past Shanghai needs additional work.
+// <dbPath>/<ChainSpecFileName>, parameterized by g.Config:
+//
+//   - chainID + networkID flow from g.Config.ChainID.
+//   - EIP transition timestamps + system-contract addresses are gated by
+//     fork-active timestamps (g.Config.{Cancun,Prague,Osaka}Time != nil).
+//     Inactive-fork keys are removed from params so Nethermind doesn't see
+//     them as active-at-genesis.
+//
+// Engine is Ethash + terminalTotalDifficulty=0 — the Kiln/Kintsugi merge-
+// from-genesis recipe. MergePlugin wraps EthashPlugin and routes every
+// block through the engine API; EthashPlugin's PoW path never runs because
+// TTD=0 means post-merge from block 0. NethDev was removed because it's
+// not in MergePlugin's SealEngineType allowlist (cf. state-actor#56).
+//
+// State-actor only supports prague+osaka today (pre-Prague is EOL in
+// genesis.BuildChainConfigForFork), so the cancun/prague gates have no
+// observable effect — they're structural future-proofing matching the
+// pattern in client/besu/chainspec.go.
 func writeChainSpec(dbPath string, g *genesis.Genesis) (string, error) {
 	if g == nil {
 		return "", fmt.Errorf("nethermind writeChainSpec: nil genesis")
 	}
+	if g.Config == nil {
+		return "", fmt.Errorf("nethermind writeChainSpec: g.Config required (use genesis.BuildSynthetic)")
+	}
 	chainID := int64(1337)
-	if g.Config != nil && g.Config.ChainID != nil {
+	if g.Config.ChainID != nil {
 		chainID = g.Config.ChainID.Int64()
 	}
 
@@ -44,6 +109,23 @@ func writeChainSpec(dbPath string, g *genesis.Genesis) (string, error) {
 	hex := fmt.Sprintf("0x%x", chainID)
 	params["chainID"] = hex
 	params["networkID"] = hex
+
+	forkActive := map[string]bool{
+		"cancun": g.Config.CancunTime != nil,
+		"prague": g.Config.PragueTime != nil,
+		"osaka":  g.Config.OsakaTime != nil,
+	}
+	for fork, active := range forkActive {
+		if active {
+			continue
+		}
+		for _, k := range nethEIPsByFork[fork] {
+			delete(params, k)
+		}
+		for _, k := range nethSystemContractAddressesByFork[fork] {
+			delete(params, k)
+		}
+	}
 
 	out, err := json.MarshalIndent(spec, "", "  ")
 	if err != nil {

--- a/client/nethermind/chainspec_test.go
+++ b/client/nethermind/chainspec_test.go
@@ -1,6 +1,7 @@
 package nethermind
 
 import (
+	"bytes"
 	"encoding/json"
 	"math/big"
 	"os"
@@ -10,9 +11,6 @@ import (
 	"github.com/nerolation/state-actor/genesis"
 )
 
-// readWrittenSpec runs writeChainSpec into a temp dir and returns the
-// re-parsed JSON tree. Centralizes setup + parse so each test below
-// stays focused on its specific assertion.
 func readWrittenSpec(t *testing.T, fork string) map[string]any {
 	t.Helper()
 	g, err := genesis.BuildSynthetic(fork, big.NewInt(1337), 30_000_000, 0, nil)
@@ -44,59 +42,33 @@ func paramsBlock(t *testing.T, spec map[string]any) map[string]any {
 	return params
 }
 
-// TestWriteChainSpec_OsakaIncludesAllForkKeys locks in #55: with --fork=osaka
-// every gated EIP timestamp (cancun + prague + osaka) and every gated
-// system-contract address is emitted. Catches accidental removal of a
-// known-active EIP, and would have caught the pre-existing eip1153 drift
-// if it had been on the gated list.
-func TestWriteChainSpec_OsakaIncludesAllForkKeys(t *testing.T) {
-	params := paramsBlock(t, readWrittenSpec(t, "osaka"))
-	for fork, keys := range nethEIPsByFork {
-		for _, k := range keys {
-			if _, ok := params[k]; !ok {
-				t.Errorf("osaka spec missing %s key %q", fork, k)
-			}
-		}
+// TestWriteChainSpec_OsakaGating drives both gating branches: the keys in
+// osakaParamKeys must be present when --fork=osaka and absent when --fork=prague.
+func TestWriteChainSpec_OsakaGating(t *testing.T) {
+	cases := []struct {
+		fork    string
+		present bool
+	}{
+		{"osaka", true},
+		{"prague", false},
 	}
-	for fork, keys := range nethSystemContractAddressesByFork {
-		for _, k := range keys {
-			if _, ok := params[k]; !ok {
-				t.Errorf("osaka spec missing %s contract address %q", fork, k)
+	for _, tc := range cases {
+		t.Run(tc.fork, func(t *testing.T) {
+			params := paramsBlock(t, readWrittenSpec(t, tc.fork))
+			for _, k := range osakaParamKeys {
+				_, ok := params[k]
+				if ok != tc.present {
+					if tc.present {
+						t.Errorf("--fork=%s spec missing osaka key %q", tc.fork, k)
+					} else {
+						t.Errorf("--fork=%s spec unexpectedly contains osaka key %q", tc.fork, k)
+					}
+				}
 			}
-		}
+		})
 	}
 }
 
-// TestWriteChainSpec_PragueStripsOsakaKeys verifies that --fork=prague
-// produces a Prague-only spec — cancun + prague keys present, osaka keys
-// stripped. This is the regression #55 was filed to prevent.
-func TestWriteChainSpec_PragueStripsOsakaKeys(t *testing.T) {
-	params := paramsBlock(t, readWrittenSpec(t, "prague"))
-	for _, k := range nethEIPsByFork["cancun"] {
-		if _, ok := params[k]; !ok {
-			t.Errorf("prague spec unexpectedly missing cancun key %q", k)
-		}
-	}
-	for _, k := range nethEIPsByFork["prague"] {
-		if _, ok := params[k]; !ok {
-			t.Errorf("prague spec unexpectedly missing prague key %q", k)
-		}
-	}
-	for _, k := range nethEIPsByFork["osaka"] {
-		if _, ok := params[k]; ok {
-			t.Errorf("prague spec unexpectedly contains osaka key %q", k)
-		}
-	}
-	for _, k := range nethSystemContractAddressesByFork["prague"] {
-		if _, ok := params[k]; !ok {
-			t.Errorf("prague spec missing prague contract address %q", k)
-		}
-	}
-}
-
-// TestWriteChainSpec_OverrideChainID asserts the chainID + networkID
-// fields flow from g.Config.ChainID rather than the template's literal
-// value. Regression test for the existing behavior.
 func TestWriteChainSpec_OverrideChainID(t *testing.T) {
 	g, err := genesis.BuildSynthetic("osaka", big.NewInt(0xbeef), 30_000_000, 0, nil)
 	if err != nil {
@@ -123,21 +95,20 @@ func TestWriteChainSpec_OverrideChainID(t *testing.T) {
 	}
 }
 
-// TestWriteChainSpec_Eip1153PresentInCancun explicitly checks the key
-// that was missing from the template before this fix. EIP-1153 is
-// Cancun's transient storage (TSTORE/TLOAD); its absence is a silent
-// chainspec drift that doesn't surface until a contract uses TSTORE.
+// TestWriteChainSpec_Eip1153PresentInCancun guards against silent template
+// drift: EIP-1153 (TSTORE/TLOAD) is Cancun-active but a missing key here
+// would only surface when a contract actually uses transient storage.
 func TestWriteChainSpec_Eip1153PresentInCancun(t *testing.T) {
 	params := paramsBlock(t, readWrittenSpec(t, "osaka"))
 	if _, ok := params["eip1153TransitionTimestamp"]; !ok {
-		t.Error("eip1153TransitionTimestamp absent — template drift bug regressed")
+		t.Error("eip1153TransitionTimestamp absent — template drift")
 	}
 }
 
-// TestWriteChainSpec_EngineIsEthash locks in #56's chainspec swap: the
-// engine block is Ethash (with mainnet difficulty params for parser
-// acceptance) and NethDev is no longer present. NethDev was incompatible
-// with MergePlugin's seal-engine allowlist {BeaconChain, Clique, Ethash}.
+// TestWriteChainSpec_EngineIsEthash guards the MergePlugin SealEngineType
+// allowlist {BeaconChain, Clique, Ethash} — using NethDev (the legacy
+// dev engine, not on the allowlist) would silently fail to seal blocks
+// on a post-Prague chain with system contracts.
 func TestWriteChainSpec_EngineIsEthash(t *testing.T) {
 	spec := readWrittenSpec(t, "osaka")
 	engine, ok := spec["engine"].(map[string]any)
@@ -148,7 +119,7 @@ func TestWriteChainSpec_EngineIsEthash(t *testing.T) {
 		t.Errorf("engine.Ethash missing; engine block = %v", engine)
 	}
 	if _, ok := engine["NethDev"]; ok {
-		t.Errorf("engine.NethDev still present — chainspec swap regressed")
+		t.Errorf("engine.NethDev still present")
 	}
 	params := paramsBlock(t, spec)
 	if ttd := params["terminalTotalDifficulty"]; ttd != "0x0" {
@@ -156,9 +127,9 @@ func TestWriteChainSpec_EngineIsEthash(t *testing.T) {
 	}
 }
 
-// TestWriteChainSpec_ParityChainIDFormat asserts the chainID hex string
-// uses lowercase Go-default formatting. Locking in the format avoids
-// surprises if a future refactor switches to strconv.FormatInt(16) etc.
+// TestWriteChainSpec_ParityChainIDFormat pins lowercase Go-default hex
+// formatting — Nethermind's parser would silently misread a strconv.FormatInt(16)
+// "beef" (no 0x prefix) as decimal.
 func TestWriteChainSpec_ParityChainIDFormat(t *testing.T) {
 	params := paramsBlock(t, readWrittenSpec(t, "osaka"))
 	if got := params["chainID"]; got != "0x539" {
@@ -166,17 +137,14 @@ func TestWriteChainSpec_ParityChainIDFormat(t *testing.T) {
 	}
 }
 
-// TestWriteChainSpec_NilGenesisRejected verifies the writer errors on
-// nil input rather than producing a garbage file.
 func TestWriteChainSpec_NilGenesisRejected(t *testing.T) {
 	if _, err := writeChainSpec(t.TempDir(), nil); err == nil {
 		t.Error("writeChainSpec(nil) returned no error")
 	}
 }
 
-// TestWriteChainSpec_FilePathIsConventional verifies the writer puts the
-// output at <dbPath>/parity-chainspec.json — smoke scripts depend on this
-// hardcoded filename.
+// TestWriteChainSpec_FilePathIsConventional locks the output filename —
+// smoke scripts hardcode parity-chainspec.json.
 func TestWriteChainSpec_FilePathIsConventional(t *testing.T) {
 	g, _ := genesis.BuildSynthetic("osaka", big.NewInt(1337), 30_000_000, 0, nil)
 	dir := t.TempDir()
@@ -187,5 +155,30 @@ func TestWriteChainSpec_FilePathIsConventional(t *testing.T) {
 	want := filepath.Join(dir, ChainSpecFileName)
 	if out != want {
 		t.Errorf("writeChainSpec returned %q; want %q", out, want)
+	}
+}
+
+// TestWriteChainSpec_ByteForByteDeterministic catches encoder-order drift.
+// The Osaka-gating loop iterates a slice (already deterministic), and
+// json.MarshalIndent sorts map keys today — but a future encoder swap
+// could silently break the cross-client genesis-root invariant.
+func TestWriteChainSpec_ByteForByteDeterministic(t *testing.T) {
+	read := func() []byte {
+		g, err := genesis.BuildSynthetic("osaka", big.NewInt(1337), 30_000_000, 0, nil)
+		if err != nil {
+			t.Fatalf("BuildSynthetic: %v", err)
+		}
+		out, err := writeChainSpec(t.TempDir(), g)
+		if err != nil {
+			t.Fatalf("writeChainSpec: %v", err)
+		}
+		raw, err := os.ReadFile(out)
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		return raw
+	}
+	if a, b := read(), read(); !bytes.Equal(a, b) {
+		t.Errorf("writeChainSpec is non-deterministic\nfirst:\n%s\nsecond:\n%s", a, b)
 	}
 }

--- a/client/nethermind/chainspec_test.go
+++ b/client/nethermind/chainspec_test.go
@@ -1,0 +1,191 @@
+package nethermind
+
+import (
+	"encoding/json"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nerolation/state-actor/genesis"
+)
+
+// readWrittenSpec runs writeChainSpec into a temp dir and returns the
+// re-parsed JSON tree. Centralizes setup + parse so each test below
+// stays focused on its specific assertion.
+func readWrittenSpec(t *testing.T, fork string) map[string]any {
+	t.Helper()
+	g, err := genesis.BuildSynthetic(fork, big.NewInt(1337), 30_000_000, 0, nil)
+	if err != nil {
+		t.Fatalf("BuildSynthetic(%q): %v", fork, err)
+	}
+	dir := t.TempDir()
+	outPath, err := writeChainSpec(dir, g)
+	if err != nil {
+		t.Fatalf("writeChainSpec: %v", err)
+	}
+	raw, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read written spec: %v", err)
+	}
+	var spec map[string]any
+	if err := json.Unmarshal(raw, &spec); err != nil {
+		t.Fatalf("parse written spec: %v", err)
+	}
+	return spec
+}
+
+func paramsBlock(t *testing.T, spec map[string]any) map[string]any {
+	t.Helper()
+	params, ok := spec["params"].(map[string]any)
+	if !ok {
+		t.Fatalf("spec missing params block")
+	}
+	return params
+}
+
+// TestWriteChainSpec_OsakaIncludesAllForkKeys locks in #55: with --fork=osaka
+// every gated EIP timestamp (cancun + prague + osaka) and every gated
+// system-contract address is emitted. Catches accidental removal of a
+// known-active EIP, and would have caught the pre-existing eip1153 drift
+// if it had been on the gated list.
+func TestWriteChainSpec_OsakaIncludesAllForkKeys(t *testing.T) {
+	params := paramsBlock(t, readWrittenSpec(t, "osaka"))
+	for fork, keys := range nethEIPsByFork {
+		for _, k := range keys {
+			if _, ok := params[k]; !ok {
+				t.Errorf("osaka spec missing %s key %q", fork, k)
+			}
+		}
+	}
+	for fork, keys := range nethSystemContractAddressesByFork {
+		for _, k := range keys {
+			if _, ok := params[k]; !ok {
+				t.Errorf("osaka spec missing %s contract address %q", fork, k)
+			}
+		}
+	}
+}
+
+// TestWriteChainSpec_PragueStripsOsakaKeys verifies that --fork=prague
+// produces a Prague-only spec — cancun + prague keys present, osaka keys
+// stripped. This is the regression #55 was filed to prevent.
+func TestWriteChainSpec_PragueStripsOsakaKeys(t *testing.T) {
+	params := paramsBlock(t, readWrittenSpec(t, "prague"))
+	for _, k := range nethEIPsByFork["cancun"] {
+		if _, ok := params[k]; !ok {
+			t.Errorf("prague spec unexpectedly missing cancun key %q", k)
+		}
+	}
+	for _, k := range nethEIPsByFork["prague"] {
+		if _, ok := params[k]; !ok {
+			t.Errorf("prague spec unexpectedly missing prague key %q", k)
+		}
+	}
+	for _, k := range nethEIPsByFork["osaka"] {
+		if _, ok := params[k]; ok {
+			t.Errorf("prague spec unexpectedly contains osaka key %q", k)
+		}
+	}
+	for _, k := range nethSystemContractAddressesByFork["prague"] {
+		if _, ok := params[k]; !ok {
+			t.Errorf("prague spec missing prague contract address %q", k)
+		}
+	}
+}
+
+// TestWriteChainSpec_OverrideChainID asserts the chainID + networkID
+// fields flow from g.Config.ChainID rather than the template's literal
+// value. Regression test for the existing behavior.
+func TestWriteChainSpec_OverrideChainID(t *testing.T) {
+	g, err := genesis.BuildSynthetic("osaka", big.NewInt(0xbeef), 30_000_000, 0, nil)
+	if err != nil {
+		t.Fatalf("BuildSynthetic: %v", err)
+	}
+	outPath, err := writeChainSpec(t.TempDir(), g)
+	if err != nil {
+		t.Fatalf("writeChainSpec: %v", err)
+	}
+	raw, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var spec map[string]any
+	if err := json.Unmarshal(raw, &spec); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	params := paramsBlock(t, spec)
+	if got := params["chainID"]; got != "0xbeef" {
+		t.Errorf("chainID = %v; want 0xbeef", got)
+	}
+	if got := params["networkID"]; got != "0xbeef" {
+		t.Errorf("networkID = %v; want 0xbeef", got)
+	}
+}
+
+// TestWriteChainSpec_Eip1153PresentInCancun explicitly checks the key
+// that was missing from the template before this fix. EIP-1153 is
+// Cancun's transient storage (TSTORE/TLOAD); its absence is a silent
+// chainspec drift that doesn't surface until a contract uses TSTORE.
+func TestWriteChainSpec_Eip1153PresentInCancun(t *testing.T) {
+	params := paramsBlock(t, readWrittenSpec(t, "osaka"))
+	if _, ok := params["eip1153TransitionTimestamp"]; !ok {
+		t.Error("eip1153TransitionTimestamp absent — template drift bug regressed")
+	}
+}
+
+// TestWriteChainSpec_EngineIsEthash locks in #56's chainspec swap: the
+// engine block is Ethash (with mainnet difficulty params for parser
+// acceptance) and NethDev is no longer present. NethDev was incompatible
+// with MergePlugin's seal-engine allowlist {BeaconChain, Clique, Ethash}.
+func TestWriteChainSpec_EngineIsEthash(t *testing.T) {
+	spec := readWrittenSpec(t, "osaka")
+	engine, ok := spec["engine"].(map[string]any)
+	if !ok {
+		t.Fatalf("spec missing engine block")
+	}
+	if _, ok := engine["Ethash"]; !ok {
+		t.Errorf("engine.Ethash missing; engine block = %v", engine)
+	}
+	if _, ok := engine["NethDev"]; ok {
+		t.Errorf("engine.NethDev still present — chainspec swap regressed")
+	}
+	params := paramsBlock(t, spec)
+	if ttd := params["terminalTotalDifficulty"]; ttd != "0x0" {
+		t.Errorf("terminalTotalDifficulty = %v; want 0x0 (merge-from-genesis)", ttd)
+	}
+}
+
+// TestWriteChainSpec_ParityChainIDFormat asserts the chainID hex string
+// uses lowercase Go-default formatting. Locking in the format avoids
+// surprises if a future refactor switches to strconv.FormatInt(16) etc.
+func TestWriteChainSpec_ParityChainIDFormat(t *testing.T) {
+	params := paramsBlock(t, readWrittenSpec(t, "osaka"))
+	if got := params["chainID"]; got != "0x539" {
+		t.Errorf("chainID = %v; want 0x539 (decimal 1337)", got)
+	}
+}
+
+// TestWriteChainSpec_NilGenesisRejected verifies the writer errors on
+// nil input rather than producing a garbage file.
+func TestWriteChainSpec_NilGenesisRejected(t *testing.T) {
+	if _, err := writeChainSpec(t.TempDir(), nil); err == nil {
+		t.Error("writeChainSpec(nil) returned no error")
+	}
+}
+
+// TestWriteChainSpec_FilePathIsConventional verifies the writer puts the
+// output at <dbPath>/parity-chainspec.json — smoke scripts depend on this
+// hardcoded filename.
+func TestWriteChainSpec_FilePathIsConventional(t *testing.T) {
+	g, _ := genesis.BuildSynthetic("osaka", big.NewInt(1337), 30_000_000, 0, nil)
+	dir := t.TempDir()
+	out, err := writeChainSpec(dir, g)
+	if err != nil {
+		t.Fatalf("writeChainSpec: %v", err)
+	}
+	want := filepath.Join(dir, ChainSpecFileName)
+	if out != want {
+		t.Errorf("writeChainSpec returned %q; want %q", out, want)
+	}
+}

--- a/client/nethermind/e2e_test.go
+++ b/client/nethermind/e2e_test.go
@@ -87,7 +87,7 @@ const nethermindE2EConfigTemplate = `{
   },
   "Metrics": {"Enabled": false},
   "Merge": {"Enabled": true, "TerminalTotalDifficulty": "0"},
-  "Mining": {"Enabled": true}
+  "Mining": {"Enabled": false}
 }`
 
 // TestE2ESuite — see client/besu/e2e_test.go for the full phase

--- a/client/nethermind/e2e_test.go
+++ b/client/nethermind/e2e_test.go
@@ -4,7 +4,6 @@ package nethermind
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math/big"
 	"os"
@@ -34,21 +33,15 @@ func nethImageRef() string {
 	return pinnedNethImage
 }
 
-// nethermindE2EConfigTemplate is the Nethermind config for the e2e suite
-// (boot + engine-API-driven block production). Mirrors client/nethermind/
-// testdata/configs/sa-dev-v2.json but inlined here so the test is
-// self-contained — written into the datadir at runtime with the
-// chainspec / DB paths plugged in, so DinD mode (where the test
-// container places state-actor data at /data/<testName>/) and direct
-// mode (/data) both resolve correctly.
+// nethermindE2EConfigTemplate is the Nethermind config for the e2e suite.
+// Inlined rather than loaded from testdata so DinD mode (container sees
+// /data/<testName>) and direct mode (/data) can both resolve at runtime.
 //
 // Engine RPC on port 8551 + UnsecureDevNoRpcAuthentication=true is the
 // symmetric equivalent of besu's --engine-rpc-enabled / --engine-jwt-disabled.
-// EngineDriver (the mock CL in internal/oracle) connects there to drive
-// block production via engine_forkchoiceUpdated / getPayload / newPayload.
 // Merge.Enabled + TerminalTotalDifficulty=0 + the Ethash chainspec engine
-// (cf. ethereum/state-actor#56) make MergePlugin take over from
-// EthashPlugin so every block is engine-API-driven from genesis.
+// hand block production to MergePlugin via the engine API from genesis;
+// EthashPlugin's PoW path never runs.
 //
 // Two %s placeholders, in order:
 //  1. ChainSpecPath  — full path to state-actor's parity-chainspec.json
@@ -96,10 +89,8 @@ const nethermindE2EConfigTemplate = `{
 //
 // nethermind-specific bits:
 //   - --fork=osaka (unified across all 4 clients after the writer migration to internal/genesisheader.Build)
-//   - Ethash-from-genesis chainspec + Merge.Enabled → engine-API-driven block
-//     production via the EngineDriver mock CL (mirrors besu). NethDev was
-//     removed because it's not in MergePlugin's seal-engine allowlist
-//     (cf. state-actor#56).
+//   - Ethash-from-genesis chainspec + Merge.Enabled → engine-API-driven
+//     block production via the EngineDriver mock CL (mirrors besu).
 //   - SlotDuration=250ms in Phase 5 (matches smoke-nethermind-spamoor pacing)
 func TestE2ESuite(t *testing.T) {
 	if testing.Short() {
@@ -205,33 +196,12 @@ func TestE2ESuite(t *testing.T) {
 		t.Fatalf("RPC never came up (logs captured in t.Cleanup): %v", err)
 	}
 
-	// Mock CL: drive block production via engine API. Same pattern besu
-	// uses — NethDev was the old dev consensus engine but it's not in
-	// MergePlugin's seal-engine allowlist {BeaconChain, Clique, Ethash},
-	// so on a post-Prague chain with system contracts it silently fails
-	// to seal (state-actor#56). The Ethash-from-genesis chainspec + this
-	// driver replace NethDev's role. Runs as a goroutine for the rest of
+	// Mock CL: drive block production via engine API. MergePlugin's
+	// seal-engine allowlist is {BeaconChain, Clique, Ethash}, so on an
+	// Ethash chainspec with Merge.Enabled + TTD=0 the engine API is the
+	// only path that produces blocks. Goroutine runs for the rest of
 	// the test so spamoor's txs (Phase 5) get included in blocks.
-	driver := &oracle.EngineDriver{
-		EngineURL: "http://" + containerIP + ":8551",
-		EthRPCURL: rpcURL,
-		BlockTime: time.Second,
-		Fork:      oracle.ForkOsaka,
-	}
-	driverCtx, driverCancel := context.WithCancel(context.Background())
-	t.Cleanup(driverCancel)
-	go func() {
-		if err := driver.DriveLoop(driverCtx); err != nil && !errors.Is(err, context.Canceled) {
-			// Goroutine context — use t.Errorf (not t.Fatalf, which is
-			// not safe outside the test goroutine). DriveLoop only
-			// returns non-context-Canceled errors when something is
-			// permanently wrong (fetchLatestBlock at startup, or K
-			// consecutive Step failures); surfacing it loud lets the
-			// suite fail with the right diagnostic instead of timing
-			// out on spamoor's deadline.
-			t.Errorf("EngineDriver exited: %v", err)
-		}
-	}()
+	oracle.StartEngineDriver(t, containerIP, rpcURL, oracle.ForkOsaka)
 
 	// Phases 3-7: shared via internal/oracle.RunSuitePhases.
 	oracle.RunSuitePhases(t, oracle.SuitePhasesCfg{

--- a/client/nethermind/e2e_test.go
+++ b/client/nethermind/e2e_test.go
@@ -4,6 +4,7 @@ package nethermind
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"os"
@@ -34,14 +35,20 @@ func nethImageRef() string {
 }
 
 // nethermindE2EConfigTemplate is the Nethermind config for the e2e suite
-// (boot + spamoor mining). Mirrors client/nethermind/testdata/configs/
-// sa-dev-v2.json but inlined here so the test is self-contained — written
-// into the datadir at runtime with the chainspec / DB paths plugged in,
-// so DinD mode (where the test container places state-actor data at
-// /data/<testName>/) and direct mode (/data) both resolve correctly.
+// (boot + engine-API-driven block production). Mirrors client/nethermind/
+// testdata/configs/sa-dev-v2.json but inlined here so the test is
+// self-contained — written into the datadir at runtime with the
+// chainspec / DB paths plugged in, so DinD mode (where the test
+// container places state-actor data at /data/<testName>/) and direct
+// mode (/data) both resolve correctly.
 //
-// Mining.Enabled = true and EnableUnsecuredDevWallet = true so spamoor's
-// --privkey deployer can submit txs and advance the chain.
+// Engine RPC on port 8551 + UnsecureDevNoRpcAuthentication=true is the
+// symmetric equivalent of besu's --engine-rpc-enabled / --engine-jwt-disabled.
+// EngineDriver (the mock CL in internal/oracle) connects there to drive
+// block production via engine_forkchoiceUpdated / getPayload / newPayload.
+// Merge.Enabled + TerminalTotalDifficulty=0 + the Ethash chainspec engine
+// (cf. ethereum/state-actor#56) make MergePlugin take over from
+// EthashPlugin so every block is engine-API-driven from genesis.
 //
 // Two %s placeholders, in order:
 //  1. ChainSpecPath  — full path to state-actor's parity-chainspec.json
@@ -72,7 +79,11 @@ const nethermindE2EConfigTemplate = `{
     "Timeout": 20000,
     "Host": "0.0.0.0",
     "Port": 8545,
-    "EnabledModules": ["Eth", "Net", "Web3"]
+    "EnabledModules": ["Eth", "Net", "Web3"],
+    "EngineHost": "0.0.0.0",
+    "EnginePort": 8551,
+    "EngineEnabledModules": ["Engine", "Eth", "Net", "Web3", "Subscribe"],
+    "UnsecureDevNoRpcAuthentication": true
   },
   "Metrics": {"Enabled": false},
   "Merge": {"Enabled": true, "TerminalTotalDifficulty": "0"},
@@ -85,7 +96,10 @@ const nethermindE2EConfigTemplate = `{
 //
 // nethermind-specific bits:
 //   - --fork=osaka (unified across all 4 clients after the writer migration to internal/genesisheader.Build)
-//   - inline boot.cfg with Mining.Enabled=true (NethDev produces blocks)
+//   - Ethash-from-genesis chainspec + Merge.Enabled → engine-API-driven block
+//     production via the EngineDriver mock CL (mirrors besu). NethDev was
+//     removed because it's not in MergePlugin's seal-engine allowlist
+//     (cf. state-actor#56).
 //   - SlotDuration=250ms in Phase 5 (matches smoke-nethermind-spamoor pacing)
 func TestE2ESuite(t *testing.T) {
 	if testing.Short() {
@@ -191,14 +205,35 @@ func TestE2ESuite(t *testing.T) {
 		t.Fatalf("RPC never came up (logs captured in t.Cleanup): %v", err)
 	}
 
-	// Phases 3-4 only — SkipBlockProduction because nethermind's NethDev
-	// consensus engine doesn't produce blocks on a post-Prague chain
-	// with the EIP-4788/2935/7002/7251 system contracts deployed in
-	// genesis state (cf. ethereum/state-actor#56). Phase 3 still
-	// captures the genesis stateRoot → result.json so the cross-client
-	// genesis-root aggregator CI gate runs as expected. Proper fix:
-	// switch nethermind e2e to the engine API + EngineDriver mock
-	// (same as besu).
+	// Mock CL: drive block production via engine API. Same pattern besu
+	// uses — NethDev was the old dev consensus engine but it's not in
+	// MergePlugin's seal-engine allowlist {BeaconChain, Clique, Ethash},
+	// so on a post-Prague chain with system contracts it silently fails
+	// to seal (state-actor#56). The Ethash-from-genesis chainspec + this
+	// driver replace NethDev's role. Runs as a goroutine for the rest of
+	// the test so spamoor's txs (Phase 5) get included in blocks.
+	driver := &oracle.EngineDriver{
+		EngineURL: "http://" + containerIP + ":8551",
+		EthRPCURL: rpcURL,
+		BlockTime: time.Second,
+		Fork:      oracle.ForkOsaka,
+	}
+	driverCtx, driverCancel := context.WithCancel(context.Background())
+	t.Cleanup(driverCancel)
+	go func() {
+		if err := driver.DriveLoop(driverCtx); err != nil && !errors.Is(err, context.Canceled) {
+			// Goroutine context — use t.Errorf (not t.Fatalf, which is
+			// not safe outside the test goroutine). DriveLoop only
+			// returns non-context-Canceled errors when something is
+			// permanently wrong (fetchLatestBlock at startup, or K
+			// consecutive Step failures); surfacing it loud lets the
+			// suite fail with the right diagnostic instead of timing
+			// out on spamoor's deadline.
+			t.Errorf("EngineDriver exited: %v", err)
+		}
+	}()
+
+	// Phases 3-7: shared via internal/oracle.RunSuitePhases.
 	oracle.RunSuitePhases(t, oracle.SuitePhasesCfg{
 		ClientName:          "nethermind",
 		RPCURL:              rpcURL,
@@ -206,6 +241,5 @@ func TestE2ESuite(t *testing.T) {
 		Contracts:           contracts,
 		GeneratorConfig:     &cfg,
 		SpamoorSlotDuration: 250 * time.Millisecond,
-		SkipBlockProduction: true,
 	})
 }

--- a/client/nethermind/testdata/chainspecs/sa-dev.json
+++ b/client/nethermind/testdata/chainspecs/sa-dev.json
@@ -2,8 +2,11 @@
 	"name": "StateActorDev",
 	"dataDir": "sa-dev",
 	"engine": {
-		"NethDev": {
+		"Ethash": {
 			"params": {
+				"minimumDifficulty": "0x1",
+				"difficultyBoundDivisor": "0x800",
+				"durationLimit": "0xd"
 			}
 		}
 	},
@@ -50,6 +53,7 @@
 		"eip4895TransitionTimestamp": "0x0",
 		"eip4788TransitionTimestamp": "0x0",
 		"eip4844TransitionTimestamp": "0x0",
+		"eip1153TransitionTimestamp": "0x0",
 		"eip5656TransitionTimestamp": "0x0",
 		"eip6780TransitionTimestamp": "0x0",
 		"eip2537TransitionTimestamp": "0x0",

--- a/client/nethermind/testdata/chainspecs/sa-dev.json
+++ b/client/nethermind/testdata/chainspecs/sa-dev.json
@@ -3,11 +3,7 @@
 	"dataDir": "sa-dev",
 	"engine": {
 		"Ethash": {
-			"params": {
-				"minimumDifficulty": "0x1",
-				"difficultyBoundDivisor": "0x800",
-				"durationLimit": "0xd"
-			}
+			"params": {}
 		}
 	},
 	"params": {

--- a/internal/oracle/engineapi.go
+++ b/internal/oracle/engineapi.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"strconv"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -368,4 +370,33 @@ func truncate(b []byte, n int) string {
 		return string(b)
 	}
 	return string(b[:n]) + "..."
+}
+
+// StartEngineDriver spins up an EngineDriver mock CL targeting the EL
+// at containerIP:8551 (engine-API standard port) and runs DriveLoop in a
+// background goroutine until the test's cleanup fires. Caller must
+// ensure the EL is up (e.g. via rpcprobe.WaitForRPC) and the engine
+// port is reachable from this process.
+func StartEngineDriver(t *testing.T, containerIP, rpcURL string, fork Fork) {
+	t.Helper()
+	driver := &EngineDriver{
+		EngineURL: "http://" + containerIP + ":8551",
+		EthRPCURL: rpcURL,
+		BlockTime: time.Second,
+		Fork:      fork,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() {
+		// Goroutine context — use t.Errorf (not t.Fatalf, which is
+		// not safe outside the test goroutine). DriveLoop only
+		// returns non-context-Canceled errors when something is
+		// permanently wrong (fetchLatestBlock at startup, or K
+		// consecutive Step failures); surfacing it loud lets the
+		// suite fail with the right diagnostic instead of timing
+		// out on spamoor's deadline.
+		if err := driver.DriveLoop(ctx); err != nil && !errors.Is(err, context.Canceled) {
+			t.Errorf("EngineDriver exited: %v", err)
+		}
+	}()
 }


### PR DESCRIPTION
## Summary

- **Closes #56**: NethDev is not in `MergePlugin.MergeEnabled`'s seal-engine allowlist (`{BeaconChain, Clique, Ethash}` per `Nethermind.Merge.Plugin/MergePlugin.cs:66-67`). Swapped chainspec to `engine: Ethash` + `terminalTotalDifficulty: 0` (Kiln/Kintsugi merge-from-genesis recipe) and wired `oracle.EngineDriver` in the e2e test mirroring besu's pattern. Phase 5-7 (spamoor) now runs end-to-end; `SkipBlockProduction: true` removed.
- **Closes #55**: `writeChainSpec` strips inactive-fork EIP keys from `params` based on `g.Config.{Cancun,Prague,Osaka}Time`. Adds missing `eip1153TransitionTimestamp` (Cancun transient storage — pre-existing template drift).

## Test plan

- [x] `go test ./client/nethermind/` — 8 new chainspec unit tests pass
- [x] `docker run state-actor-nethermind-builder:latest go test -tags cgo_neth ./client/nethermind/` — TestNethGoldenStateRoot + TestDifferentialOracle + TestWriteChainSpec_* all pass
- [ ] CI: `make test-nethermind-suite` — spamoor funds wallets, `PostSpamoorBlock > 0`
- [ ] CI: cross-client genesis-root invariant unchanged