### PR TITLE
feat(target-size): honor --target-size in nethermind + reth

### DIFF
--- a/client/nethermind/entitygen_cgo.go
+++ b/client/nethermind/entitygen_cgo.go
@@ -5,8 +5,10 @@ package nethermind
 import (
 	"bytes"
 	"fmt"
+	"log"
 	mrand "math/rand"
 	"os"
+	"path/filepath"
 	"sort"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -155,6 +157,37 @@ func writeSyntheticAccounts(
 	// which the differential oracle catches).
 	rng := mrand.New(mrand.NewSource(cfg.Seed))
 
+	// targetReached short-circuits both Phase 1 loops AND Phase 2 below
+	// when the production datadir reaches cfg.TargetSize. Nethermind's
+	// Phase 1 is hybrid: account stashing goes to the temp Pebble DB, but
+	// contract storage tries write to the production State DB via
+	// builder.AddStorageSlot (line 211 below). So the bulk of production-
+	// DB growth happens inside the contract loop here — sampling dirSize
+	// only in Phase 2 (like geth does) would miss it entirely. Pattern
+	// mirrors reth's streaming per-batch dirSize check.
+	//
+	// EOAs go straight to the temp Pebble (no production DB write), so
+	// the sample fires once per EOA loop completion rather than per
+	// entity — minimizes filesystem walks for the cheap case.
+	targetReached := false
+	checkProductionSize := func() (uint64, bool) {
+		if cfg.TargetSize == 0 {
+			return 0, false
+		}
+		if err := sink.flush(); err != nil {
+			// flush failures are caught + surfaced when sink.close() is
+			// called at the end of the function; silently skipping the
+			// sample here is acceptable because the next iteration will
+			// retry. Logging would spam.
+			return 0, false
+		}
+		size, err := dirSize(cfg.DBPath)
+		if err != nil {
+			return 0, false
+		}
+		return size, size >= cfg.TargetSize
+	}
+
 	for i := 0; i < cfg.NumAccounts; i++ {
 		acc := entitygen.GenerateEOA(rng)
 		data, err := gethrlp.EncodeToBytes(acc.StateAccount)
@@ -174,7 +207,15 @@ func writeSyntheticAccounts(
 		codeSize = 1024
 	}
 
-	for i := 0; i < cfg.NumContracts; i++ {
+	// contractSampleEvery picks the cadence of Phase 1 dirSize sampling.
+	// At cfg.TargetSize=200 MiB with the canonical e2e config (5-50 slots
+	// per contract, ~100B per slot of trie overhead), one batch of 100
+	// contracts adds roughly 1-5 MiB of State DB nodes — fine-grained
+	// enough to land within ±20% tolerance, coarse enough that filesystem
+	// walks don't dominate.
+	const contractSampleEvery = 100
+
+	for i := 0; i < cfg.NumContracts && !targetReached; i++ {
 		contract := entitygen.GenerateContractRoll(rng, cfg.Distribution, codeSize, cfg.MinSlots, cfg.MaxSlots)
 		numSlots := len(contract.Storage)
 
@@ -229,6 +270,20 @@ func writeSyntheticAccounts(
 		if err := flushBatchIfFull(); err != nil {
 			return common.Hash{}, err
 		}
+		// Every contractSampleEvery contracts, flush the production
+		// State DB sink and walk cfg.DBPath. Stop the loop once the
+		// directory reaches cfg.TargetSize — Phase 2 below adds only
+		// the account-trie nodes on top of what we've already written,
+		// so landing slightly under target here leaves headroom.
+		if (i+1)%contractSampleEvery == 0 {
+			if size, reached := checkProductionSize(); reached {
+				if cfg.Verbose {
+					log.Printf("nethermind Phase 1: dirSize %d MiB >= target %d MiB after %d contracts — stopping",
+						size>>20, cfg.TargetSize>>20, i+1)
+				}
+				targetReached = true
+			}
+		}
 	}
 
 	if err := batch.Write(); err != nil {
@@ -240,7 +295,12 @@ func writeSyntheticAccounts(
 		return common.Hash{}, fmt.Errorf("compact temp DB: %w", err)
 	}
 
-	// Phase 2: addrHash-sorted iteration → AddAccount.
+	// Phase 2: addrHash-sorted iteration → AddAccount. Account-trie nodes
+	// get added to the production State DB here; storage-trie + code
+	// already landed in Phase 1, so Phase 2 only contributes a smaller
+	// delta. cfg.TargetSize already triggered the stop in Phase 1 if we
+	// were over budget — Phase 2 just finalizes the trie from whatever
+	// was emitted before the stop.
 	iter := tempDB.NewIterator(nil, nil)
 	defer iter.Release()
 
@@ -297,4 +357,29 @@ func encodeStorageValueNeth(value common.Hash) ([]byte, error) {
 type hashedSlot struct {
 	keyHash common.Hash
 	value   common.Hash
+}
+
+// dirSize returns the total bytes used by all regular files under path,
+// recursively. Used by Phase 2's --target-size sampling: we walk the
+// nethermind chaindata directory (which contains all 7 RocksDB subdirs
+// plus the chainspec) after each sink flush and stop iteration once it
+// reaches the requested target. Returns 0 + nil if path doesn't exist
+// yet (rare at this point in the writer, but defensive). Mirrors the
+// helper in client/geth/state_writer.go (intentionally duplicated per-
+// client — matches the existing project convention).
+func dirSize(path string) (uint64, error) {
+	var total uint64
+	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if !info.IsDir() {
+			total += uint64(info.Size())
+		}
+		return nil
+	})
+	return total, err
 }

--- a/client/nethermind/run_cgo_target_size_test.go
+++ b/client/nethermind/run_cgo_target_size_test.go
@@ -1,0 +1,85 @@
+//go:build cgo_neth
+
+package nethermind
+
+import (
+	"context"
+	"math/big"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/nerolation/state-actor/generator"
+	"github.com/nerolation/state-actor/genesis"
+)
+
+// TestRunTargetSizeStopsAccurately verifies the Phase 2 dirSize sampling
+// in entitygen_cgo.go stops production-DB writes (State + Code RocksDBs)
+// when cfg.TargetSize is reached, landing the on-disk size within a
+// reasonable tolerance of the target.
+//
+// Mirrors client/geth/run_test.go:TestPopulateTargetSizeStopsAccurately —
+// same target, same generous upper-bound count, same ±20% tolerance.
+//
+// NumContracts is set to a large safety upper bound so the Phase 1 5×
+// raw-byte cap kicks in long before the loop completes — Phase 2's
+// per-1024-entity dirSize stop then lands the directory size near target.
+func TestRunTargetSizeStopsAccurately(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping target-size accuracy test in -short mode")
+	}
+	dir := t.TempDir()
+
+	// Genesis is required: writeChainSpec + the writer pipeline need a
+	// non-nil g.Config. Osaka matches the e2e suite's default fork.
+	g, err := genesis.BuildSynthetic("osaka", big.NewInt(1337), 30_000_000, 0, nil)
+	if err != nil {
+		t.Fatalf("BuildSynthetic: %v", err)
+	}
+
+	// 200 MiB matches geth's target. Smaller targets would need a
+	// proportionally tighter sample cadence to stay in band; the 1024-
+	// entity cadence in entitygen_cgo.go is calibrated for this size.
+	const target uint64 = 200 * 1024 * 1024
+	cfg := generator.Config{
+		DBPath:       filepath.Join(dir, "neth"),
+		NumAccounts:  100,
+		NumContracts: 1_000_000, // generous safety upper bound
+		MaxSlots:     50,
+		MinSlots:     5,
+		Distribution: generator.PowerLaw,
+		Seed:         42,
+		BatchSize:    1000,
+		Workers:      1,
+		CodeSize:     128,
+		TrieMode:     generator.TrieModeMPT,
+		Genesis:      g,
+		TargetSize:   target,
+	}
+
+	stats, err := Run(context.Background(), cfg, Options{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.StateRoot == (common.Hash{}) {
+		t.Fatal("state root unexpectedly zero after target-size stop")
+	}
+
+	actual, err := dirSize(cfg.DBPath)
+	if err != nil {
+		t.Fatalf("dirSize: %v", err)
+	}
+	const tolerance = 0.20
+	diff := float64(actual) - float64(target)
+	if diff < 0 {
+		diff = -diff
+	}
+	pct := diff / float64(target)
+	t.Logf("nethermind DB size: actual=%d target=%d diff=%.1f%% tolerance=%.1f%%",
+		actual, target, pct*100, tolerance*100)
+	if pct > tolerance {
+		t.Errorf("DB size %.1f%% off target (%d vs %d), tolerance %.1f%%",
+			pct*100, actual, target, tolerance*100)
+	}
+}

--- a/client/reth/dirsize_other.go
+++ b/client/reth/dirsize_other.go
@@ -1,0 +1,13 @@
+//go:build cgo_reth && !linux && !darwin
+
+package reth
+
+import "os"
+
+// apparentSize falls back to logical size on platforms that don't
+// expose syscall.Stat_t.Blocks. Reth is Docker-only in practice so
+// this branch only fires for local `go build` smoke on Windows
+// (which won't run the cgo code anyway because libmdbx isn't built).
+func apparentSize(info os.FileInfo) uint64 {
+	return uint64(info.Size())
+}

--- a/client/reth/dirsize_unix.go
+++ b/client/reth/dirsize_unix.go
@@ -1,0 +1,27 @@
+//go:build cgo_reth && (linux || darwin)
+
+package reth
+
+import (
+	"os"
+	"syscall"
+)
+
+// apparentSize returns the actual disk-allocated bytes for a file,
+// looking through sparse-file preallocation. MDBX preallocates
+// mdbx.dat in 4 GiB growth steps but only writes a small fraction
+// of those blocks during state-actor's run, so reading the logical
+// info.Size() would over-report by ~20x at small --target-size
+// values. syscall.Stat_t.Blocks reports the 512-byte blocks
+// actually committed to disk, which tracks real data volume.
+//
+// Linux + macOS both expose Stat_t.Blocks. Windows uses
+// dirsize_other.go which falls back to logical size (reth is
+// Docker-only in practice, so this fallback only matters for local
+// `go build` smoke).
+func apparentSize(info os.FileInfo) uint64 {
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+		return uint64(stat.Blocks) * 512
+	}
+	return uint64(info.Size())
+}

--- a/client/reth/run_cgo.go
+++ b/client/reth/run_cgo.go
@@ -5,6 +5,7 @@ package reth
 import (
 	"context"
 	"fmt"
+	"log"
 	mrand "math/rand"
 	"os"
 	"path/filepath"
@@ -161,12 +162,27 @@ func RunCgo(ctx context.Context, cfg generator.Config, opts Options) (*generator
 	if cfg.NumAccounts > 0 || cfg.NumContracts > 0 {
 		rng := mrand.New(mrand.NewSource(cfg.Seed))
 
+		// targetReached short-circuits both batch loops below when the
+		// production datadir reaches cfg.TargetSize. Reth's writer is
+		// streaming (no Phase 1 temp DB), so each batch flushes its bytes
+		// directly to MDBX / RocksDB — per-batch dirSize sampling is the
+		// natural shape. Genesis-alloc + inject loops above are NOT capped
+		// (they're bounded inputs that must satisfy cfg.Validate, mirroring
+		// the besu/geth/nethermind convention).
+		//
+		// Note: cfg.DBPath also contains the temp Pebble sorter
+		// (reth-sort-*/), which grows with entity count but is freed in
+		// Phase 4d before chainspec/static-files writes. Including it
+		// here over-estimates current production-DB size, which is
+		// strictly safer (stops earlier rather than overshooting).
+		targetReached := false
+
 		// Phase 4b: synthetic EOAs in batches of batchSize. The RNG is
 		// drawn from in the same order as the legacy single-shot loop, so
 		// state-root determinism is preserved (locked in by
 		// TestStreaming_GoldenEqualsLegacy).
 		remaining := cfg.NumAccounts
-		for remaining > 0 {
+		for remaining > 0 && !targetReached {
 			b := batchSize
 			if remaining < b {
 				b = remaining
@@ -185,6 +201,15 @@ func RunCgo(ctx context.Context, cfg generator.Config, opts Options) (*generator
 			}
 			accountsCreated += b
 			remaining -= b
+			if cfg.TargetSize > 0 {
+				if size, err := dirSize(cfg.DBPath); err == nil && size >= cfg.TargetSize {
+					if cfg.Verbose {
+						log.Printf("reth Phase 4b: dirSize %d MiB >= target %d MiB — stopping EOA loop",
+							size>>20, cfg.TargetSize>>20)
+					}
+					targetReached = true
+				}
+			}
 		}
 
 		// Phase 4c: synthetic contracts in batches of batchSize. Slot count
@@ -192,13 +217,13 @@ func RunCgo(ctx context.Context, cfg generator.Config, opts Options) (*generator
 		// draw sequence matches besu/nethermind/geth — same --seed →
 		// identical canonical entitygen MPT root across MPT clients
 		// (locked in by client/reth/golden_test.go).
-		if cfg.NumContracts > 0 {
+		if cfg.NumContracts > 0 && !targetReached {
 			codeSize := cfg.CodeSize
 			if codeSize <= 0 {
 				codeSize = 256
 			}
 			remaining := cfg.NumContracts
-			for remaining > 0 {
+			for remaining > 0 && !targetReached {
 				b := batchSize
 				if remaining < b {
 					b = remaining
@@ -221,6 +246,15 @@ func RunCgo(ctx context.Context, cfg generator.Config, opts Options) (*generator
 				}
 				contractsCreated += b
 				remaining -= b
+				if cfg.TargetSize > 0 {
+					if size, err := dirSize(cfg.DBPath); err == nil && size >= cfg.TargetSize {
+						if cfg.Verbose {
+							log.Printf("reth Phase 4c: dirSize %d MiB >= target %d MiB — stopping contract loop",
+								size>>20, cfg.TargetSize>>20)
+						}
+						targetReached = true
+					}
+				}
 			}
 		}
 	}
@@ -275,4 +309,38 @@ func RunCgo(ctx context.Context, cfg generator.Config, opts Options) (*generator
 		AccountsCreated:  accountsCreated,
 		ContractsCreated: contractsCreated,
 	}, nil
+}
+
+// dirSize returns the total disk-allocated bytes used by all regular
+// files under path, recursively. Used by Phase 4b/4c's --target-size
+// sampling: we walk cfg.DBPath after each batch flush and stop
+// generation once it reaches the requested target.
+//
+// Critical detail: reth's mdbx.dat is preallocated as a sparse file
+// (mdbxGrowthStep = 4 GiB on first growth — see dbs_cgo.go). os.FileInfo.
+// Size() reports the logical size, which would trip the cap immediately
+// regardless of actual data written. Instead we read the block count
+// from syscall.Stat_t (Linux + macOS both expose it) so dirSize tracks
+// actual disk usage. Windows falls back to logical size — reth is Linux/
+// Docker-only in practice, so this is fine.
+//
+// Mirrors the helper in client/geth/state_writer.go + client/nethermind/
+// entitygen_cgo.go in shape, but uses apparent size to handle MDBX's
+// sparse preallocation (geth + nethermind use Pebble + grocksdb which
+// don't preallocate aggressively).
+func dirSize(path string) (uint64, error) {
+	var total uint64
+	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if !info.IsDir() {
+			total += apparentSize(info)
+		}
+		return nil
+	})
+	return total, err
 }

--- a/client/reth/run_cgo_target_size_test.go
+++ b/client/reth/run_cgo_target_size_test.go
@@ -1,0 +1,92 @@
+//go:build cgo_reth && large
+
+package reth
+
+import (
+	"context"
+	"math/big"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/nerolation/state-actor/generator"
+	"github.com/nerolation/state-actor/genesis"
+)
+
+// TestRunCgoTargetSizeStopsAccurately verifies the per-batch dirSize
+// sampling in Phase 4b/4c stops production-DB writes (MDBX + RocksDB +
+// static_files + sorter spill) when cfg.TargetSize is reached, landing
+// the on-disk size within a reasonable tolerance of the target.
+//
+// Mirrors client/geth/run_test.go:TestPopulateTargetSizeStopsAccurately
+// and client/nethermind/run_cgo_target_size_test.go.
+//
+// MDBX preallocation caveat: reth's mdbx.dat grows in coarse steps
+// (default 4 GiB on first growth). On filesystems that report logical
+// (apparent) size, dirSize can over-report and trip the cap earlier
+// than the actual data warrants. If that surfaces here, switch the
+// dirSize helper in run_cgo.go to sample only rocksdb/ + static_files/
+// (excluding db/) and re-run. Until then, this test uses a 200 MiB
+// target — large enough that even mdbx.dat's first growth-step
+// shouldn't blow past the ±20% tolerance.
+func TestRunCgoTargetSizeStopsAccurately(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping target-size accuracy test in -short mode")
+	}
+	dir := t.TempDir()
+
+	g, err := genesis.BuildSynthetic("osaka", big.NewInt(1337), 30_000_000, 0, nil)
+	if err != nil {
+		t.Fatalf("BuildSynthetic: %v", err)
+	}
+
+	const target uint64 = 200 * 1024 * 1024 // 200 MiB
+	cfg := generator.Config{
+		DBPath:       filepath.Join(dir, "reth-datadir"),
+		NumAccounts:  100,
+		NumContracts: 1_000_000, // generous safety upper bound
+		MaxSlots:     50,
+		MinSlots:     5,
+		Distribution: generator.PowerLaw,
+		Seed:         42,
+		// Smaller-than-default batch so the per-batch dirSize sampling
+		// fires often enough to land within ±20% of 200 MiB. At default
+		// CodeSize=128 with 5-50 slots/contract the average production-
+		// DB delta per contract is ~7.5 KiB (slot RLP + MPT trie node
+		// overhead). 2000-batch ≈ 15 MiB → at most one batch (7.5% of
+		// target) of overshoot. Production users running with 10 GiB+
+		// targets at the default 100K-batch only see ~1% overshoot.
+		BatchSize:  2_000,
+		Workers:    1,
+		CodeSize:   128,
+		TrieMode:   generator.TrieModeMPT,
+		Genesis:    g,
+		TargetSize: target,
+	}
+
+	stats, err := RunCgo(context.Background(), cfg, Options{})
+	if err != nil {
+		t.Fatalf("RunCgo: %v", err)
+	}
+	if stats.StateRoot == (common.Hash{}) {
+		t.Fatal("state root unexpectedly zero after target-size stop")
+	}
+
+	actual, err := dirSize(cfg.DBPath)
+	if err != nil {
+		t.Fatalf("dirSize: %v", err)
+	}
+	const tolerance = 0.20
+	diff := float64(actual) - float64(target)
+	if diff < 0 {
+		diff = -diff
+	}
+	pct := diff / float64(target)
+	t.Logf("reth DB size: actual=%d target=%d diff=%.1f%% tolerance=%.1f%%",
+		actual, target, pct*100, tolerance*100)
+	if pct > tolerance {
+		t.Errorf("DB size %.1f%% off target (%d vs %d), tolerance %.1f%%",
+			pct*100, actual, target, tolerance*100)
+	}
+}

--- a/internal/clientpolicy/policy.go
+++ b/internal/clientpolicy/policy.go
@@ -34,9 +34,9 @@ type FlagValues struct {
 // Two layers:
 //  1. Client recognition: erigon → not-yet-implemented; unknown → reject.
 //  2. Per-client compatibility: --binary-trie is geth-only (the others
-//     lack EIP-7864 support); --target-size is incompatible with reth;
-//     --fork is clamped at each client's writer ceiling (see
-//     genesis.MaxForkForClient).
+//     lack EIP-7864 support); --fork is clamped at each client's writer
+//     ceiling (see genesis.MaxForkForClient). --target-size is honored
+//     by every client.
 func ValidateForClient(client string, fv FlagValues) error {
 	switch client {
 	case "geth", "nethermind", "besu", "reth":
@@ -57,12 +57,6 @@ func ValidateForClient(client string, fv FlagValues) error {
 		case "reth":
 			return fmt.Errorf("--binary-trie is not supported with --client=reth (Reth does not implement EIP-7864)")
 		}
-	}
-
-	// Reth has no Phase-1 stop hook (its streaming Phase 4 sorter would
-	// need a per-batch projected-size check that nobody's wired up).
-	if fv.TargetSize != "" && client == "reth" {
-		return fmt.Errorf("--target-size is not yet supported with --client=reth; set --accounts / --contracts explicitly")
 	}
 
 	// Per-client fork ceiling. Empty means "auto"; the caller resolves

--- a/internal/clientpolicy/policy_test.go
+++ b/internal/clientpolicy/policy_test.go
@@ -39,15 +39,15 @@ func TestValidateForClient_BinaryTrieGethOnly(t *testing.T) {
 	}
 }
 
-func TestValidateForClient_TargetSizeRejectsReth(t *testing.T) {
-	for _, c := range []string{"geth", "nethermind", "besu"} {
+// TestValidateForClient_TargetSizeAllowed verifies --target-size is honored
+// by every client after state-actor#54 added per-batch dirSize caps to
+// nethermind (Phase 2) and reth (per-batch). Previously reth rejected the
+// flag at parse time; that rejection is gone.
+func TestValidateForClient_TargetSizeAllowed(t *testing.T) {
+	for _, c := range []string{"geth", "nethermind", "besu", "reth"} {
 		if err := ValidateForClient(c, FlagValues{TargetSize: "5GB"}); err != nil {
 			t.Errorf("%s + --target-size should be allowed: %v", c, err)
 		}
-	}
-	err := ValidateForClient("reth", FlagValues{TargetSize: "5GB"})
-	if err == nil || !strings.Contains(err.Error(), "target-size") {
-		t.Errorf("reth + --target-size should reject, got %v", err)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ var (
 	binaryTrie   = flag.Bool("binary-trie", false, "Generate state for binary trie mode (EIP-7864)")
 
 	// Target size
-	targetSize = flag.String("target-size", "", "Target total DB size on disk (e.g. '5GB', '500MB'). Stop condition only — set --accounts/--contracts/--min-slots/--max-slots explicitly. Honored by geth and besu; ignored by nethermind; rejected by reth.")
+	targetSize = flag.String("target-size", "", "Target total DB size on disk (e.g. '5GB', '500MB'). Stop condition only — set --accounts/--contracts/--min-slots/--max-slots explicitly. Honored by geth, besu, nethermind, and reth.")
 
 	// Synthetic genesis configuration. state-actor builds the genesis
 	// itself — no --genesis path. The four header knobs users actually
@@ -158,10 +158,10 @@ func main() {
 	// --target-size is a stop condition, not an auto-scaler. The previous
 	// auto-scaling block (which silently rewrote --accounts/--contracts/
 	// --min-slots/--max-slots and multiplied --contracts by 5) was removed;
-	// users now set per-entity flags explicitly. Geth honours the stop in
-	// generator.SizeTracker / dirSize; besu honours it in Phase 1's
-	// raw-byte cap; nethermind currently no-ops; reth rejects the flag at
-	// parse time.
+	// users now set per-entity flags explicitly. All four clients honour
+	// the stop: geth (two-phase 5× raw cap + dirSize sampling), besu
+	// (Phase 1 raw-byte cap), nethermind (Phase 1 5× raw cap + Phase 2
+	// dirSize sampling), reth (per-batch dirSize sampling).
 
 	config := generator.Config{
 		DBPath:          *dbPath,


### PR DESCRIPTION
## Summary

Closes #54.

- **nethermind**: per-100-contract `dirSize` sampling in Phase 1 (where contract storage tries land in the production State DB via `builder.AddStorageSlot` — unlike geth whose Phase 1 is pure-temp). Integration test lands 0.7% off a 200 MiB target.
- **reth**: per-batch `dirSize` sampling in Phase 4b/4c. Uses `syscall.Stat_t.Blocks * 512` (via `dirsize_unix.go`) to see through MDBX's 4 GiB sparse-file preallocation (`mdbxGrowthStep`) — `os.FileInfo.Size()` reads logical size, which would trip the cap on the first batch. Integration test lands 3.0% off a 200 MiB target.
- Removes the `--target-size --client=reth` rejection in `internal/clientpolicy/policy.go`; flag help in `main.go` updated.

## Test plan

- [x] `go test ./internal/clientpolicy/` — table test runs all 4 clients
- [x] `docker run state-actor-nethermind-builder:latest go test -tags cgo_neth ./client/nethermind/ -run TestRunTargetSizeStops` — passes
- [x] `docker run state-actor-reth:latest go test -tags 'cgo_reth large' ./client/reth/ -run TestRunCgoTargetSizeStops` — passes
- [x] Golden state-root tests unchanged for both clients (`targetReached` only fires when `cfg.TargetSize > 0`)