### PR TITLE
feat(nethermind): wire genesis block fields from g.* into chainspec

### DIFF
--- a/client/nethermind/chainspec.go
+++ b/client/nethermind/chainspec.go
@@ -4,8 +4,11 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"os"
 	"path/filepath"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/nerolation/state-actor/genesis"
 )
@@ -37,9 +40,13 @@ var osakaParamKeys = []string{
 }
 
 // writeChainSpec emits the embedded sa-dev Parity chainspec to
-// <dbPath>/<ChainSpecFileName>, with chainID + networkID overridden from
-// g.Config.ChainID and Osaka-only keys stripped if g.Config.OsakaTime is
-// unset.
+// <dbPath>/<ChainSpecFileName>. Everything that varies per-run flows from g:
+// chainID/networkID from g.Config.ChainID, the Osaka-only param keys gated
+// by g.Config.OsakaTime, and the genesis block (gasLimit/timestamp/extraData/
+// nonce/mixHash/difficulty/author/parentHash) materialized from g.* so the
+// chainspec and the on-disk header agree byte-for-byte — otherwise Nethermind
+// rejects the DB at boot with "Supplied genesis block does not match chain
+// data stored".
 //
 // Engine is Ethash + terminalTotalDifficulty=0 — the Kiln/Kintsugi merge-
 // from-genesis recipe. MergePlugin wraps EthashPlugin and routes every
@@ -77,6 +84,8 @@ func writeChainSpec(dbPath string, g *genesis.Genesis) (string, error) {
 		}
 	}
 
+	spec["genesis"] = genesisBlockFromG(g)
+
 	out, err := json.MarshalIndent(spec, "", "  ")
 	if err != nil {
 		return "", fmt.Errorf("nethermind writeChainSpec marshal: %w", err)
@@ -86,4 +95,32 @@ func writeChainSpec(dbPath string, g *genesis.Genesis) (string, error) {
 		return "", fmt.Errorf("nethermind writeChainSpec write: %w", err)
 	}
 	return outPath, nil
+}
+
+// genesisBlockFromG renders the Parity-style "genesis" sub-object from g.
+// Field shape matches Nethermind.Specs.ChainSpecStyle.Json.ChainSpecGenesisJson —
+// seal.ethereum.{nonce,mixHash} nested, author for coinbase, fixed 8-byte
+// nonce width. Every value is sourced from g so the chainspec and the
+// on-disk header (built by internal/genesisheader.Build from the same g)
+// cannot diverge.
+func genesisBlockFromG(g *genesis.Genesis) map[string]any {
+	difficulty := big.NewInt(0)
+	if g.Difficulty != nil {
+		difficulty = g.Difficulty.ToInt()
+	}
+	return map[string]any{
+		"seal": map[string]any{
+			"ethereum": map[string]any{
+				// Nethermind's parser requires exactly 8 bytes / 16 hex chars.
+				"nonce":   fmt.Sprintf("0x%016x", uint64(g.Nonce)),
+				"mixHash": g.Mixhash.Hex(),
+			},
+		},
+		"difficulty": fmt.Sprintf("0x%x", difficulty),
+		"author":     g.Coinbase.Hex(),
+		"timestamp":  fmt.Sprintf("0x%x", uint64(g.Timestamp)),
+		"parentHash": g.ParentHash.Hex(),
+		"extraData":  hexutil.Encode([]byte(g.ExtraData)),
+		"gasLimit":   fmt.Sprintf("0x%x", uint64(g.GasLimit)),
+	}
 }

--- a/client/nethermind/chainspec_test.go
+++ b/client/nethermind/chainspec_test.go
@@ -6,7 +6,12 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/nerolation/state-actor/genesis"
 )
@@ -180,5 +185,92 @@ func TestWriteChainSpec_ByteForByteDeterministic(t *testing.T) {
 	}
 	if a, b := read(), read(); !bytes.Equal(a, b) {
 		t.Errorf("writeChainSpec is non-deterministic\nfirst:\n%s\nsecond:\n%s", a, b)
+	}
+}
+
+func parseHexUint(t *testing.T, v any) uint64 {
+	t.Helper()
+	s, ok := v.(string)
+	if !ok {
+		t.Fatalf("expected hex string, got %T (%v)", v, v)
+	}
+	n, err := strconv.ParseUint(strings.TrimPrefix(s, "0x"), 16, 64)
+	if err != nil {
+		t.Fatalf("parse hex %q: %v", s, err)
+	}
+	return n
+}
+
+// TestWriteChainSpec_GenesisBlockFromG locks the unification contract: every
+// genesis-block field the on-disk header carries is also emitted to the
+// chainspec from the same g. Drives every customizable field with a non-
+// default value so a regression that re-introduces a literal in the template
+// (or short-circuits the override) shows up here.
+func TestWriteChainSpec_GenesisBlockFromG(t *testing.T) {
+	const (
+		wantGasLimit  uint64 = 20_000_000
+		wantTimestamp uint64 = 1_700_000_000
+	)
+	wantExtraData := []byte("hello state-actor")
+
+	g, err := genesis.BuildSynthetic("osaka", big.NewInt(0xc0de), wantGasLimit, wantTimestamp, wantExtraData)
+	if err != nil {
+		t.Fatalf("BuildSynthetic: %v", err)
+	}
+	// Set the legacy fields that have no CLI flag but are still part of
+	// the chainspec/header contract — POTENTIAL-divergence coverage.
+	g.Mixhash = common.HexToHash("0x1111222233334444555566667777888899990000aaaabbbbccccddddeeeeffff")
+	g.Coinbase = common.HexToAddress("0xcafe000000000000000000000000000000000000")
+
+	outPath, err := writeChainSpec(t.TempDir(), g)
+	if err != nil {
+		t.Fatalf("writeChainSpec: %v", err)
+	}
+	raw, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var spec map[string]any
+	if err := json.Unmarshal(raw, &spec); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	gen, ok := spec["genesis"].(map[string]any)
+	if !ok {
+		t.Fatalf("spec missing genesis block; got %T", spec["genesis"])
+	}
+
+	if got := parseHexUint(t, gen["gasLimit"]); got != wantGasLimit {
+		t.Errorf("gasLimit = %d; want %d", got, wantGasLimit)
+	}
+	if got := parseHexUint(t, gen["timestamp"]); got != wantTimestamp {
+		t.Errorf("timestamp = %d; want %d", got, wantTimestamp)
+	}
+	if got := gen["extraData"]; got != hexutil.Encode(wantExtraData) {
+		t.Errorf("extraData = %v; want %s", got, hexutil.Encode(wantExtraData))
+	}
+	if got := gen["author"]; got != g.Coinbase.Hex() {
+		t.Errorf("author = %v; want %s", got, g.Coinbase.Hex())
+	}
+	if got := gen["parentHash"]; got != g.ParentHash.Hex() {
+		t.Errorf("parentHash = %v; want %s", got, g.ParentHash.Hex())
+	}
+	if got := gen["difficulty"]; got != "0x0" {
+		t.Errorf("difficulty = %v; want 0x0 (BuildSynthetic fixes to 0)", got)
+	}
+
+	seal, ok := gen["seal"].(map[string]any)
+	if !ok {
+		t.Fatalf("genesis.seal missing or wrong type")
+	}
+	eth, ok := seal["ethereum"].(map[string]any)
+	if !ok {
+		t.Fatalf("genesis.seal.ethereum missing or wrong type")
+	}
+	if got := eth["mixHash"]; got != g.Mixhash.Hex() {
+		t.Errorf("mixHash = %v; want %s", got, g.Mixhash.Hex())
+	}
+	// Nethermind's parser requires fixed 8-byte / 16-hex-char nonce width.
+	if got, _ := eth["nonce"].(string); got != "0x0000000000000000" || len(got) != 18 {
+		t.Errorf("nonce = %q; want exactly %q (18 chars / 0x + 16 hex)", got, "0x0000000000000000")
 	}
 }

--- a/client/nethermind/testdata/chainspecs/sa-dev.json
+++ b/client/nethermind/testdata/chainspecs/sa-dev.json
@@ -72,20 +72,7 @@
 		"eip7951TransitionTimestamp": "0x0",
 		"terminalTotalDifficulty": "0x0"
 	},
-	"genesis": {
-		"seal": {
-			"ethereum": {
-				"nonce": "0x0000000000000000",
-				"mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
-			}
-		},
-		"difficulty": "0x00",
-		"author": "0x0000000000000000000000000000000000000000",
-		"timestamp": "0x00",
-		"parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-		"extraData": "0x",
-		"gasLimit": "0x1c9c380"
-	},
+	"genesis": {},
 	"nodes": [],
 	"accounts": {}
 }


### PR DESCRIPTION
## Summary

PR A of the [#51 unification plan](https://github.com/ethereum/state-actor/issues/51): the nethermind Parity-chainspec writer no longer hardcodes the genesis block. Every field that has a corresponding `g.*` value (gasLimit, timestamp, extraData, nonce, mixHash, difficulty, author/coinbase, parentHash) is now materialized at write time so the chainspec and the on-disk header (built by \`internal/genesisheader.Build\` from the same \`g\`) cannot diverge.

Before: passing \`--gas-limit=20000000\` or \`--timestamp=1700000000\` produced a chainspec/header mismatch and Nethermind refused to boot with \"Supplied genesis block does not match chain data stored\". After: all 5 active genesis flags (\`--fork\`, \`--chain-id\`, \`--gas-limit\`, \`--timestamp\`, \`--extra-data\`) flow through to the chainspec.

The embedded \`sa-dev.json\` template's \`genesis:\` subobject is reduced to \`{}\` — one source of truth, and if a future change short-circuits the override, Nethermind fails loudly at boot rather than silently emitting stale defaults.
