### PR TITLE
feat(besu): wire mixHash and coinbase from g.* into chainspec

### DIFF
--- a/client/besu/chainspec.go
+++ b/client/besu/chainspec.go
@@ -129,8 +129,8 @@ func writeChainSpec(dbPath string, g *genesis.Genesis) (string, error) {
 		"extraData":  extraDataHex,
 		"gasLimit":   fmt.Sprintf("0x%x", gasLimit),
 		"difficulty": diffHex,
-		"mixHash":    "0x0000000000000000000000000000000000000000000000000000000000000000",
-		"coinbase":   "0x0000000000000000000000000000000000000000",
+		"mixHash":    g.Mixhash.Hex(),
+		"coinbase":   g.Coinbase.Hex(),
 		"alloc":      map[string]any{},
 	}
 	if baseFeeHex != "" {

--- a/client/besu/chainspec_test.go
+++ b/client/besu/chainspec_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/nerolation/state-actor/genesis"
 )
 
@@ -109,5 +111,39 @@ func TestChainSpec_RejectsPrePrague(t *testing.T) {
 	}
 	if _, err := writeChainSpec(t.TempDir(), g); err == nil {
 		t.Error("writeChainSpec should reject genesis without post-Prague config")
+	}
+}
+
+// TestChainSpec_MixHashAndCoinbaseFromG locks the unification contract: the
+// chainspec writer reads mixHash and coinbase from g rather than hardcoding
+// zero literals. The shared header builder (internal/genesisheader.Build)
+// already reads g.Mixhash and g.Coinbase, so a non-zero value here would
+// otherwise produce a chainspec/header divergence that breaks besu boot.
+func TestChainSpec_MixHashAndCoinbaseFromG(t *testing.T) {
+	g, err := genesis.BuildSynthetic("osaka", big.NewInt(1337), 30_000_000, 0, nil)
+	if err != nil {
+		t.Fatalf("BuildSynthetic: %v", err)
+	}
+	g.Mixhash = common.HexToHash("0x1111222233334444555566667777888899990000aaaabbbbccccddddeeeeffff")
+	g.Coinbase = common.HexToAddress("0xcafe000000000000000000000000000000000000")
+
+	path, err := writeChainSpec(t.TempDir(), g)
+	if err != nil {
+		t.Fatalf("writeChainSpec: %v", err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var spec map[string]any
+	if err := json.Unmarshal(b, &spec); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if got := spec["mixHash"]; got != g.Mixhash.Hex() {
+		t.Errorf("mixHash = %v; want %s", got, g.Mixhash.Hex())
+	}
+	if got := spec["coinbase"]; got != g.Coinbase.Hex() {
+		t.Errorf("coinbase = %v; want %s", got, g.Coinbase.Hex())
 	}
 }


### PR DESCRIPTION
## Summary

PR B of the [#51 unification plan](https://github.com/ethereum/state-actor/issues/51). The besu chainspec writer was the only remaining holdout with hardcoded zero literals for two header fields:

```go
// client/besu/chainspec.go:132-133 (before)
"mixHash":    "0x0000000000000000000000000000000000000000000000000000000000000000",
"coinbase":   "0x0000000000000000000000000000000000000000",
```

Meanwhile `internal/genesisheader.Build` (used by all 3 non-geth clients) already reads `g.Mixhash` and `g.Coinbase`. The literals matched the defaults today because `BuildSynthetic` doesn't surface flags for these fields, but any caller that sets them non-zero — including `genesis.LoadGenesis` from a fixture file — would have triggered a chainspec/header mismatch and a boot failure.

Both fields now read from `g.<Field>.Hex()`, matching the pattern besu's writer uses for every other header field.