### PR TITLE
feat(reth): zero-coalesce Cancun blob-gas fields in chainspec

### DIFF
--- a/client/reth/chainspec.go
+++ b/client/reth/chainspec.go
@@ -3,6 +3,7 @@ package reth
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"os"
 
 	"github.com/nerolation/state-actor/genesis"
@@ -37,6 +38,20 @@ func writeChainSpec(g *genesis.Genesis, outPath string) error {
 	// "no genesis accounts in chainspec" rather than tripping on a missing
 	// required field.
 	spec["alloc"] = map[string]any{}
+
+	// When Cancun is active at genesis, g.{ExcessBlobGas,BlobGasUsed} are
+	// nil pointers in BuildSynthetic's output → json.Marshal emits null.
+	// The shared header builder (internal/genesisheader.Build) materializes
+	// both to 0 in the on-disk header, so null-vs-0 is a potential
+	// chainspec/header divergence. Force "0x0" so both sides agree.
+	if g.Config != nil && g.Config.IsCancun(big.NewInt(0), uint64(g.Timestamp)) {
+		if v, ok := spec["excessBlobGas"]; !ok || v == nil {
+			spec["excessBlobGas"] = "0x0"
+		}
+		if v, ok := spec["blobGasUsed"]; !ok || v == nil {
+			spec["blobGasUsed"] = "0x0"
+		}
+	}
 
 	out, err := json.MarshalIndent(spec, "", "  ")
 	if err != nil {

--- a/client/reth/chainspec_test.go
+++ b/client/reth/chainspec_test.go
@@ -1,0 +1,57 @@
+package reth
+
+import (
+	"encoding/json"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nerolation/state-actor/genesis"
+)
+
+func readWrittenSpec(t *testing.T, fork string) map[string]any {
+	t.Helper()
+	g, err := genesis.BuildSynthetic(fork, big.NewInt(1337), 30_000_000, 0, nil)
+	if err != nil {
+		t.Fatalf("BuildSynthetic(%q): %v", fork, err)
+	}
+	out := filepath.Join(t.TempDir(), "chainspec.json")
+	if err := writeChainSpec(g, out); err != nil {
+		t.Fatalf("writeChainSpec: %v", err)
+	}
+	raw, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var spec map[string]any
+	if err := json.Unmarshal(raw, &spec); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return spec
+}
+
+// TestWriteChainSpec_CancunBlobGasFieldsNotNull guards against the
+// chainspec/header divergence flagged in #51: BuildSynthetic leaves
+// g.{ExcessBlobGas,BlobGasUsed} nil → json.Marshal emits "null", while
+// internal/genesisheader.Build materializes both to 0 in the on-disk
+// header. Without the writer's zero-coalesce, alloy-genesis could parse
+// null inconsistently with the header's 0 and produce a different
+// genesis hash.
+func TestWriteChainSpec_CancunBlobGasFieldsNotNull(t *testing.T) {
+	spec := readWrittenSpec(t, "osaka")
+	for _, k := range []string{"excessBlobGas", "blobGasUsed"} {
+		v, ok := spec[k]
+		if !ok {
+			t.Errorf("%s missing", k)
+			continue
+		}
+		if v == nil {
+			t.Errorf("%s = null; want \"0x0\" (chainspec/header parity)", k)
+			continue
+		}
+		if got, ok := v.(string); !ok || got != "0x0" {
+			t.Errorf("%s = %v (%T); want \"0x0\"", k, v, v)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

PR C of the [#51 unification plan](https://github.com/ethereum/state-actor/issues/51). Closes the last remaining chainspec/header POTENTIAL divergence flagged by the audit.

`BuildSynthetic` leaves `g.ExcessBlobGas` and `g.BlobGasUsed` nil. `json.Marshal` of a nil `*hexutil.Uint64` emits `"null"` — verified by a probe test that printed:

```
excessBlobGas = <nil>
blobGasUsed   = <nil>
```

Meanwhile `internal/genesisheader.Build` materializes both to `0` in the on-disk header when Cancun is active. The null-vs-0 discrepancy is benign today only because alloy-genesis happens to treat `null` as 0 — but that's not a contract we should rely on, especially as reth/alloy evolve.

`writeChainSpec` now post-marshal coalesces both fields to `"0x0"` when `g.Config.IsCancun(0, g.Timestamp)` is true. Chainspec and header now agree byte-for-byte on every blob-related field.

The fix is gated on `IsCancun` (not just `CancunTime != nil`) so a future pre-Cancun fork — or a chain configured to activate Cancun later than the genesis timestamp — correctly omits the fields, matching what the header writer would do.

