### PR TITLE
feat(oracle): cross-client header-customization round-trip check (#51)

### DIFF
--- a/internal/oracle/header_assert.go
+++ b/internal/oracle/header_assert.go
@@ -1,0 +1,99 @@
+package oracle
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+
+	"github.com/nerolation/state-actor/genesis"
+	"github.com/nerolation/state-actor/internal/rpcprobe"
+)
+
+// AssertGenesisHeaderMatches is the end-to-end proof of the unification
+// contract closed by #51 (PRs A/B/C): chainspec writer and on-disk header
+// both read every customizable field from g, so the EL re-emits the same
+// values over JSON-RPC. Any divergence — hardcoded literal in a chainspec
+// writer, short-circuited override, parser quirk — surfaces here instead
+// of as a confusing boot failure further down the test.
+//
+// Asserts on the four flag-driven fields:
+//
+//   - eth_chainId                                  == g.Config.ChainID
+//   - eth_getBlockByNumber("0x0").gasLimit         == g.GasLimit
+//   - eth_getBlockByNumber("0x0").timestamp        == g.Timestamp
+//   - eth_getBlockByNumber("0x0").extraData (hex)  == g.ExtraData
+//
+// All mismatches are reported in one call via t.Errorf so callers see
+// every field's status, not just the first failure.
+func AssertGenesisHeaderMatches(t *testing.T, rpcURL string, g *genesis.Genesis) {
+	t.Helper()
+
+	if g == nil || g.Config == nil {
+		t.Fatalf("AssertGenesisHeaderMatches: nil genesis or g.Config")
+	}
+
+	// eth_chainId — client metadata, not from the block header.
+	wantChainID := g.Config.ChainID.Uint64()
+	raw, err := rpcprobe.Call(rpcURL, "eth_chainId", []any{})
+	if err != nil {
+		t.Errorf("eth_chainId: %v", err)
+	} else {
+		var hexStr string
+		if jerr := jsonUnmarshalString(raw, &hexStr); jerr != nil {
+			t.Errorf("eth_chainId: parse %s: %v", raw, jerr)
+		} else if got, perr := parseHexUint64(hexStr); perr != nil {
+			t.Errorf("eth_chainId: parse %q: %v", hexStr, perr)
+		} else if got != wantChainID {
+			t.Errorf("eth_chainId = %d (0x%x); want %d (0x%x)", got, got, wantChainID, wantChainID)
+		}
+	}
+
+	// Genesis block header — the four customizable fields.
+	block, err := rpcprobe.BlockByNumber(rpcURL, "0x0")
+	if err != nil {
+		t.Fatalf("eth_getBlockByNumber(0x0): %v", err)
+	}
+
+	if got, perr := parseHexUint64(block.GasLimit); perr != nil {
+		t.Errorf("block.gasLimit %q: %v", block.GasLimit, perr)
+	} else if got != uint64(g.GasLimit) {
+		t.Errorf("block.gasLimit = %d (0x%x); want %d (0x%x)", got, got, uint64(g.GasLimit), uint64(g.GasLimit))
+	}
+
+	if got, perr := parseHexUint64(block.Timestamp); perr != nil {
+		t.Errorf("block.timestamp %q: %v", block.Timestamp, perr)
+	} else if got != uint64(g.Timestamp) {
+		t.Errorf("block.timestamp = %d (0x%x); want %d (0x%x)", got, got, uint64(g.Timestamp), uint64(g.Timestamp))
+	}
+
+	wantExtraData := hexutil.Encode([]byte(g.ExtraData))
+	if !strings.EqualFold(block.ExtraData, wantExtraData) {
+		t.Errorf("block.extraData = %q; want %q", block.ExtraData, wantExtraData)
+	}
+}
+
+// parseHexUint64 decodes "0x"-prefixed hex into a uint64. Accepts mixed
+// case; rejects empty / missing-prefix / overflow with a useful error.
+func parseHexUint64(s string) (uint64, error) {
+	if s == "" {
+		return 0, fmt.Errorf("empty hex string")
+	}
+	if !strings.HasPrefix(s, "0x") && !strings.HasPrefix(s, "0X") {
+		return 0, fmt.Errorf("missing 0x prefix: %q", s)
+	}
+	return strconv.ParseUint(s[2:], 16, 64)
+}
+
+// jsonUnmarshalString decodes a JSON string token into out without
+// allocating an intermediate map. raw must be a quoted JSON string
+// (e.g. `"0x539"`).
+func jsonUnmarshalString(raw []byte, out *string) error {
+	if len(raw) < 2 || raw[0] != '"' || raw[len(raw)-1] != '"' {
+		return fmt.Errorf("not a JSON string: %s", raw)
+	}
+	*out = string(raw[1 : len(raw)-1])
+	return nil
+}

--- a/internal/oracle/header_assert_test.go
+++ b/internal/oracle/header_assert_test.go
@@ -1,0 +1,75 @@
+package oracle
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/nerolation/state-actor/genesis"
+)
+
+// mockHeaderEL serves the JSON-RPC subset AssertGenesisHeaderMatches reads:
+// eth_chainId and eth_getBlockByNumber("0x0"). Field values are returned
+// verbatim from the struct, so a test can drive any combination of
+// agreement and divergence.
+type mockHeaderEL struct {
+	chainID   string // hex with "0x" prefix
+	gasLimit  string
+	timestamp string
+	extraData string
+}
+
+func (m *mockHeaderEL) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			Method string `json:"method"`
+			ID     int    `json:"id"`
+		}
+		_ = json.Unmarshal(body, &req)
+
+		w.Header().Set("Content-Type", "application/json")
+		switch req.Method {
+		case "eth_chainId":
+			fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%d,"result":%q}`, req.ID, m.chainID)
+		case "eth_getBlockByNumber":
+			// BlockByNumber rejects zero stateRoot and missing Number; fake
+			// both with stable non-zero values so the call returns.
+			fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%d,"result":{`+
+				`"number":"0x0",`+
+				`"hash":"0xaa00000000000000000000000000000000000000000000000000000000000000",`+
+				`"stateRoot":"0xbb00000000000000000000000000000000000000000000000000000000000000",`+
+				`"parentHash":"0x0000000000000000000000000000000000000000000000000000000000000000",`+
+				`"timestamp":%q,`+
+				`"gasLimit":%q,`+
+				`"extraData":%q`+
+				`}}`, req.ID, m.timestamp, m.gasLimit, m.extraData)
+		default:
+			http.Error(w, "method not mocked: "+req.Method, http.StatusBadRequest)
+		}
+	}
+}
+
+func startMockHeaderEL(t *testing.T, chainID, gasLimit, timestamp, extraData string) string {
+	t.Helper()
+	m := &mockHeaderEL{chainID: chainID, gasLimit: gasLimit, timestamp: timestamp, extraData: extraData}
+	srv := httptest.NewServer(m.handler())
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func TestAssertGenesisHeaderMatches_AllFieldsAgree(t *testing.T) {
+	g, err := genesis.BuildSynthetic("osaka", big.NewInt(1337), 20_000_000, 1_700_000_000, []byte{0xde, 0xad, 0xbe, 0xef})
+	if err != nil {
+		t.Fatalf("BuildSynthetic: %v", err)
+	}
+	// Hex equivalents: 1337=0x539, 20M=0x1312d00, 1700000000=0x6553f100, extraData="0xdeadbeef".
+	url := startMockHeaderEL(t, "0x539", "0x1312d00", "0x6553f100", "0xdeadbeef")
+	// Agreement case — t.Errorf isn't called. If the helper has a bug that
+	// reports a divergence here, the subtest fails.
+	AssertGenesisHeaderMatches(t, url, g)
+}

--- a/internal/oracle/runphases.go
+++ b/internal/oracle/runphases.go
@@ -88,6 +88,15 @@ func RunSuitePhases(t *testing.T, cfg SuitePhasesCfg) {
 		t.Fatalf("WriteResult (pre-spamoor): %v", err)
 	}
 
+	// ---- Phase 3a: chainspec/header unification round-trip (#51) ----
+	// Asserts the EL's RPC view of the genesis header matches the *Genesis
+	// we wrote — catches any residual chainspec/header divergence (a
+	// per-client writer hardcoding a literal would surface as a per-field
+	// mismatch here, not as a confusing boot failure 20 lines later).
+	if cfg.GeneratorConfig != nil && cfg.GeneratorConfig.Genesis != nil {
+		AssertGenesisHeaderMatches(t, cfg.RPCURL, cfg.GeneratorConfig.Genesis)
+	}
+
 	// ---- Phase 4: oracle re-query at "0x0" ----
 	// 4a — entitygen synthetic entities (RNG-driven).
 	if !CheckEntities(t, cfg.RPCURL, cfg.EOAs, cfg.Contracts, "0x0") {

--- a/internal/rpcprobe/probe.go
+++ b/internal/rpcprobe/probe.go
@@ -230,7 +230,9 @@ type Block struct {
 	Hash       common.Hash `json:"hash"`
 	StateRoot  common.Hash `json:"stateRoot"`
 	ParentHash common.Hash `json:"parentHash"`
-	Timestamp  string      `json:"timestamp"` // hex unix seconds
+	Timestamp  string      `json:"timestamp"`  // hex unix seconds
+	GasLimit   string      `json:"gasLimit"`   // hex
+	ExtraData  string      `json:"extraData"`  // "0x" + hex bytes
 }
 
 // BlockByNumber calls eth_getBlockByNumber(blockTag, false) and returns the


### PR DESCRIPTION
## Summary

PR D of the [#51 unification plan](https://github.com/ethereum/state-actor/issues/51). PRs A/B/C closed every chainspec/header divergence on the writer side. This PR closes the **proof loop**: an end-to-end assertion that the EL's RPC view of the genesis header byte-for-byte matches the \`*Genesis\` we wrote.

Without this check, a future regression that re-hardcodes a literal in any per-client chainspec writer would only surface as a confusing \"Supplied genesis block does not match chain data stored\" boot failure — not as a per-field diagnostic at the bug site.

## What it does

Adds \`oracle.AssertGenesisHeaderMatches(t, rpcURL, g)\` and wires it into \`RunSuitePhases\` as **Phase 3a** (right after capturing the genesis state root, before entitygen re-query). Every client's existing \`TestE2ESuite\` exercises the check automatically — no per-client edits required.

Asserts:
- \`eth_chainId\`                                  == \`g.Config.ChainID\`
- \`eth_getBlockByNumber(\"0x0\").gasLimit\`         == \`g.GasLimit\`
- \`eth_getBlockByNumber(\"0x0\").timestamp\`        == \`g.Timestamp\`
- \`eth_getBlockByNumber(\"0x0\").extraData\` (hex)  == \`g.ExtraData\`

All four mismatches are reported via separate \`t.Errorf\` calls (not one fatal), so a single CI run lists every diverging field instead of only the first.

## What it adds

- \`internal/oracle/header_assert.go\` — the helper (~100 LoC).
- \`internal/oracle/header_assert_test.go\` — unit test driving a mock EL via \`httptest\` (~75 LoC).
- \`internal/oracle/runphases.go\` — 9-line Phase 3a hook.
- \`internal/rpcprobe/probe.go\` — \`Block\` gains \`GasLimit\` and \`ExtraData\` fields (additive; existing callers unaffected).