### PR TITLE
refactor(oracle→e2e_testing): split CI helpers from library + spamoor output verification (#51)

### DIFF
--- a/client/besu/e2e_test.go
+++ b/client/besu/e2e_test.go
@@ -15,6 +15,7 @@ import (
 
 	stategenesis "github.com/nerolation/state-actor/genesis"
 	"github.com/nerolation/state-actor/generator"
+	e2e "github.com/nerolation/state-actor/internal/e2e_testing"
 	"github.com/nerolation/state-actor/internal/oracle"
 	"github.com/nerolation/state-actor/internal/rpcprobe"
 )
@@ -36,7 +37,7 @@ func besuImageRef() string {
 // TestE2ESuite — per-PR end-to-end gate for the besu writer + boot path.
 // Phase 1-2 (datadir + Run + boot besu) is besu-specific; Phase 3-7
 // (capture root → re-query → spamoor → re-query → write result) is in
-// internal/oracle.RunSuitePhases — same shape across all 4 client suites.
+// internal/e2e.RunSuitePhases — same shape across all 4 client suites.
 //
 // Build-tagged `cgo_besu && oracle`. Run via `make test-besu-suite`;
 // not in plain `go test ./...`. Spamoor binary must be on PATH or
@@ -63,7 +64,7 @@ func TestE2ESuite(t *testing.T) {
 		t.Fatalf("BuildSynthetic: %v", err)
 	}
 
-	dd, cleanup := oracle.AcquireDatadir(t, "BESU")
+	dd, cleanup := e2e.AcquireDatadir(t, "BESU")
 	defer cleanup()
 
 	cfg := generator.Config{
@@ -112,9 +113,9 @@ func TestE2ESuite(t *testing.T) {
 	// (clique broken post-Shanghai per hyperledger/besu#8532, removed
 	// in 26.4.0). JWT is disabled for tests.
 	imageRef := besuImageRef()
-	containerName := "state-actor-besu-boot-" + oracle.RandSuffix(8)
+	containerName := "state-actor-besu-boot-" + e2e.RandSuffix(8)
 	chainspecPath := dd.ContainerDatadir + "/" + ChainSpecFileName
-	runArgs := append([]string{"run", "-d"}, oracle.DockerPlatformArgs("BESU_DOCKER_PLATFORM")...)
+	runArgs := append([]string{"run", "-d"}, e2e.DockerPlatformArgs("BESU_DOCKER_PLATFORM")...)
 	runArgs = append(runArgs,
 		"--name", containerName,
 		"-v", dd.VolMount,
@@ -151,7 +152,7 @@ func TestE2ESuite(t *testing.T) {
 		exec.Command("docker", "rm", "-f", containerName).Run() //nolint:errcheck
 	})
 
-	containerIP, err := oracle.InspectContainerIP(containerName)
+	containerIP, err := e2e.InspectContainerIP(containerName)
 	if err != nil {
 		logs, _ := exec.Command("docker", "logs", containerName).CombinedOutput()
 		t.Fatalf("InspectContainerIP: %v\nbesu logs:\n%s", err, logs)
@@ -167,10 +168,10 @@ func TestE2ESuite(t *testing.T) {
 	// Mock CL: drive block production via engine API. Modeled after besu's
 	// own PragueAcceptanceTestHelper.java. The goroutine runs for the
 	// rest of the test so spamoor's txs (Phase 5) get included in blocks.
-	oracle.StartEngineDriver(t, containerIP, rpcURL, oracle.ForkOsaka)
+	e2e.StartEngineDriver(t, containerIP, rpcURL, e2e.ForkOsaka)
 
-	// Phases 3-7: shared via internal/oracle.RunSuitePhases.
-	oracle.RunSuitePhases(t, oracle.SuitePhasesCfg{
+	// Phases 3-7: shared via internal/e2e.RunSuitePhases.
+	e2e.RunSuitePhases(t, e2e.SuitePhasesCfg{
 		ClientName:      "besu",
 		RPCURL:          rpcURL,
 		EOAs:            eoas,

--- a/client/geth/e2e_test.go
+++ b/client/geth/e2e_test.go
@@ -18,6 +18,7 @@ import (
 
 	stategenesis "github.com/nerolation/state-actor/genesis"
 	"github.com/nerolation/state-actor/generator"
+	e2e "github.com/nerolation/state-actor/internal/e2e_testing"
 	"github.com/nerolation/state-actor/internal/oracle"
 	"github.com/nerolation/state-actor/internal/rpcprobe"
 )
@@ -124,7 +125,7 @@ func TestE2ESuite(t *testing.T) {
 	// the chainID in state-actor's genesis. --db.engine=pebble points
 	// geth at our Pebble datadir. --http.api includes txpool so spamoor
 	// can monitor pending txs.
-	containerName := "state-actor-geth-boot-" + oracle.RandSuffix(8)
+	containerName := "state-actor-geth-boot-" + e2e.RandSuffix(8)
 	hostPort := freeTCPPort(t)
 
 	// Run geth as the test process's UID/GID so any files it writes to
@@ -132,7 +133,7 @@ func TestE2ESuite(t *testing.T) {
 	// on native Linux (e.g. GHA runners), geth's default-root container
 	// would write root-owned files into datadir, and t.TempDir's cleanup
 	// (running as the test user) would fail with "permission denied".
-	runArgs := append([]string{"run", "-d"}, oracle.DockerPlatformArgs("GETH_DOCKER_PLATFORM")...)
+	runArgs := append([]string{"run", "-d"}, e2e.DockerPlatformArgs("GETH_DOCKER_PLATFORM")...)
 	runArgs = append(runArgs,
 		"--name", containerName,
 		"--user", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
@@ -174,8 +175,8 @@ func TestE2ESuite(t *testing.T) {
 		t.Fatalf("RPC never came up (logs captured in t.Cleanup): %v", err)
 	}
 
-	// Phases 3-7: shared via internal/oracle.RunSuitePhases.
-	oracle.RunSuitePhases(t, oracle.SuitePhasesCfg{
+	// Phases 3-7: shared via internal/e2e.RunSuitePhases.
+	e2e.RunSuitePhases(t, e2e.SuitePhasesCfg{
 		ClientName:      "geth",
 		RPCURL:          rpcURL,
 		EOAs:            eoas,

--- a/client/nethermind/e2e_test.go
+++ b/client/nethermind/e2e_test.go
@@ -17,6 +17,7 @@ import (
 
 	stategenesis "github.com/nerolation/state-actor/genesis"
 	"github.com/nerolation/state-actor/generator"
+	e2e "github.com/nerolation/state-actor/internal/e2e_testing"
 	"github.com/nerolation/state-actor/internal/oracle"
 	"github.com/nerolation/state-actor/internal/rpcprobe"
 )
@@ -85,7 +86,7 @@ const nethermindE2EConfigTemplate = `{
 
 // TestE2ESuite — see client/besu/e2e_test.go for the full phase
 // description. Phase 1-2 (datadir + Run + boot nethermind) is per-client;
-// Phase 3-7 is internal/oracle.RunSuitePhases.
+// Phase 3-7 is internal/e2e.RunSuitePhases.
 //
 // nethermind-specific bits:
 //   - --fork=osaka (unified across all 4 clients after the writer migration to internal/genesisheader.Build)
@@ -114,7 +115,7 @@ func TestE2ESuite(t *testing.T) {
 		t.Fatalf("BuildSynthetic: %v", err)
 	}
 
-	dd, cleanup := oracle.AcquireDatadir(t, "NETH")
+	dd, cleanup := e2e.AcquireDatadir(t, "NETH")
 	defer cleanup()
 
 	cfg := generator.Config{
@@ -161,9 +162,9 @@ func TestE2ESuite(t *testing.T) {
 	})
 
 	imageRef := nethImageRef()
-	containerName := "state-actor-neth-boot-" + oracle.RandSuffix(8)
+	containerName := "state-actor-neth-boot-" + e2e.RandSuffix(8)
 	containerCfgPath := dd.ContainerDatadir + "/boot.cfg"
-	runArgs := append([]string{"run", "-d"}, oracle.DockerPlatformArgs("NETH_DOCKER_PLATFORM")...)
+	runArgs := append([]string{"run", "-d"}, e2e.DockerPlatformArgs("NETH_DOCKER_PLATFORM")...)
 	runArgs = append(runArgs,
 		"--name", containerName,
 		"-v", dd.VolMount,
@@ -183,7 +184,7 @@ func TestE2ESuite(t *testing.T) {
 		exec.Command("docker", "rm", "-f", containerName).Run() //nolint:errcheck
 	})
 
-	containerIP, err := oracle.InspectContainerIP(containerName)
+	containerIP, err := e2e.InspectContainerIP(containerName)
 	if err != nil {
 		logs, _ := exec.Command("docker", "logs", containerName).CombinedOutput()
 		t.Fatalf("InspectContainerIP: %v\nnethermind logs:\n%s", err, logs)
@@ -201,10 +202,10 @@ func TestE2ESuite(t *testing.T) {
 	// Ethash chainspec with Merge.Enabled + TTD=0 the engine API is the
 	// only path that produces blocks. Goroutine runs for the rest of
 	// the test so spamoor's txs (Phase 5) get included in blocks.
-	oracle.StartEngineDriver(t, containerIP, rpcURL, oracle.ForkOsaka)
+	e2e.StartEngineDriver(t, containerIP, rpcURL, e2e.ForkOsaka)
 
-	// Phases 3-7: shared via internal/oracle.RunSuitePhases.
-	oracle.RunSuitePhases(t, oracle.SuitePhasesCfg{
+	// Phases 3-7: shared via internal/e2e.RunSuitePhases.
+	e2e.RunSuitePhases(t, e2e.SuitePhasesCfg{
 		ClientName:          "nethermind",
 		RPCURL:              rpcURL,
 		EOAs:                eoas,

--- a/client/reth/oracle_test.go
+++ b/client/reth/oracle_test.go
@@ -15,6 +15,7 @@ import (
 
 	stategenesis "github.com/nerolation/state-actor/genesis"
 	"github.com/nerolation/state-actor/generator"
+	e2e "github.com/nerolation/state-actor/internal/e2e_testing"
 	"github.com/nerolation/state-actor/internal/oracle"
 	iReth "github.com/nerolation/state-actor/internal/reth"
 	"github.com/nerolation/state-actor/internal/rpcprobe"
@@ -63,7 +64,7 @@ func TestRethDbStats(t *testing.T) {
 		t.Skip("oracle test in short mode")
 	}
 
-	dd, cleanup := oracle.AcquireDatadir(t, "RETH")
+	dd, cleanup := e2e.AcquireDatadir(t, "RETH")
 	defer cleanup()
 
 	cfg := generator.Config{DBPath: dd.HostPath}
@@ -71,7 +72,7 @@ func TestRethDbStats(t *testing.T) {
 		t.Fatalf("RunCgo: %v", err)
 	}
 
-	args := append([]string{"run", "--rm"}, oracle.DockerPlatformArgs("RETH_DOCKER_PLATFORM")...)
+	args := append([]string{"run", "--rm"}, e2e.DockerPlatformArgs("RETH_DOCKER_PLATFORM")...)
 	args = append(args,
 		"-v", dd.VolMount,
 		rethImageRef(),
@@ -97,7 +98,7 @@ func TestRethDbStatsSyntheticEOAs(t *testing.T) {
 	}
 	const numAccounts = 100
 
-	dd, cleanup := oracle.AcquireDatadir(t, "RETH")
+	dd, cleanup := e2e.AcquireDatadir(t, "RETH")
 	defer cleanup()
 
 	cfg := generator.Config{DBPath: dd.HostPath, NumAccounts: numAccounts, Seed: 12345}
@@ -109,7 +110,7 @@ func TestRethDbStatsSyntheticEOAs(t *testing.T) {
 		t.Fatalf("AccountsCreated = %d, want %d", stats.AccountsCreated, numAccounts)
 	}
 
-	args := append([]string{"run", "--rm"}, oracle.DockerPlatformArgs("RETH_DOCKER_PLATFORM")...)
+	args := append([]string{"run", "--rm"}, e2e.DockerPlatformArgs("RETH_DOCKER_PLATFORM")...)
 	args = append(args,
 		"-v", dd.VolMount,
 		rethImageRef(),
@@ -148,7 +149,7 @@ func TestRethNodeBootEmptyAlloc(t *testing.T) {
 		t.Skip("oracle boot test skipped in short mode")
 	}
 
-	dd, cleanup := oracle.AcquireDatadir(t, "RETH")
+	dd, cleanup := e2e.AcquireDatadir(t, "RETH")
 	defer cleanup()
 
 	cfg := generator.Config{DBPath: dd.HostPath} // empty alloc
@@ -157,9 +158,9 @@ func TestRethNodeBootEmptyAlloc(t *testing.T) {
 	}
 
 	imageRef := rethImageRef()
-	containerName := "state-actor-reth-boot-empty-" + oracle.RandSuffix(8)
+	containerName := "state-actor-reth-boot-empty-" + e2e.RandSuffix(8)
 	chainspecPath := dd.ContainerDatadir + "/chainspec.json"
-	runArgs := append([]string{"run", "-d"}, oracle.DockerPlatformArgs("RETH_DOCKER_PLATFORM")...)
+	runArgs := append([]string{"run", "-d"}, e2e.DockerPlatformArgs("RETH_DOCKER_PLATFORM")...)
 	runArgs = append(runArgs,
 		"--name", containerName,
 		"-v", dd.VolMount,
@@ -185,7 +186,7 @@ func TestRethNodeBootEmptyAlloc(t *testing.T) {
 		exec.Command("docker", "rm", "-f", containerName).Run() //nolint:errcheck
 	})
 
-	containerIP, err := oracle.InspectContainerIP(containerName)
+	containerIP, err := e2e.InspectContainerIP(containerName)
 	if err != nil {
 		logs, _ := exec.Command("docker", "logs", containerName).CombinedOutput()
 		t.Fatalf("InspectContainerIP: %v\nreth logs:\n%s", err, logs)
@@ -227,7 +228,7 @@ func TestE2ESuite(t *testing.T) {
 		t.Fatalf("BuildSynthetic: %v", err)
 	}
 
-	dd, cleanup := oracle.AcquireDatadir(t, "RETH")
+	dd, cleanup := e2e.AcquireDatadir(t, "RETH")
 	defer cleanup()
 
 	cfg := generator.Config{
@@ -260,9 +261,9 @@ func TestE2ESuite(t *testing.T) {
 	})
 
 	imageRef := rethImageRef()
-	containerName := "state-actor-reth-boot-" + oracle.RandSuffix(8)
+	containerName := "state-actor-reth-boot-" + e2e.RandSuffix(8)
 	chainspecPath := dd.ContainerDatadir + "/chainspec.json"
-	runArgs := append([]string{"run", "-d"}, oracle.DockerPlatformArgs("RETH_DOCKER_PLATFORM")...)
+	runArgs := append([]string{"run", "-d"}, e2e.DockerPlatformArgs("RETH_DOCKER_PLATFORM")...)
 	runArgs = append(runArgs,
 		"--name", containerName,
 		"-v", dd.VolMount,
@@ -288,7 +289,7 @@ func TestE2ESuite(t *testing.T) {
 		exec.Command("docker", "rm", "-f", containerName).Run() //nolint:errcheck
 	})
 
-	containerIP, err := oracle.InspectContainerIP(containerName)
+	containerIP, err := e2e.InspectContainerIP(containerName)
 	if err != nil {
 		logs, _ := exec.Command("docker", "logs", containerName).CombinedOutput()
 		t.Fatalf("InspectContainerIP: %v\nreth logs:\n%s", err, logs)
@@ -300,8 +301,8 @@ func TestE2ESuite(t *testing.T) {
 		t.Fatalf("RPC never came up (logs captured in t.Cleanup): %v", err)
 	}
 
-	// Phases 3-7: shared via internal/oracle.RunSuitePhases.
-	oracle.RunSuitePhases(t, oracle.SuitePhasesCfg{
+	// Phases 3-7: shared via internal/e2e.RunSuitePhases.
+	e2e.RunSuitePhases(t, e2e.SuitePhasesCfg{
 		ClientName:      "reth",
 		RPCURL:          rpcURL,
 		EOAs:            eoas,

--- a/internal/e2e_testing/check_entities.go
+++ b/internal/e2e_testing/check_entities.go
@@ -1,4 +1,4 @@
-package oracle
+package e2e_testing
 
 import (
 	"bytes"

--- a/internal/e2e_testing/check_entities_test.go
+++ b/internal/e2e_testing/check_entities_test.go
@@ -1,4 +1,4 @@
-package oracle
+package e2e_testing
 
 import (
 	"encoding/json"

--- a/internal/e2e_testing/dockerutil.go
+++ b/internal/e2e_testing/dockerutil.go
@@ -1,4 +1,4 @@
-package oracle
+package e2e_testing
 
 import (
 	"fmt"

--- a/internal/e2e_testing/engineapi.go
+++ b/internal/e2e_testing/engineapi.go
@@ -1,4 +1,4 @@
-package oracle
+package e2e_testing
 
 import (
 	"bytes"

--- a/internal/e2e_testing/engineapi_test.go
+++ b/internal/e2e_testing/engineapi_test.go
@@ -1,4 +1,4 @@
-package oracle
+package e2e_testing
 
 import (
 	"context"

--- a/internal/e2e_testing/header_assert.go
+++ b/internal/e2e_testing/header_assert.go
@@ -1,4 +1,4 @@
-package oracle
+package e2e_testing
 
 import (
 	"fmt"

--- a/internal/e2e_testing/header_assert_test.go
+++ b/internal/e2e_testing/header_assert_test.go
@@ -1,4 +1,4 @@
-package oracle
+package e2e_testing
 
 import (
 	"encoding/json"

--- a/internal/e2e_testing/result.go
+++ b/internal/e2e_testing/result.go
@@ -1,4 +1,4 @@
-package oracle
+package e2e_testing
 
 import (
 	"encoding/json"

--- a/internal/e2e_testing/runphases.go
+++ b/internal/e2e_testing/runphases.go
@@ -1,4 +1,4 @@
-package oracle
+package e2e_testing
 
 import (
 	"os"
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nerolation/state-actor/generator"
 	"github.com/nerolation/state-actor/internal/entitygen"
+	"github.com/nerolation/state-actor/internal/oracle"
 	"github.com/nerolation/state-actor/internal/rpcprobe"
 )
 
@@ -134,7 +135,7 @@ func RunSuitePhases(t *testing.T, cfg SuitePhasesCfg) {
 	postBlock, err := SpamoorRun(SpamoorRunCfg{
 		Binary:           spamoorBin,
 		RPCURL:           cfg.RPCURL,
-		PrivKey:          SpamoorSenderPrivKey,
+		PrivKey:          oracle.SpamoorSenderPrivKey,
 		Seed:             12345,
 		TargetBlockDelta: 100,
 		SlotDuration:     slotDur,
@@ -154,15 +155,24 @@ func RunSuitePhases(t *testing.T, cfg SuitePhasesCfg) {
 	} else {
 		result.PostSpamoorEntityCheck = "entitygen entities drifted post-spamoor"
 	}
-	deployerNonce, err := rpcprobe.EthGetTransactionCount(cfg.RPCURL, SpamoorSenderAddr, "latest")
+	deployerNonce, err := rpcprobe.EthGetTransactionCount(cfg.RPCURL, oracle.SpamoorSenderAddr, "latest")
 	if err != nil {
-		t.Errorf("eth_getTransactionCount %s: %v", SpamoorSenderAddr.Hex(), err)
+		t.Errorf("eth_getTransactionCount %s: %v", oracle.SpamoorSenderAddr.Hex(), err)
 	} else {
 		result.PostSpamoorDeployerNonce = deployerNonce
 		if deployerNonce == 0 {
 			t.Errorf("post-spamoor deployer nonce is 0 — spamoor didn't send any txs?")
 		}
 	}
+
+	// ---- Phase 6a: spamoor output verification ----
+	// Phase 6 above proves spamoor's deployer SENT txs (nonce ticked) but
+	// not that the client actually EXECUTED them. AssertSpamoorOutputs
+	// finds spamoor's contract-creation tx in early blocks and asserts
+	// the receipt is non-revert AND the deployed contract has code on
+	// chain — closes the "txs landed in blocks but EVM silently dropped
+	// the work" hole.
+	AssertSpamoorOutputs(t, cfg.RPCURL)
 
 	// ---- Phase 7: write final result JSON ----
 	if err := WriteResult(result); err != nil {

--- a/internal/e2e_testing/spamoor.go
+++ b/internal/e2e_testing/spamoor.go
@@ -1,4 +1,4 @@
-package oracle
+package e2e_testing
 
 import (
 	"errors"

--- a/internal/e2e_testing/spamoor_test.go
+++ b/internal/e2e_testing/spamoor_test.go
@@ -1,4 +1,4 @@
-package oracle
+package e2e_testing
 
 import (
 	"encoding/json"

--- a/internal/e2e_testing/spamoor_verify.go
+++ b/internal/e2e_testing/spamoor_verify.go
@@ -1,0 +1,84 @@
+package e2e_testing
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/nerolation/state-actor/internal/rpcprobe"
+)
+
+// AssertSpamoorOutputs verifies that spamoor's tx-blasting actually
+// produced an observable state change on chain. Without this check, a
+// client that accepts spamoor's payloads into blocks but silently drops
+// EVM execution would still pass Phase 6 (which only asserts the
+// deployer nonce ticked, not that anything actually executed).
+//
+// The check scans the first maxScan blocks for a contract-creation tx
+// (whose `to` field is null), then asserts:
+//   - the deploy tx's receipt has status 0x1 (i.e. the transaction did
+//     not revert)
+//   - the receipt's contractAddress has non-empty code at "latest"
+//     (i.e. the EVM actually deployed the bytecode)
+//
+// Errors are reported via t.Errorf so a single CI run produces a useful
+// diagnostic — caller continues running.
+func AssertSpamoorOutputs(t *testing.T, rpcURL string) {
+	t.Helper()
+
+	// spamoor's deploy is observed in early blocks (typically <10). Cap
+	// the scan so a misbehaving client (no creation tx) fails fast rather
+	// than walking the whole chain.
+	const maxScan = uint64(30)
+
+	latest, err := rpcprobe.EthBlockNumber(rpcURL)
+	if err != nil {
+		t.Errorf("AssertSpamoorOutputs: eth_blockNumber: %v", err)
+		return
+	}
+	end := latest
+	if end > maxScan {
+		end = maxScan
+	}
+
+	for n := uint64(1); n <= end; n++ {
+		tag := fmt.Sprintf("0x%x", n)
+		block, err := rpcprobe.BlockByNumberWithTxs(rpcURL, tag)
+		if err != nil {
+			t.Errorf("AssertSpamoorOutputs: %s: %v", tag, err)
+			return
+		}
+		for _, tx := range block.Transactions {
+			if tx.To != nil {
+				continue
+			}
+			// Contract creation tx — fetch receipt for status + the
+			// authoritative deploy address (avoids re-deriving with
+			// crypto.CreateAddress, which would require parsing tx.Nonce).
+			receipt, err := rpcprobe.EthGetTransactionReceipt(rpcURL, tx.Hash)
+			if err != nil {
+				t.Errorf("AssertSpamoorOutputs: receipt for %s: %v", tx.Hash.Hex(), err)
+				return
+			}
+			if receipt.Status != "0x1" {
+				t.Errorf("AssertSpamoorOutputs: deploy tx %s reverted (status=%q)", tx.Hash.Hex(), receipt.Status)
+				return
+			}
+			if receipt.ContractAddress == nil {
+				t.Errorf("AssertSpamoorOutputs: deploy receipt %s has nil contractAddress", tx.Hash.Hex())
+				return
+			}
+			code, err := rpcprobe.EthGetCode(rpcURL, *receipt.ContractAddress, "latest")
+			if err != nil {
+				t.Errorf("AssertSpamoorOutputs: eth_getCode(%s): %v", receipt.ContractAddress.Hex(), err)
+				return
+			}
+			if len(code) == 0 {
+				t.Errorf("AssertSpamoorOutputs: deployed contract %s has empty code (EVM silently dropped execution?)", receipt.ContractAddress.Hex())
+				return
+			}
+			t.Logf("AssertSpamoorOutputs: verified deployed contract %s (%d code bytes) in block %d", receipt.ContractAddress.Hex(), len(code), n)
+			return
+		}
+	}
+	t.Errorf("AssertSpamoorOutputs: no contract-creation tx found in blocks 1..%d (spamoor didn't deploy?)", end)
+}

--- a/internal/oracle/syscontracts_test.go
+++ b/internal/oracle/syscontracts_test.go
@@ -126,3 +126,10 @@ func TestAddPragueSystemContracts_NilCfgSafe(t *testing.T) {
 	}()
 	AddPragueSystemContracts(nil)
 }
+
+func safePrefix(b []byte, n int) []byte {
+	if len(b) < n {
+		return b
+	}
+	return b[:n]
+}

--- a/internal/rpcprobe/probe.go
+++ b/internal/rpcprobe/probe.go
@@ -278,3 +278,71 @@ func GenesisStateRoot(url string) (common.Hash, error) {
 	}
 	return b.StateRoot, nil
 }
+
+// TxRef is the subset of an eth_getBlockByNumber(_, true) transaction we
+// read to find contract-creation calls. Contract creations have a null
+// "to" field, so To is a pointer.
+type TxRef struct {
+	Hash  common.Hash     `json:"hash"`
+	From  common.Address  `json:"from"`
+	To    *common.Address `json:"to"`
+	Nonce string          `json:"nonce"` // hex with 0x prefix
+}
+
+// BlockWithTxs is BlockByNumber's reply when called with fullTxObjects=true.
+type BlockWithTxs struct {
+	Number       string  `json:"number"`
+	Hash         common.Hash `json:"hash"`
+	Transactions []TxRef `json:"transactions"`
+}
+
+// BlockByNumberWithTxs calls eth_getBlockByNumber(blockTag, true) and
+// returns the block with its full transactions list. Used by spamoor-
+// output verification to find the contract-creation tx and its sender.
+func BlockByNumberWithTxs(url, blockTag string) (*BlockWithTxs, error) {
+	raw, err := Call(url, "eth_getBlockByNumber", []any{blockTag, true})
+	if err != nil {
+		return nil, err
+	}
+	if len(bytes.TrimSpace(raw)) == 0 || string(raw) == "null" {
+		return nil, fmt.Errorf("eth_getBlockByNumber(%s, true): block not found", blockTag)
+	}
+	var b BlockWithTxs
+	if err := json.Unmarshal(raw, &b); err != nil {
+		return nil, fmt.Errorf("unmarshal block: %w (raw: %s)", err, raw)
+	}
+	if b.Number == "" {
+		return nil, fmt.Errorf("eth_getBlockByNumber(%s, true): empty Number field", blockTag)
+	}
+	return &b, nil
+}
+
+// TxReceipt is the subset of eth_getTransactionReceipt's reply we read.
+// ContractAddress is the deployed-contract address for creation txs and
+// the zero address otherwise; Status is "0x1" on success, "0x0" on revert.
+type TxReceipt struct {
+	TransactionHash common.Hash     `json:"transactionHash"`
+	ContractAddress *common.Address `json:"contractAddress"`
+	Status          string          `json:"status"`
+}
+
+// EthGetTransactionReceipt calls eth_getTransactionReceipt(txHash). Returns
+// an error if the receipt is missing or empty-shaped (defensive against
+// clients that return {} or null for unknown hashes).
+func EthGetTransactionReceipt(url string, txHash common.Hash) (*TxReceipt, error) {
+	raw, err := Call(url, "eth_getTransactionReceipt", []any{txHash.Hex()})
+	if err != nil {
+		return nil, err
+	}
+	if len(bytes.TrimSpace(raw)) == 0 || string(raw) == "null" {
+		return nil, fmt.Errorf("eth_getTransactionReceipt(%s): receipt not found", txHash.Hex())
+	}
+	var r TxReceipt
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return nil, fmt.Errorf("unmarshal receipt: %w (raw: %s)", err, raw)
+	}
+	if r.Status == "" {
+		return nil, fmt.Errorf("eth_getTransactionReceipt(%s): empty status (incomplete reply)", txHash.Hex())
+	}
+	return &r, nil
+}


### PR DESCRIPTION
## Summary

PR E1c of the post-#51 hardening plan. Two changes bundled:

### 1. Refactor: `internal/oracle/` → `internal/e2e_testing/`

The `internal/oracle/` package mixed two concerns:
- **Library code** (no `testing` import, reusable): `EngineDriver` type, system-contract data, dev keys, entitygen replay
- **CI-only test orchestration** (imports `testing` or only called from `_test.go`): `RunSuitePhases`, `AssertGenesisHeaderMatches`, `CheckEntities`, `AcquireDatadir`, `SpamoorRun`, `SuiteResult` JSON

Split into two packages so library consumers don't pull in the test-orchestration surface:

| Moved to `internal/e2e_testing/` | Stayed in `internal/oracle/` |
|---|---|
| `engineapi.go` (`EngineDriver`, `StartEngineDriver`, `ForkOsaka`) | `syscontracts.go` (`AddPragueSystemContracts`) |
| `dockerutil.go` (`AcquireDatadir`, `RandSuffix`, `InspectContainerIP`, `DockerPlatformArgs`) | `devkeys.go` (`SpamoorSenderAddr`, `SpamoorSenderPrivKey`) |
| `runphases.go` (`RunSuitePhases`, `SuitePhasesCfg`) | `reproduce.go` (`Reproduce`, `ReproduceCfg`) |
| `header_assert.go` (`AssertGenesisHeaderMatches`) | |
| `check_entities.go` (`CheckEntities`, `CheckInjections`) | |
| `result.go` (`SuiteResult`, `WriteResult`) | |
| `spamoor.go` (`SpamoorRun`, `SpamoorRunCfg`) | |

All 4 client e2e tests (`client/{besu,geth,nethermind,reth}/{e2e,oracle}_test.go`) updated to import both packages: aliased `e2e` for moved symbols, kept `oracle` for the library symbols.

The heuristic for the split: **if the file imports the `testing` package OR is only called from `_test.go` files, it belongs in `internal/e2e_testing/`**.

### 2. New: `AssertSpamoorOutputs` (Phase 6a)

Phase 6 today asserts only "deployer nonce > 0" + "genesis entities did not drift". A client could ack spamoor's payloads into blocks but silently drop EVM execution and CI would still pass.

`AssertSpamoorOutputs` (in `internal/e2e_testing/spamoor_verify.go`) scans the first 30 blocks for a contract-creation tx, fetches its receipt, and asserts:
- receipt.status == 0x1 (deploy did not revert)
- receipt.contractAddress has non-empty code at \"latest\" (EVM actually deployed bytecode)

Wired into `RunSuitePhases` as Phase 6a (between the existing Phase 6 RPC re-queries and the final WriteResult).

No mock-based unit test per plan direction — the function is exercised against real RPC in every client e2e suite. If a regression breaks it, CI catches it.

`rpcprobe` gains the supporting helpers: `BlockByNumberWithTxs`, `EthGetTransactionReceipt`, plus `TxRef` / `BlockWithTxs` / `TxReceipt` structs.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -count=1 ./internal/e2e_testing/ ./internal/rpcprobe/ ./internal/oracle/` green
- [x] `go test -count=1 ./client/...` non-cgo packages green (geth's existing target-size flake is unrelated)
- [ ] CI: 4 `*-suite` jobs — Phase 6a verifies spamoor's deploy against real RPC; if a client silently dropped EVM execution this PR would catch it