### PR TITLE
feat(ci): ~100 MB warmup before spamoor in all 4 e2e suites

### DIFF
--- a/client/besu/e2e_test.go
+++ b/client/besu/e2e_test.go
@@ -49,11 +49,11 @@ func TestE2ESuite(t *testing.T) {
 
 	const (
 		seed         = int64(42)
-		numAccounts  = 10
-		numContracts = 3
-		codeSize     = 256
-		minSlots     = 2
-		maxSlots     = 2
+		numAccounts  = 100
+		numContracts = 15_000 // ~100 MB warmup before spamoor (avg 27 slots × 240 B/entry)
+		codeSize     = 128
+		minSlots     = 5
+		maxSlots     = 50
 	)
 
 	// All 4 clients pin --fork=osaka after the writer migration to internal/genesisheader.Build. state-actor's

--- a/client/geth/e2e_test.go
+++ b/client/geth/e2e_test.go
@@ -67,11 +67,11 @@ func TestE2ESuite(t *testing.T) {
 
 	const (
 		seed         = int64(42)
-		numAccounts  = 10
-		numContracts = 3
-		codeSize     = 256
-		minSlots     = 2
-		maxSlots     = 2
+		numAccounts  = 100
+		numContracts = 15_000 // ~100 MB warmup before spamoor (avg 27 slots × 240 B/entry)
+		codeSize     = 128
+		minSlots     = 5
+		maxSlots     = 50
 	)
 
 	// Pin --fork=osaka (geth's MaxForkForClient ceiling). 60M gas matches

--- a/client/nethermind/e2e_test.go
+++ b/client/nethermind/e2e_test.go
@@ -100,11 +100,11 @@ func TestE2ESuite(t *testing.T) {
 
 	const (
 		seed         = int64(42)
-		numAccounts  = 10
-		numContracts = 3
-		codeSize     = 256
-		minSlots     = 2
-		maxSlots     = 2
+		numAccounts  = 100
+		numContracts = 15_000 // ~100 MB warmup before spamoor (avg 27 slots × 240 B/entry)
+		codeSize     = 128
+		minSlots     = 5
+		maxSlots     = 50
 	)
 
 	// All 4 clients pin --fork=osaka after the writer migration to internal/genesisheader.Build. state-actor's

--- a/client/reth/oracle_test.go
+++ b/client/reth/oracle_test.go
@@ -216,11 +216,11 @@ func TestE2ESuite(t *testing.T) {
 
 	const (
 		seed         = int64(42)
-		numAccounts  = 10
-		numContracts = 3
-		codeSize     = 256
-		minSlots     = 2
-		maxSlots     = 2
+		numAccounts  = 100
+		numContracts = 15_000 // ~100 MB warmup before spamoor (avg 27 slots × 240 B/entry)
+		codeSize     = 128
+		minSlots     = 5
+		maxSlots     = 50
 	)
 
 	g, err := stategenesis.BuildSynthetic("osaka", big.NewInt(1337), 60_000_000,


### PR DESCRIPTION
## Summary
E2E tests previously built trivial datasets (10 accounts / 3 contracts ≈ few KB) before spamoor blasted them. A bug that only surfaces above ~100K trie entries (LSM tier compaction edge cases, snapshot churn, code-storage flush ordering) would slip through.

Bumps each client's e2e suite to write ~100 MB of state before spamoor runs, using **fixed N + slots** (no `--target-size`):

```go
NumAccounts:  100
NumContracts: 15_000   // avg 27 slots × 240 B/entry ≈ 100 MB
MinSlots:     5
MaxSlots:     50
CodeSize:     128
```

This shape matches the existing 200 MiB target-size tests (mainnet-representative: many contracts × few slots).

## Why not --target-size?

The first attempt in this PR used `--target-size=1<<30` (1 GiB). CI failed on all 4 clients with two root causes:

1. **Per-client stop-point divergence** → different state roots → cross-client invariant breaks. Each client samples on-disk size at different cadences with different storage-format compression, so same target produces different N written.
2. **`entitygen.Reproduce` assumes all N written**, but state-actor stops at M < N when target-size hits → CheckEntities fails on contracts M+1..N.

Filed as **issue #71** for follow-up fix: make target-size deterministic across clients + plumb the actual stop point back to entitygen.
