### PR TITLE
fix(e2e): scan all blocks for spamoor's deploy tx 

### DIFF
--- a/internal/e2e_testing/spamoor_verify.go
+++ b/internal/e2e_testing/spamoor_verify.go
@@ -13,7 +13,7 @@ import (
 // EVM execution would still pass Phase 6 (which only asserts the
 // deployer nonce ticked, not that anything actually executed).
 //
-// The check scans the first maxScan blocks for a contract-creation tx
+// The check scans every block 1..latest for a contract-creation tx
 // (whose `to` field is null), then asserts:
 //   - the deploy tx's receipt has status 0x1 (i.e. the transaction did
 //     not revert)
@@ -22,25 +22,22 @@ import (
 //
 // Errors are reported via t.Errorf so a single CI run produces a useful
 // diagnostic — caller continues running.
+//
+// Note on scan range: spamoor's wallet-funding phase scales with the
+// configured wallet count and target gas, so the deploy can land
+// anywhere from block 3 (small warmup) to block 100+ (large pre-spamoor
+// state). Scanning to `latest` instead of a fixed cap keeps the check
+// resilient.
 func AssertSpamoorOutputs(t *testing.T, rpcURL string) {
 	t.Helper()
-
-	// spamoor's deploy is observed in early blocks (typically <10). Cap
-	// the scan so a misbehaving client (no creation tx) fails fast rather
-	// than walking the whole chain.
-	const maxScan = uint64(30)
 
 	latest, err := rpcprobe.EthBlockNumber(rpcURL)
 	if err != nil {
 		t.Errorf("AssertSpamoorOutputs: eth_blockNumber: %v", err)
 		return
 	}
-	end := latest
-	if end > maxScan {
-		end = maxScan
-	}
 
-	for n := uint64(1); n <= end; n++ {
+	for n := uint64(1); n <= latest; n++ {
 		tag := fmt.Sprintf("0x%x", n)
 		block, err := rpcprobe.BlockByNumberWithTxs(rpcURL, tag)
 		if err != nil {
@@ -80,5 +77,5 @@ func AssertSpamoorOutputs(t *testing.T, rpcURL string) {
 			return
 		}
 	}
-	t.Errorf("AssertSpamoorOutputs: no contract-creation tx found in blocks 1..%d (spamoor didn't deploy?)", end)
+	t.Errorf("AssertSpamoorOutputs: no contract-creation tx found in blocks 1..%d (spamoor didn't deploy?)", latest)
 }


### PR DESCRIPTION
## Summary

Bug fix in `AssertSpamoorOutputs` (added in #65). The 30-block scan window was sized against the small e2e config (10 accounts / 3 contracts) where spamoor's setup-then-deploy fits in <10 blocks.

#68 bumps e2e warmup to ~100 MB (15K contracts). With more pre-existing state, spamoor's wallet-funding phase takes ~85 blocks before deploying — observed in #68's failing CI run:

\`\`\`
block 86: root wallet funded
block 87: child wallet funding
block 88: deploy tx sent
block 89: deploy contract 0xE6ea698F89F0beaeBb806E1eA37BDbc33073e2A1 confirmed
\`\`\`

The 30-block scan misses the deploy at block 89, so Phase 6a errors with \"no contract-creation tx found in blocks 1..30\". Spamoor's deploy window scales with configured wallet count + target gas, so a fixed cap is fundamentally fragile.

## Fix

Scan every block 1..latest (no fixed cap). At ~3 RPC calls per block × 100-200 blocks, overhead is <500ms — well within the e2e budget. The \"spamoor didn't deploy?\" error still fires if the client genuinely produces no creation tx.

