### PR TITLE
fix(reth): pin nightly tag to a content digest for CI reproducibility

### DIFF
--- a/client/reth/doc.go
+++ b/client/reth/doc.go
@@ -50,11 +50,12 @@
 // instead of recomputing the genesis hash from chainspec.alloc.
 //
 // The `--debug.skip-genesis-validation` flag is an upstream paradigmxyz/reth
-// addition (currently SHA-pinned via internal/reth/constants.go to a
-// CPerezz/reth fork branch with the patch). Without that flag, reth's
-// init_genesis_with_settings will reject the boot with GenesisHashMismatch
-// because the alloc-derived genesis hash (empty MPT root) differs from the
-// DB-resident genesis hash.
+// addition (currently digest-pinned via internal/reth/constants.go to a
+// nightly snapshot containing #23919, which landed on 2026-05-06 —
+// formerly the CPerezz/reth fork before the upstream merge). Without that
+// flag, reth's init_genesis_with_settings will reject the boot with
+// GenesisHashMismatch because the alloc-derived genesis hash (empty MPT
+// root) differs from the DB-resident genesis hash.
 //
 // # Build tag gating
 //

--- a/client/reth/oracle_test.go
+++ b/client/reth/oracle_test.go
@@ -203,8 +203,10 @@ func TestRethNodeBootEmptyAlloc(t *testing.T) {
 //   - --fork=osaka (reth's MaxForkForClient ceiling, after the writer migration to internal/genesisheader.Build).
 //   - 60M gas matches mainnet-current.
 //   - DinD via the `oracle` build tag.
-//   - Pinned image: paradigmxyz/reth:nightly (post-#23919, supports
-//     --debug.skip-genesis-validation; previously the CPerezz/reth fork).
+//   - Pinned image: paradigmxyz/reth digest-pinned via
+//     internal/reth.PinnedRethRelease (post-#23919, supports
+//     --debug.skip-genesis-validation; previously the CPerezz/reth fork
+//     before the upstream merge on 2026-05-06).
 //   - --dev mode auto-mines on tx, so spamoor advances the chain without
 //     an external CL.
 //

--- a/internal/reth/constants.go
+++ b/internal/reth/constants.go
@@ -20,17 +20,25 @@ const (
 	// PinnedRethRelease is the Docker image tag the differential oracle
 	// + e2e suite boot against in CI.
 	//
-	// "nightly" tracks paradigmxyz/reth main, which contains the
-	// `--debug.skip-genesis-validation` flag (paradigmxyz/reth#23919,
-	// merged 2026-05-06). State-actor's writer-direct datadir requires
-	// that flag — without it reth recomputes the genesis hash from the
-	// chainspec's alloc and rejects the DB.
+	// Pinned by content digest (sha256) appended to the `nightly` tag.
+	// The digest is what Docker resolves to; the `nightly` prefix is a
+	// human-readable hint that this snapshot was a nightly build.
+	//
+	// Why a digest and not just `nightly`: the `nightly` tag in the
+	// upstream registry is overwritten daily, so a fresh CI run can pull
+	// a different image than yesterday and break unrelated PRs. The
+	// digest pin makes builds reproducible.
+	//
+	// The pinned snapshot contains `--debug.skip-genesis-validation`
+	// (paradigmxyz/reth#23919, merged 2026-05-06). State-actor's
+	// writer-direct datadir requires that flag — without it reth
+	// recomputes the genesis hash from the chainspec's alloc and rejects
+	// the DB.
 	//
 	// Bump to a specific `vX.Y.Z` release tag once one is cut after
 	// 2026-05-06 — the oldest release containing #23919 will be the
-	// stable pin. Until then nightly is the only paradigm channel
-	// with the flag.
-	PinnedRethRelease = "nightly"
+	// long-term stable pin.
+	PinnedRethRelease = "nightly@sha256:e528857e5e9ebc2c6cb99f28436e70ded38ca905629f00afc98d186e27d206e0"
 
 	// PinnedRethImage is the fully-qualified image reference (registry + name)
 	// without the tag. Reth is published to GHCR. Migrated from CPerezz/reth

--- a/internal/reth/constants_test.go
+++ b/internal/reth/constants_test.go
@@ -1,6 +1,9 @@
 package reth
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestPinnedConstants(t *testing.T) {
 	if PinnedCodecsVer != "0.3.1" {
@@ -20,5 +23,14 @@ func TestPinnedConstants(t *testing.T) {
 	}
 	if PinnedRethRelease == "" {
 		t.Error("PinnedRethRelease must not be empty")
+	}
+	// PinnedRethRelease must remain digest-pinned. The whole reason this
+	// pin exists is CI reproducibility — upstream's `nightly` tag is
+	// overwritten daily, so a future bump that drops the `@sha256:...`
+	// suffix (e.g., a hasty switch to a plain semver tag, which GHCR
+	// allows to be overwritten) silently re-introduces the failure mode
+	// this PR exists to prevent. Fail loud here instead.
+	if !strings.Contains(PinnedRethRelease, "@sha256:") {
+		t.Errorf("PinnedRethRelease = %q must be digest-pinned (contain @sha256:) for CI reproducibility", PinnedRethRelease)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #47.

The reth `nightly` tag in upstream's GHCR (`ghcr.io/paradigmxyz/reth:nightly`) is overwritten daily by a scheduled workflow. State-actor's CI pulls fresh on every PR run, so two runs of the same PR — even back-to-back — can land different reth images. That's a latent flake source: an upstream nightly that regresses (or just changes behavior) breaks unrelated state-actor PRs.

## Fix

Pin by content digest. The `nightly` prefix is kept as a human-readable hint that this snapshot is a nightly (not a release); Docker resolves the ref by digest regardless.

```diff
- PinnedRethRelease = \"nightly\"
+ PinnedRethRelease = \"nightly@sha256:e528857e5e9ebc2c6cb99f28436e70ded38ca905629f00afc98d186e27d206e0\"
```

The existing join `image + \":\" + tag` produces `ghcr.io/paradigmxyz/reth:nightly@sha256:e528857e...` which is valid OCI reference syntax (digest pin with tag hint).

## Why now, why not bump to a release tag

The merged PR `paradigmxyz/reth#23919` (`--debug.skip-genesis-validation`) is required by state-actor's writer-direct datadir. The PR merged 2026-05-06.

- Latest reth release: **v2.2.0** (commit `88505c7`, dated 2026-04-29) — **before** the merge.
- No tagged release contains the flag yet.

When upstream cuts v2.3.0 (or whatever the first post-2026-05-06 release is), we bump `PinnedRethRelease` from `nightly@sha256:...` to `vX.Y.Z` and drop the digest. Single-line change.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/reth/` green
- [ ] CI: reth e2e suite (Docker pulls by digest, runs as before)