### PR TITLE
feat(reth): storage_v2 migration — drop Plain*, packed trie, RocksDB history, no root-cache emits (closes #79 + #80)

### DIFF
--- a/client/reth/contracts_writer_cgo.go
+++ b/client/reth/contracts_writer_cgo.go
@@ -14,20 +14,20 @@ import (
 	iReth "github.com/nerolation/state-actor/internal/reth"
 )
 
-// WriteContracts writes the 9 reth tables for each contract: Bytecodes
-// (deduped), PlainAccountState, HashedAccounts, AccountChangeSets,
-// AccountsHistory, PlainStorageState, HashedStorages, StorageChangeSets,
-// StoragesHistory.
+// WriteContracts writes the v2 contract tables: Bytecodes (deduped),
+// HashedAccounts, AccountChangeSets (archive), HashedStorages,
+// StorageChangeSets (archive). AccountsHistory + StoragesHistory rows
+// (archive) are routed to the RocksDB CFs via envs.HistorySink().
 //
 // SIDE EFFECT: each contract's StateAccount.Root and .CodeHash are
 // mutated in place from the supplied Storage + Code. With empty Storage
-// the existing Root is preserved (the spec-storage streaming Phase sets
+// the existing Root is preserved (the spec-storage streaming phase sets
 // it ahead of time); a zero Root in that case is rejected.
 //
 // stats (optional) accumulates AccountBytes, CodeBytes (deduped — only
 // counts code that actually got written), and StorageBytes (sum of
-// PlainStorageState compact-encoded entries). Increments are applied
-// only after the MDBX transaction commits.
+// HashedStorages compact-encoded entries). Increments are applied only
+// after the MDBX transaction commits.
 func WriteContracts(envs *Envs, contracts []*entitygen.Account, blockNum uint64, archive bool, stats *generator.Stats) error {
 	var (
 		localAccountBytes uint64
@@ -56,10 +56,15 @@ func WriteContracts(envs *Envs, contracts []*entitygen.Account, blockNum uint64,
 				// precondition would fail on cross-contract boundaries.
 				contractAddrHash := contract.AddrHash
 				emit := func(path iReth.StoredNibbles, node iReth.BranchNodeCompact) error {
+					if path.Length == 0 {
+						// Skip root branch — see TestNoRootCacheRows.
+						return nil
+					}
 					var valBuf bytes.Buffer
 					entry := iReth.StorageTrieEntry{SubKey: path, Node: node}
-					entry.EncodeCompact(&valBuf)
-					// DupSort: main key = keccak(address); value = SubKey||BNC.
+					// v2: 33-byte PackedStoredNibblesSubKey + BNC.
+					entry.EncodePackedCompact(&valBuf)
+					// DupSort: main key = keccak(address); value = packed SubKey || BNC.
 					return txn.Put(envs.MdbxDBIs["StoragesTrie"], contractAddrHash[:], valBuf.Bytes(), 0)
 				}
 				var err error
@@ -96,11 +101,7 @@ func WriteContracts(envs *Envs, contracts []*entitygen.Account, blockNum uint64,
 			ethAccount.EncodeCompact(&accBuf)
 			accountBytes := accBuf.Bytes()
 
-			// PlainAccountState: raw addr → Account
-			if err := txn.Put(envs.MdbxDBIs["PlainAccountState"], contract.Address[:], accountBytes, 0); err != nil {
-				return fmt.Errorf("PlainAccountState %s: %w", contract.Address.Hex(), err)
-			}
-			// HashedAccounts: keccak(addr) → Account
+			// HashedAccounts: keccak(addr) → Account (canonical v2 state).
 			if err := txn.Put(envs.MdbxDBIs["HashedAccounts"], contract.AddrHash[:], accountBytes, 0); err != nil {
 				return fmt.Errorf("HashedAccounts %s: %w", contract.Address.Hex(), err)
 			}
@@ -112,18 +113,13 @@ func WriteContracts(envs *Envs, contracts []*entitygen.Account, blockNum uint64,
 				if err := txn.Put(envs.MdbxDBIs["AccountChangeSets"], blockKey[:], abtBuf.Bytes(), 0); err != nil {
 					return fmt.Errorf("AccountChangeSets %s: %w", contract.Address.Hex(), err)
 				}
-				// AccountsHistory: ShardedKey(addr, u64::MAX) → IntegerList([blockNum])
-				shardedKey := iReth.ShardedKeyAddress{Address: contract.Address, BlockNumber: ^uint64(0)}
-				var keyBuf bytes.Buffer
-				shardedKey.EncodeKey(&keyBuf)
-				var listBuf bytes.Buffer
-				iReth.EncodeIntegerList(&listBuf, []uint64{blockNum})
-				if err := txn.Put(envs.MdbxDBIs["AccountsHistory"], keyBuf.Bytes(), listBuf.Bytes(), 0); err != nil {
+				// AccountsHistory → RocksDB CF (v2 routing).
+				if err := envs.HistorySink().PutAccountHistory(contract.Address, blockNum); err != nil {
 					return fmt.Errorf("AccountsHistory %s: %w", contract.Address.Hex(), err)
 				}
 			}
 
-			storBytes, err := WriteContractStorage(txn, envs.MdbxDBIs, contract, blockNum, archive)
+			storBytes, err := WriteContractStorage(envs, txn, contract, blockNum, archive)
 			if err != nil {
 				return fmt.Errorf("WriteContracts: WriteContractStorage %s: %w", contract.Address.Hex(), err)
 			}

--- a/client/reth/data_writer_cgo.go
+++ b/client/reth/data_writer_cgo.go
@@ -13,30 +13,21 @@ import (
 	iReth "github.com/nerolation/state-actor/internal/reth"
 )
 
-// WriteEOAs writes data-table rows for each account: PlainAccountState,
-// HashedAccounts, and (in archive mode) AccountChangeSets at blockNum
-// + AccountsHistory.
-//
-// All writes happen in ONE MDBX write transaction. Atomic; on error no
-// partial state is committed.
+// WriteEOAs writes the v2 data-table rows for each account inside one
+// atomic MDBX write transaction.
 //
 // Tables written per EOA:
-//   - PlainAccountState (Address → Account) — always
-//   - HashedAccounts (keccak(Address) → Account) — always
-//   - AccountChangeSets (DupSort: BE_u64(block) → AccountBeforeTx{addr, nil}) — archive only
-//   - AccountsHistory (ShardedKey(addr, u64::MAX) → IntegerList([blockNum])) — archive only
+//   - HashedAccounts (keccak(Address) → Account) — canonical v2 state, always.
+//   - AccountChangeSets (DupSort: BE_u64(block) → AccountBeforeTx{addr, nil}) — archive only.
+//   - AccountsHistory (ShardedKey(addr, u64::MAX) → IntegerList([blockNum])) — archive only;
+//     routed to the RocksDB CF via envs.HistorySink().
 //
-// In full mode (archive=false), the two archive-only tables are skipped:
-// at block 0 there's no history to preserve, and a full-mode reth node
-// prunes them once past the pruning window.
-//
-// Accounts are written in input order (caller is responsible for ordering).
-// Uses tx.Put (not cursor.Append) for safety regardless of input ordering.
+// Accounts are written in input order (caller controls ordering). Uses
+// tx.Put (not cursor.Append) for safety regardless of input ordering.
 //
 // stats (optional) accumulates AccountBytes — the encoded compact-Account
-// size for every account written. Pass nil to skip accounting. The
-// accumulator is applied to stats only after the MDBX transaction commits;
-// a write that rolls back leaves stats untouched.
+// size for every account written. Pass nil to skip accounting; only applied
+// after the MDBX transaction commits, so a rollback leaves stats untouched.
 func WriteEOAs(envs *Envs, accounts []*entitygen.Account, blockNum uint64, archive bool, stats *generator.Stats) error {
 	var localAccountBytes uint64
 	err := envs.Mdbx.Update(func(txn *mdbx.Txn) error {
@@ -56,18 +47,14 @@ func WriteEOAs(envs *Envs, accounts []*entitygen.Account, blockNum uint64, archi
 			ethAccount.EncodeCompact(&accBuf)
 			accountBytes := accBuf.Bytes()
 
-			// 1. PlainAccountState — raw addr → Account
-			if err := txn.Put(envs.MdbxDBIs["PlainAccountState"], acc.Address[:], accountBytes, 0); err != nil {
-				return fmt.Errorf("PlainAccountState %s: %w", acc.Address.Hex(), err)
-			}
-
-			// 2. HashedAccounts — keccak(addr) → Account
+			// HashedAccounts — keccak(addr) → Account. Canonical v2 state;
+			// reth's Latest/HistoricalStateProvider reads this table.
 			if err := txn.Put(envs.MdbxDBIs["HashedAccounts"], acc.AddrHash[:], accountBytes, 0); err != nil {
 				return fmt.Errorf("HashedAccounts %s: %w", acc.Address.Hex(), err)
 			}
 
 			if archive {
-				// 3. AccountChangeSets — DupSort: BE_u64(block) → AccountBeforeTx{addr, nil}
+				// AccountChangeSets — DupSort: BE_u64(block) → AccountBeforeTx{addr, nil}
 				// Address is the DupSort SubKey (encoded first in AccountBeforeTx.EncodeCompact).
 				// Info=nil: account had no prior state (genesis creation).
 				abt := iReth.AccountBeforeTx{Address: acc.Address, Info: nil}
@@ -77,22 +64,16 @@ func WriteEOAs(envs *Envs, accounts []*entitygen.Account, blockNum uint64, archi
 					return fmt.Errorf("AccountChangeSets %s: %w", acc.Address.Hex(), err)
 				}
 
-				// 4. AccountsHistory — ShardedKey(addr, u64::MAX) → IntegerList([blockNum])
-				// u64::MAX marks the latest (open) shard; the bitmap contains the block
-				// numbers at which this account was first touched.
-				shardedKey := iReth.ShardedKeyAddress{Address: acc.Address, BlockNumber: ^uint64(0)}
-				var keyBuf bytes.Buffer
-				shardedKey.EncodeKey(&keyBuf)
-				var listBuf bytes.Buffer
-				iReth.EncodeIntegerList(&listBuf, []uint64{blockNum})
-				if err := txn.Put(envs.MdbxDBIs["AccountsHistory"], keyBuf.Bytes(), listBuf.Bytes(), 0); err != nil {
+				// AccountsHistory → RocksDB CF (v2 routing per
+				// EitherReader::new_accounts_history). Wire format:
+				// ShardedKeyAddress(addr, u64::MAX) → EncodeIntegerList([blockNum]).
+				if err := envs.HistorySink().PutAccountHistory(acc.Address, blockNum); err != nil {
 					return fmt.Errorf("AccountsHistory %s: %w", acc.Address.Hex(), err)
 				}
 			}
 
-			// Plain + Hashed writes always succeed; archive-only writes
-			// inside the if-block fall through to here. Bank the row's
-			// bytes locally; transferred to stats only if Update succeeds.
+			// Bank the row's bytes locally; transferred to stats only if
+			// Update succeeds.
 			localAccountBytes += uint64(len(accountBytes))
 		}
 		return nil

--- a/client/reth/data_writer_cgo_test.go
+++ b/client/reth/data_writer_cgo_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/erigontech/mdbx-go/mdbx"
+	"github.com/linxGnu/grocksdb"
 
 	"github.com/nerolation/state-actor/generator"
 	"github.com/nerolation/state-actor/internal/entitygen"
@@ -33,10 +34,27 @@ func TestWriteEOAsRoundtrip(t *testing.T) {
 		t.Fatalf("WriteEOAs: %v", err)
 	}
 
-	// Read back PlainAccountState for each account; verify nonce + balance.
+	// v2 invariant: PlainAccountState MUST be empty.
+	if err := envs.Mdbx.View(func(txn *mdbx.Txn) error {
+		cur, err := txn.OpenCursor(envs.MdbxDBIs["PlainAccountState"])
+		if err != nil {
+			return err
+		}
+		defer cur.Close()
+		k, _, err := cur.Get(nil, nil, mdbx.First)
+		if err == nil {
+			t.Errorf("PlainAccountState should be empty under v2, first key = %x", k)
+		}
+		return nil
+	}); err != nil {
+		t.Errorf("v2 invariant check on PlainAccountState: %v", err)
+	}
+
+	// Read back HashedAccounts — canonical v2 state. Decode + verify
+	// nonce/balance (moved from the dropped PlainAccountState read-back).
 	if err := envs.Mdbx.View(func(txn *mdbx.Txn) error {
 		for _, acc := range accounts {
-			val, err := txn.Get(envs.MdbxDBIs["PlainAccountState"], acc.Address[:])
+			val, err := txn.Get(envs.MdbxDBIs["HashedAccounts"], acc.AddrHash[:])
 			if err != nil {
 				return err
 			}
@@ -54,43 +72,31 @@ func TestWriteEOAsRoundtrip(t *testing.T) {
 		}
 		return nil
 	}); err != nil {
-		t.Errorf("read-back PlainAccountState: %v", err)
-	}
-
-	// Read back HashedAccounts — entry must exist for each account.
-	if err := envs.Mdbx.View(func(txn *mdbx.Txn) error {
-		for _, acc := range accounts {
-			val, err := txn.Get(envs.MdbxDBIs["HashedAccounts"], acc.AddrHash[:])
-			if err != nil {
-				return err
-			}
-			if len(val) == 0 {
-				t.Errorf("HashedAccounts empty for %s", acc.AddrHash.Hex())
-			}
-		}
-		return nil
-	}); err != nil {
 		t.Errorf("read-back HashedAccounts: %v", err)
 	}
 
-	// Read back AccountsHistory — ShardedKey(addr, u64::MAX) must exist.
-	if err := envs.Mdbx.View(func(txn *mdbx.Txn) error {
-		for _, acc := range accounts {
-			sk := iReth.ShardedKeyAddress{Address: acc.Address, BlockNumber: ^uint64(0)}
-			var keyBuf bytes.Buffer
-			sk.EncodeKey(&keyBuf)
-			val, err := txn.Get(envs.MdbxDBIs["AccountsHistory"], keyBuf.Bytes())
-			if err != nil {
-				return err
-			}
-			list, _ := iReth.DecodeIntegerList(val)
-			if len(list) != 1 || list[0] != 0 {
-				t.Errorf("AccountsHistory for %s: got %v, want [0]", acc.Address.Hex(), list)
-			}
+	// Read back AccountsHistory from the RocksDB CF (v2 routing). Flush the
+	// historySink first so the WAL-disabled batch lands in the memtable
+	// where GetCF can see it.
+	if err := envs.HistorySink().Flush(); err != nil {
+		t.Fatalf("historySink.Flush: %v", err)
+	}
+	ro := grocksdb.NewDefaultReadOptions()
+	defer ro.Destroy()
+	for _, acc := range accounts {
+		sk := iReth.ShardedKeyAddress{Address: acc.Address, BlockNumber: ^uint64(0)}
+		var keyBuf bytes.Buffer
+		sk.EncodeKey(&keyBuf)
+		val, err := envs.RocksDB.GetCF(ro, envs.RocksCFs["AccountsHistory"], keyBuf.Bytes())
+		if err != nil {
+			t.Errorf("GetCF AccountsHistory %s: %v", acc.Address.Hex(), err)
+			continue
 		}
-		return nil
-	}); err != nil {
-		t.Errorf("read-back AccountsHistory: %v", err)
+		list, _ := iReth.DecodeIntegerList(val.Data())
+		if len(list) != 1 || list[0] != 0 {
+			t.Errorf("AccountsHistory for %s: got %v, want [0]", acc.Address.Hex(), list)
+		}
+		val.Free()
 	}
 }
 

--- a/client/reth/dbs_cgo.go
+++ b/client/reth/dbs_cgo.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Reth MDBX geometry — matches reth's default in
-// crates/storage/db/src/implementation/mdbx/mod.rs:72-240.
+// crates/storage/db/src/implementation/mdbx/mod.rs.
 //
 // Page size: reth uses default_page_size() = OS page size clamped to
 // [4096, 65536]. Passing 0 to mdbx-go is treated as MDBX_MIN_PAGESIZE
@@ -32,7 +32,7 @@ const (
 )
 
 // mdbxDefaultPageSize matches reth's default_page_size() in
-// crates/storage/db/src/implementation/mdbx/mod.rs:139,160.
+// crates/storage/db/src/implementation/mdbx/mod.rs.
 func mdbxDefaultPageSize() int {
 	ps := os.Getpagesize()
 	if ps < 4096 {
@@ -61,7 +61,23 @@ type Envs struct {
 	RocksDB  *grocksdb.DB
 	RocksCFs map[string]*grocksdb.ColumnFamilyHandle
 
+	// historySink batches archive-mode AccountsHistory + StoragesHistory
+	// writes into the RocksDB column families v2 reth reads from. Lazy-
+	// initialised by HistorySink; Close drains + tears it down.
+	historySink *historySink
+
 	closed bool
+}
+
+// HistorySink returns the per-Envs archive-mode history sink, creating it
+// on first call. NOT goroutine-safe — callers serialise puts (the streaming
+// consumer is single-goroutine; the inline writers are called from one
+// MDBX Update closure at a time).
+func (e *Envs) HistorySink() *historySink {
+	if e.historySink == nil {
+		e.historySink = newHistorySink(e)
+	}
+	return e.historySink
 }
 
 // OpenEnvs creates a fresh datadir at dataDir and opens the MDBX env +
@@ -111,20 +127,11 @@ func OpenEnvs(dataDir string, freshDir bool) (*Envs, error) {
 		return nil, fmt.Errorf("mdbx.SetOption(OptMaxDB): %w", err)
 	}
 
-	// MDBX_WRITEMAP + MDBX_SAFE_NOSYNC turn per-txn.Put cost from
-	// O(log N) + periodic O(N) (in-process dirty-page list with a radixsort
-	// at mdbx.c:6897-6951) into kernel-managed O(1) writeback via mmap.
-	// This is what reth's own MDBX env does (reth's mdbx/mod.rs:411 —
-	// inner_env.write_map()). Without these flags, a single Mdbx.Update
-	// with hundreds of millions of Puts (one bloatnet bloated EOA)
-	// thrashes the L2/L3 cache and degrades from ~3 MB/s to <0.3 MB/s.
-	// Durability is owed at Envs.Close — see the explicit Sync there.
-	//
-	// MDBX_NOMEMINIT skips the zero-fill on freshly-allocated pages
-	// (we overwrite them immediately on the bulk-write path). MDBX_LIFORECLAIM
-	// makes free-page reclamation LIFO instead of FIFO — better cache
-	// locality for sequential writes. Both are used in production by Erigon
-	// (where mdbx-go originates) and are safe for our one-shot genesis use.
+	// WriteMap + SafeNoSync mirror reth's own MDBX env (mdbx/mod.rs)
+	// for bulk-write throughput; durability is owed at Envs.Close via the
+	// explicit Sync. NoMemInit skips zero-fill on freshly-allocated pages
+	// (we overwrite them). LifoReclaim improves cache locality for
+	// sequential writes.
 	const envFlags = mdbx.WriteMap | mdbx.SafeNoSync | mdbx.NoMemInit | mdbx.LifoReclaim
 	if err := env.Open(dbDir, envFlags, 0o644); err != nil {
 		env.Close()
@@ -199,13 +206,39 @@ func requireFreshDir(dataDir string) error {
 // MDBX_SAFE_NOSYNC deferred writes are flushed to disk on a clean
 // process exit. force=true requests synchronous fdatasync;
 // nonblock=false waits for completion.
+//
+// On the RocksDB side, FlushCFs forces the per-CF memtables to land as
+// SST files before Close. Bulk writes go through historySink with
+// WAL-disabled, so without this flush reth's first read could see an
+// empty CF whose state lived only in the now-discarded memtable.
 func (e *Envs) Close() error {
 	if e == nil || e.closed {
 		return nil
 	}
 	e.closed = true
 	var firstErr error
+	// Drain the history sink BEFORE FlushCFs — sink.Close moves any
+	// pending batch into the RocksDB memtable; FlushCFs then drains the
+	// memtable to SST files. Reversed order = silent data loss.
+	if e.historySink != nil {
+		if err := e.historySink.Close(); err != nil {
+			firstErr = fmt.Errorf("historySink.Close: %w", err)
+		}
+		e.historySink = nil
+	}
 	if e.RocksDB != nil {
+		flushOpts := grocksdb.NewDefaultFlushOptions()
+		flushOpts.SetWait(true)
+		cfs := make([]*grocksdb.ColumnFamilyHandle, 0, len(e.RocksCFs))
+		for _, cf := range e.RocksCFs {
+			cfs = append(cfs, cf)
+		}
+		if err := e.RocksDB.FlushCFs(cfs, flushOpts); err != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("rocksdb.FlushCFs: %w", err)
+			}
+		}
+		flushOpts.Destroy()
 		for _, cf := range e.RocksCFs {
 			cf.Destroy()
 		}
@@ -213,7 +246,9 @@ func (e *Envs) Close() error {
 	}
 	if e.Mdbx != nil {
 		if err := e.Mdbx.Sync(true, false); err != nil {
-			firstErr = fmt.Errorf("mdbx.Sync: %w", err)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("mdbx.Sync: %w", err)
+			}
 		}
 		e.Mdbx.Close()
 	}

--- a/client/reth/doc.go
+++ b/client/reth/doc.go
@@ -8,19 +8,28 @@
 //
 //	stats, err := reth.RunCgo(ctx, cfg, reth.Options{})
 //
-// RunCgo writes the on-disk artifacts reth boot validates:
+// RunCgo writes the on-disk artifacts reth boot validates. The datadir is a
+// v2 layout (Metadata.storage_settings = {"storage_v2":true}):
 //
-//   - <datadir>/db/mdbx.dat — MDBX env with all named DBIs
-//     (PlainAccountState, HashedAccounts, AccountChangeSets,
-//     AccountsHistory, PlainStorageState, HashedStorages,
-//     StorageChangeSets, StoragesHistory, Bytecodes, plus 15 metadata
-//     tables incl. StageCheckpoints/Metadata/HeaderNumbers/etc.)
+//   - <datadir>/db/mdbx.dat — MDBX env. Canonical state lives in
+//     HashedAccounts + HashedStorages; Plain* tables are declared but
+//     empty under storage_v2. Trie + changeset + metadata tables
+//     (AccountsTrie, StoragesTrie, AccountChangeSets, StorageChangeSets,
+//     Bytecodes, StageCheckpoints, HeaderNumbers, BlockBodyIndices,
+//     PruneCheckpoints, etc.) stay MDBX-resident.
 //   - <datadir>/db/database.version — schema version sentinel ("2")
-//   - <datadir>/rocksdb/* — RocksDB env with v2 history-table column
-//     families
-//   - <datadir>/static_files/{headers,transactions,receipts,
-//     transaction-senders}/static_file_*_0_499999.{conf,sf,off} — block-0
-//     segment files in the nippy-jar format
+//   - <datadir>/rocksdb/* — RocksDB env with the v2 history CFs
+//     (AccountsHistory + StoragesHistory + TransactionHashNumbers + the
+//     default CF). The two history CFs receive writes under
+//     cfg.Archive=true; default-mode runs leave them empty (PruneCheckpoint
+//     markers tell reth's read path "history pruned before block 1",
+//     routing historical-tag queries through HashedAccounts).
+//   - <datadir>/static_files/static_file_<segment>_0_499999 (no extension)
+//     + .conf + .off (+ .csoff for change-based segments) — block-0
+//     nippy-jar segment files for headers, transactions, receipts,
+//     transaction-senders, account-change-sets, storage-change-sets. The
+//     two change-based segments are required as empty bootstrap shells so
+//     reth's persistence service can append block 1 cleanly.
 //   - <datadir>/chainspec.json — sidecar reth boot revalidates
 //
 // The state root in the genesis header is computed from the generated
@@ -59,9 +68,9 @@
 // # Build tag gating
 //
 // The cgo path lives behind `//go:build cgo_reth`. Without that tag,
-// RunCgo returns errNotImplemented pointing at Dockerfile.reth (see
-// run_stub.go). Local Go builds without libmdbx + librocksdb headers
-// remain compilable but cannot exercise the cgo path.
+// RunCgo returns runCgoNotAvailableError pointing at Dockerfile.reth
+// (see run_stub.go). Local Go builds without libmdbx + librocksdb
+// headers remain compilable but cannot exercise the cgo path.
 //
 // # Validation
 //
@@ -84,7 +93,7 @@
 //   - sidecars.go: database.version writer
 //   - state_root.go / storage_root.go: HashBuilder-driven state-root
 //     computation (sliced + streaming variants)
-//   - temp_sort_cgo.go: Pebble-backed temp sorter for streaming Phase 4
+//   - internal/streamsort: Pebble-backed temp sorter for streaming Phase 4
 //   - chainspec.go: chainspec JSON writer (built from cfg.Genesis)
 //   - header.go: genesis header construction
 //   - options.go: Options struct (reserved); buildAllocAccounts helper

--- a/client/reth/history_rocks_cgo.go
+++ b/client/reth/history_rocks_cgo.go
@@ -1,0 +1,119 @@
+//go:build cgo_reth
+
+package reth
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/linxGnu/grocksdb"
+
+	iReth "github.com/nerolation/state-actor/internal/reth"
+)
+
+// historyFlushThresholdBytes mirrors the besu writer's bulk-flush threshold:
+// large enough to amortise RocksDB commit overhead, small enough to bound
+// peak resident memory during archive-mode genesis writes.
+const historyFlushThresholdBytes = 64 * 1024 * 1024
+
+// historySink batches puts into reth v2's AccountsHistory and StoragesHistory
+// column families (EitherReader::new_accounts_history /
+// new_storages_history routes reads there under storage_v2).
+//
+// Durability is owed at Envs.Close (which FlushCFs the underlying
+// memtables to SST files); per-flush we DisableWAL so the per-row append
+// doesn't pay an fsync.
+//
+// NOT goroutine-safe; producers must serialise puts through one sink, or
+// use one sink per goroutine and Flush each before merging results.
+type historySink struct {
+	db         *grocksdb.DB
+	accountsCF *grocksdb.ColumnFamilyHandle
+	storagesCF *grocksdb.ColumnFamilyHandle
+	batch      *grocksdb.WriteBatch
+	bytes      int
+}
+
+// newHistorySink builds a sink backed by envs.RocksDB + envs.RocksCFs.
+// Caller must Close the sink (or call Flush before letting it go out of
+// scope) to drain pending puts and release the underlying C++ WriteBatch.
+func newHistorySink(envs *Envs) *historySink {
+	return &historySink{
+		db:         envs.RocksDB,
+		accountsCF: envs.RocksCFs["AccountsHistory"],
+		storagesCF: envs.RocksCFs["StoragesHistory"],
+		batch:      grocksdb.NewWriteBatch(),
+	}
+}
+
+// PutAccountHistory puts ShardedKeyAddress(addr, u64::MAX) →
+// EncodeIntegerList([blockNum]) into the AccountsHistory column family.
+func (s *historySink) PutAccountHistory(addr common.Address, blockNum uint64) error {
+	shardedKey := iReth.ShardedKeyAddress{Address: addr, BlockNumber: ^uint64(0)}
+	var keyBuf bytes.Buffer
+	shardedKey.EncodeKey(&keyBuf)
+	var listBuf bytes.Buffer
+	iReth.EncodeIntegerList(&listBuf, []uint64{blockNum})
+	s.batch.PutCF(s.accountsCF, keyBuf.Bytes(), listBuf.Bytes())
+	s.bytes += keyBuf.Len() + listBuf.Len()
+	return s.maybeFlush()
+}
+
+// PutStorageHistory puts StorageShardedKey(addr, slotKey, u64::MAX) →
+// EncodeIntegerList([blockNum]) into the StoragesHistory column family.
+func (s *historySink) PutStorageHistory(addr common.Address, slotKey common.Hash, blockNum uint64) error {
+	ssk := iReth.StorageShardedKey{
+		Address:     addr,
+		StorageKey:  slotKey,
+		BlockNumber: ^uint64(0),
+	}
+	var keyBuf bytes.Buffer
+	ssk.EncodeKey(&keyBuf)
+	var listBuf bytes.Buffer
+	iReth.EncodeIntegerList(&listBuf, []uint64{blockNum})
+	s.batch.PutCF(s.storagesCF, keyBuf.Bytes(), listBuf.Bytes())
+	s.bytes += keyBuf.Len() + listBuf.Len()
+	return s.maybeFlush()
+}
+
+// Flush drains the current batch via an async WAL-disabled write. Safe to
+// call repeatedly; resets the batch on success.
+func (s *historySink) Flush() error {
+	if s.bytes == 0 {
+		return nil
+	}
+	return s.flush()
+}
+
+// Close drains any pending writes and releases the underlying WriteBatch.
+// Idempotent.
+func (s *historySink) Close() error {
+	if s.batch == nil {
+		return nil
+	}
+	defer func() {
+		s.batch.Destroy()
+		s.batch = nil
+	}()
+	return s.Flush()
+}
+
+func (s *historySink) maybeFlush() error {
+	if s.bytes < historyFlushThresholdBytes {
+		return nil
+	}
+	return s.flush()
+}
+
+func (s *historySink) flush() error {
+	wo := grocksdb.NewDefaultWriteOptions()
+	defer wo.Destroy()
+	wo.DisableWAL(true)
+	if err := s.db.Write(wo, s.batch); err != nil {
+		return fmt.Errorf("reth history sink: flush: %w", err)
+	}
+	s.batch.Clear()
+	s.bytes = 0
+	return nil
+}

--- a/client/reth/history_rocks_cgo_test.go
+++ b/client/reth/history_rocks_cgo_test.go
@@ -1,0 +1,179 @@
+//go:build cgo_reth
+
+package reth
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/linxGnu/grocksdb"
+
+	iReth "github.com/nerolation/state-actor/internal/reth"
+)
+
+// TestHistorySink_PutAndFlush exercises the basic write+read cycle: stage
+// a few entries via PutAccountHistory + PutStorageHistory, Flush, then
+// read the rows back via the RocksDB CF cursor and verify byte-identical
+// key/value pairs.
+func TestHistorySink_PutAndFlush(t *testing.T) {
+	tmp := t.TempDir()
+	envs, err := OpenEnvs(tmp, true)
+	if err != nil {
+		t.Fatalf("OpenEnvs: %v", err)
+	}
+	defer envs.Close()
+
+	sink := newHistorySink(envs)
+	defer sink.Close()
+
+	addrA := common.Address{0x01, 0x02, 0x03}
+	addrB := common.Address{0xAA, 0xBB}
+	if err := sink.PutAccountHistory(addrA, 7); err != nil {
+		t.Fatalf("PutAccountHistory: %v", err)
+	}
+	if err := sink.PutAccountHistory(addrB, 42); err != nil {
+		t.Fatalf("PutAccountHistory: %v", err)
+	}
+	slotKey := common.Hash{0x10}
+	if err := sink.PutStorageHistory(addrA, slotKey, 7); err != nil {
+		t.Fatalf("PutStorageHistory: %v", err)
+	}
+	if err := sink.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	ro := grocksdb.NewDefaultReadOptions()
+	defer ro.Destroy()
+
+	// AccountsHistory: ShardedKeyAddress(addr, u64::MAX) → EncodeIntegerList([blockNum])
+	for _, tc := range []struct {
+		addr     common.Address
+		blockNum uint64
+	}{{addrA, 7}, {addrB, 42}} {
+		shardedKey := iReth.ShardedKeyAddress{Address: tc.addr, BlockNumber: ^uint64(0)}
+		var keyBuf bytes.Buffer
+		shardedKey.EncodeKey(&keyBuf)
+		val, err := envs.RocksDB.GetCF(ro, envs.RocksCFs["AccountsHistory"], keyBuf.Bytes())
+		if err != nil {
+			t.Fatalf("GetCF AccountsHistory %s: %v", tc.addr.Hex(), err)
+		}
+		var listBuf bytes.Buffer
+		iReth.EncodeIntegerList(&listBuf, []uint64{tc.blockNum})
+		if !bytes.Equal(val.Data(), listBuf.Bytes()) {
+			t.Errorf("AccountsHistory[%s] = %x, want %x", tc.addr.Hex(), val.Data(), listBuf.Bytes())
+		}
+		val.Free()
+	}
+
+	// StoragesHistory: StorageShardedKey(addr, slotKey, u64::MAX) → EncodeIntegerList([blockNum])
+	ssk := iReth.StorageShardedKey{Address: addrA, StorageKey: slotKey, BlockNumber: ^uint64(0)}
+	var sskBuf bytes.Buffer
+	ssk.EncodeKey(&sskBuf)
+	val, err := envs.RocksDB.GetCF(ro, envs.RocksCFs["StoragesHistory"], sskBuf.Bytes())
+	if err != nil {
+		t.Fatalf("GetCF StoragesHistory: %v", err)
+	}
+	defer val.Free()
+	var listBuf bytes.Buffer
+	iReth.EncodeIntegerList(&listBuf, []uint64{7})
+	if !bytes.Equal(val.Data(), listBuf.Bytes()) {
+		t.Errorf("StoragesHistory = %x, want %x", val.Data(), listBuf.Bytes())
+	}
+}
+
+// TestHistorySink_CloseDrainsBatch checks the durability contract: writes
+// staged via the sink but never explicitly flushed must still land on disk
+// when Envs.Close runs (sink.Close drains the WriteBatch into the memtable
+// + Envs.Close's FlushCFs forces the memtable to SST).
+//
+// Catches a regression where someone removes the FlushCFs in Envs.Close
+// (silent data loss; reth would later see an empty AccountsHistory CF).
+func TestHistorySink_CloseDrainsBatch(t *testing.T) {
+	tmp := t.TempDir()
+	envs, err := OpenEnvs(tmp, true)
+	if err != nil {
+		t.Fatalf("OpenEnvs: %v", err)
+	}
+
+	sink := newHistorySink(envs)
+	addr := common.Address{0xCC, 0xDD}
+	if err := sink.PutAccountHistory(addr, 99); err != nil {
+		envs.Close()
+		t.Fatalf("PutAccountHistory: %v", err)
+	}
+	// Deliberately skip sink.Flush(); rely on sink.Close + Envs.Close FlushCFs.
+	if err := sink.Close(); err != nil {
+		envs.Close()
+		t.Fatalf("sink.Close: %v", err)
+	}
+	if err := envs.Close(); err != nil {
+		t.Fatalf("Envs.Close: %v", err)
+	}
+
+	// Re-open and assert the row landed.
+	envs2, err := OpenEnvs(tmp, false)
+	if err != nil {
+		t.Fatalf("re-open: %v", err)
+	}
+	defer envs2.Close()
+
+	ro := grocksdb.NewDefaultReadOptions()
+	defer ro.Destroy()
+	shardedKey := iReth.ShardedKeyAddress{Address: addr, BlockNumber: ^uint64(0)}
+	var keyBuf bytes.Buffer
+	shardedKey.EncodeKey(&keyBuf)
+	val, err := envs2.RocksDB.GetCF(ro, envs2.RocksCFs["AccountsHistory"], keyBuf.Bytes())
+	if err != nil {
+		t.Fatalf("GetCF after reopen: %v", err)
+	}
+	defer val.Free()
+	if val.Size() == 0 {
+		t.Errorf("AccountsHistory[%s] not found after Envs.Close round-trip — FlushCFs may be missing", addr.Hex())
+	}
+}
+
+// TestHistorySink_Threshold guards the historyFlushThresholdBytes
+// auto-flush logic: enough puts to cumulatively exceed the threshold MUST
+// trigger ≥1 in-band flush (s.bytes drops back below the threshold).
+// Catches a regression that forgets to advance s.bytes or to compare
+// against the constant. Skipped in -short.
+func TestHistorySink_Threshold(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Threshold test does bulk RocksDB writes; skipped in short mode")
+	}
+	tmp := t.TempDir()
+	envs, err := OpenEnvs(tmp, true)
+	if err != nil {
+		t.Fatalf("OpenEnvs: %v", err)
+	}
+	defer envs.Close()
+
+	sink := newHistorySink(envs)
+	defer sink.Close()
+
+	// Each PutStorageHistory writes ~(53 key + small varint value) ≈ 63
+	// bytes via PutCF. 2.0M puts ≈ 126 MiB → guaranteed to cross the
+	// 64 MiB threshold at least once. Each crossing resets s.bytes to 0,
+	// so the final s.bytes is bounded by one threshold's worth of puts.
+	addr := common.Address{0xEF}
+	const N = 2_000_000
+	for i := uint64(0); i < N; i++ {
+		var slot common.Hash
+		slot[24] = byte(i >> 56)
+		slot[25] = byte(i >> 48)
+		slot[26] = byte(i >> 40)
+		slot[27] = byte(i >> 32)
+		slot[28] = byte(i >> 24)
+		slot[29] = byte(i >> 16)
+		slot[30] = byte(i >> 8)
+		slot[31] = byte(i)
+		if err := sink.PutStorageHistory(addr, slot, i); err != nil {
+			t.Fatalf("PutStorageHistory[%d]: %v", i, err)
+		}
+	}
+	if sink.bytes >= historyFlushThresholdBytes {
+		t.Errorf("after %d puts, s.bytes=%d >= threshold %d — auto-flush never triggered",
+			N, sink.bytes, historyFlushThresholdBytes)
+	}
+}

--- a/client/reth/metadata_cgo.go
+++ b/client/reth/metadata_cgo.go
@@ -13,37 +13,32 @@ import (
 	iReth "github.com/nerolation/state-actor/internal/reth"
 )
 
-// WriteMetadata populates the minimum-boot MDBX metadata into envs.
-// header is the genesis header (block 0). chainID is reth's chain ID.
-// archive controls whether to write PruneCheckpoint markers (see below).
+// WriteMetadata populates the minimum-boot MDBX metadata into envs in a
+// single atomic transaction. header must be the genesis header (block 0);
+// archive controls whether to write PruneCheckpoint markers.
 //
-// Writes the following tables in a single atomic transaction:
-//   - Metadata.storage_v2 = Compact-encoded StorageSettings{storage_v2: true}
-//     (1-byte bitflag header with the single bit set = 0x01).
-//   - StageCheckpoints: one entry per stage in iReth.StageIDsAll (15 entries),
-//     Compact-encoded StageCheckpoint{BlockNumber: 0}.
+// Tables written:
+//   - Metadata.storage_settings = SCALE-prefixed JSON `{"storage_v2":true}`
+//     (selects reth's v2 reader/writer surface).
+//   - StageCheckpoints: one entry per stage in iReth.StageIDsAll (15 entries).
 //   - HeaderNumbers: header.Hash() → BE u64(0).
 //   - BlockBodyIndices: BE u64(0) → Compact StoredBlockBodyIndices{0, 0}.
-//   - PruneCheckpoints (NON-ARCHIVE ONLY): two rows for AccountHistory +
-//     StorageHistory with block_number=Some(0), prune_mode=Before(1).
-//     Triggers reth's HistoricalStateProvider.MaybeInPlainState branch
-//     (historical.rs:861-867) so eth_getBalance on genesis accounts reads
-//     PlainAccountState directly instead of returning NotYetWritten when
-//     history-index tables are empty in non-archive mode.
+//   - PruneCheckpoints (NON-ARCHIVE ONLY): AccountHistory + StorageHistory
+//     rows with block_number=Some(0), prune_mode=Before(1). Tells reth's
+//     read path "history pruned before block 1" so historical-tag queries
+//     route through HashedAccounts/HashedStorages instead of returning
+//     NotYetWritten when the RocksDB history CFs are empty.
 //
-// VersionHistory is intentionally NOT written here. Reth's init_db writes its
-// own ClientVersion entry keyed by the current Unix timestamp on every boot.
-// ChainState is left empty; reth populates it lazily on finality.
-//
-// NOTE: the Number=0 guard below is a forward-compatibility trap. If a future
-// caller switches to a non-genesis header, this guard must be relaxed.
-func WriteMetadata(envs *Envs, header *types.Header, chainID uint64, archive bool) error {
+// VersionHistory is intentionally NOT written — reth's init_db writes its
+// own ClientVersion on every boot. ChainState is left empty; reth populates
+// it lazily on finality.
+func WriteMetadata(envs *Envs, header *types.Header, archive bool) error {
 	if header.Number.Sign() != 0 {
 		return fmt.Errorf("WriteMetadata: header must be block 0, got %s", header.Number)
 	}
 	return envs.Mdbx.Update(func(txn *mdbx.Txn) error {
-		if err := writeStorageV2Flag(txn, envs.MdbxDBIs["Metadata"]); err != nil {
-			return fmt.Errorf("Metadata.storage_v2: %w", err)
+		if err := writeStorageSettings(txn, envs.MdbxDBIs["Metadata"]); err != nil {
+			return fmt.Errorf("Metadata.storage_settings: %w", err)
 		}
 		if err := writeStageCheckpoints(txn, envs.MdbxDBIs["StageCheckpoints"], 0); err != nil {
 			return fmt.Errorf("StageCheckpoints: %w", err)
@@ -63,19 +58,12 @@ func WriteMetadata(envs *Envs, header *types.Header, chainID uint64, archive boo
 	})
 }
 
-// writePruneCheckpoints writes the two non-archive-mode PruneCheckpoint rows
-// for AccountHistory and StorageHistory. Together they trigger reth's
-// MaybeInPlainState read-path fallback (see WriteMetadata doc).
-//
-// Both rows use the same value: PruneCheckpoint{
-//
-//	block_number: Some(0),
-//	tx_number:    None,
-//	prune_mode:   PruneMode::Before(1),
-//
-// }. The block_number-is-Some bit is what flips reth's history_info() from
-// NotYetWritten to MaybeInPlainState; the prune_mode value is informational
-// (mirrors what reth's own pruner would write after a single run).
+// writePruneCheckpoints writes non-archive-mode PruneCheckpoint rows for
+// AccountHistory + StorageHistory. Both rows use the same value:
+// {block_number: Some(0), tx_number: None, prune_mode: Before(1)}. The
+// block_number-is-Some bit tells reth's read path "history pruned before
+// block 1" so historical-tag queries route through Hashed* state instead of
+// returning NotYetWritten.
 func writePruneCheckpoints(txn *mdbx.Txn, dbi mdbx.DBI) error {
 	ckpt := iReth.PruneCheckpoint{
 		BlockNumber: iReth.U64Ptr(0),
@@ -95,13 +83,28 @@ func writePruneCheckpoints(txn *mdbx.Txn, dbi mdbx.DBI) error {
 	return nil
 }
 
-// writeStorageV2Flag puts Compact-encoded StorageSettings{storage_v2: true}
-// (single byte 0x01) under the key "storage_v2" in the Metadata table.
+// writeStorageSettings puts a SCALE-wrapped JSON storage_settings row into
+// the Metadata table.
 //
-// StorageSettings has one bool field. Compact derives a 1-bit bitflag header
-// (padded to 1 byte). storage_v2=true sets that bit → 0x01.
-func writeStorageV2Flag(txn *mdbx.Txn, dbi mdbx.DBI) error {
-	return txn.Put(dbi, []byte("storage_v2"), []byte{0x01}, 0)
+// Wire: `outer_len_prefix[1 byte] || inner_json[19 bytes]`.
+//
+// Reth's Metadata table value type is Vec<u8> with a SCALE Decompress impl
+// (reth-codecs-0.3.1/src/compress/scale.rs). For inner lengths 0-63 the
+// SCALE compact-length prefix is a single byte = (len << 2). Reth's trait
+// reader (storage-api/src/metadata.rs) then serde-decodes the inner
+// bytes as StorageSettings. Our payload is 19 bytes (`{"storage_v2":true}`)
+// so the prefix is 0x4C.
+func writeStorageSettings(txn *mdbx.Txn, dbi mdbx.DBI) error {
+	inner := []byte(`{"storage_v2":true}`)
+	if len(inner) > 63 {
+		// Defensive: switch to 2-byte SCALE prefix if the JSON ever grows.
+		// Today's payload is 19 bytes — well under the single-byte cap.
+		return fmt.Errorf("storage_settings JSON length %d > 63; needs 2-byte SCALE prefix encoder", len(inner))
+	}
+	value := make([]byte, 0, 1+len(inner))
+	value = append(value, byte(len(inner)<<2)) // SCALE single-byte compact-length prefix.
+	value = append(value, inner...)
+	return txn.Put(dbi, []byte("storage_settings"), value, 0)
 }
 
 // writeStageCheckpoints writes one StageCheckpoint{BlockNumber: blockNum}

--- a/client/reth/metadata_cgo_test.go
+++ b/client/reth/metadata_cgo_test.go
@@ -4,6 +4,7 @@ package reth
 
 import (
 	"bytes"
+	"encoding/json"
 	"math/big"
 	"testing"
 
@@ -34,21 +35,25 @@ func TestWriteMetadataAllTables(t *testing.T) {
 			header := &types.Header{
 				Number: big.NewInt(0),
 			}
-			chainID := uint64(1337)
 
-			if err := WriteMetadata(envs, header, chainID, tc.archive); err != nil {
+			if err := WriteMetadata(envs, header, tc.archive); err != nil {
 				t.Fatalf("WriteMetadata: %v", err)
 			}
 
-			// Verify Metadata.storage_v2
+			// Verify Metadata.storage_settings — key matches reth's
+			// STORAGE_SETTINGS const; value is SCALE-prefixed JSON.
+			// 0x4C = (19 << 2) is the SCALE single-byte compact-length
+			// prefix for the 19-byte JSON payload {"storage_v2":true}.
+			// See writeStorageSettings doc comment for the full wire-
+			// format rationale.
 			if err := envs.Mdbx.View(func(txn *mdbx.Txn) error {
-				val, err := txn.Get(envs.MdbxDBIs["Metadata"], []byte("storage_v2"))
+				val, err := txn.Get(envs.MdbxDBIs["Metadata"], []byte("storage_settings"))
 				if err != nil {
 					return err
 				}
-				// Compact bool true = 1-byte 0x01 (1-bit bitflag header).
-				if !bytes.Equal(val, []byte{0x01}) {
-					t.Errorf("Metadata[storage_v2] = %x, want 01", val)
+				want := append([]byte{0x4C}, []byte(`{"storage_v2":true}`)...)
+				if !bytes.Equal(val, want) {
+					t.Errorf("Metadata[storage_settings] = %x, want %x", val, want)
 				}
 				return nil
 			}); err != nil {
@@ -144,5 +149,59 @@ func TestWriteMetadataAllTables(t *testing.T) {
 
 			// NOTE: VersionHistory is intentionally NOT written by WriteMetadata.
 		})
+	}
+}
+
+// TestWriteMetadata_StorageSettingsSCALEWrappedJSON pins the byte-level
+// wire format reth actually reads: SCALE compact-length-prefixed JSON
+// (NOT raw Compact bitflag, NOT raw JSON).
+//
+// Byte 0 is (inner_len << 2) for inner_len ∈ [0, 63] (parity_scale_codec
+// single-byte compact mode). Bytes 1..end are the serde JSON serialization
+// of reth's StorageSettings struct. If reth bumps the wire format this
+// test fails without needing to spin docker.
+func TestWriteMetadata_StorageSettingsSCALEWrappedJSON(t *testing.T) {
+	tmp := t.TempDir()
+	envs, err := OpenEnvs(tmp, true)
+	if err != nil {
+		t.Fatalf("OpenEnvs: %v", err)
+	}
+	defer envs.Close()
+
+	header := &types.Header{Number: big.NewInt(0)}
+	if err := WriteMetadata(envs, header, true); err != nil {
+		t.Fatalf("WriteMetadata: %v", err)
+	}
+
+	if err := envs.Mdbx.View(func(txn *mdbx.Txn) error {
+		val, err := txn.Get(envs.MdbxDBIs["Metadata"], []byte("storage_settings"))
+		if err != nil {
+			return err
+		}
+		if len(val) < 2 {
+			t.Fatalf("Metadata[storage_settings] = %x (%d bytes); want >= 2 (SCALE prefix + JSON)", val, len(val))
+		}
+		// SCALE single-byte mode: low 2 bits == 0, upper 6 bits = length.
+		if val[0]&0b11 != 0 {
+			t.Errorf("SCALE prefix %#x: low 2 bits = %#b, want 0b00 (single-byte mode)", val[0], val[0]&0b11)
+		}
+		innerLen := int(val[0] >> 2)
+		if innerLen != len(val)-1 {
+			t.Errorf("SCALE prefix says inner_len=%d, actual remaining bytes = %d", innerLen, len(val)-1)
+		}
+		// Decode inner JSON via encoding/json — matches what reth's
+		// serde_json::from_slice does after SCALE-decoding the outer Vec<u8>.
+		var got struct {
+			StorageV2 bool `json:"storage_v2"`
+		}
+		if err := json.Unmarshal(val[1:], &got); err != nil {
+			t.Errorf("inner JSON parse failed: %v (bytes = %s)", err, val[1:])
+		}
+		if !got.StorageV2 {
+			t.Errorf("decoded storage_v2 = false, want true")
+		}
+		return nil
+	}); err != nil {
+		t.Errorf("read Metadata[storage_settings]: %v", err)
 	}
 }

--- a/client/reth/no_root_cache_test.go
+++ b/client/reth/no_root_cache_test.go
@@ -1,0 +1,163 @@
+//go:build cgo_reth
+
+package reth
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"path/filepath"
+	"testing"
+
+	"github.com/erigontech/mdbx-go/mdbx"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
+
+	"github.com/nerolation/state-actor/generator"
+	"github.com/nerolation/state-actor/internal/autofill"
+	"github.com/nerolation/state-actor/internal/templates"
+)
+
+// TestNoRootCacheRows guards the invariant that state-actor's AccountsTrie
+// and StoragesTrie writers never persist the root branch — mirroring reth's
+// own writer guards in provider.rs (`if !key.is_empty()`) and
+// trie_cursor.rs (`.filter(|(n, _)| !n.is_empty())`). Without these guards
+// (regressed in any of the 3 emit callbacks in run_cgo.go,
+// contracts_writer_cgo.go, spec_storage_streaming_cgo.go), reth's proof_v2
+// cursor would decode the 33-zero-byte AccountsTrie key (or all-zero
+// packed StoragesTrie SubKey) as cached_path == empty Nibbles and panic.
+func TestNoRootCacheRows(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Coverage knobs to exercise all 3 emit sites:
+	//   - AutoFill plan → batched WriteEOAs + WriteContracts → AccountsTrie
+	//     branching (run_cgo emit) + per-contract storage (contracts_writer emit).
+	//   - PreAlloc with non-empty Storage → spec_storage_streaming emit.
+	plan, err := autofill.PlanForBudget(512 << 10)
+	if err != nil {
+		t.Fatalf("PlanForBudget: %v", err)
+	}
+	specStorage := map[common.Hash]common.Hash{}
+	for i := byte(0); i < 8; i++ {
+		var k, v common.Hash
+		k[31] = i
+		v[31] = i + 1
+		specStorage[k] = v
+	}
+	cfg := generator.Config{
+		DBPath:   tmp,
+		AutoFill: plan,
+		Seed:     12345,
+		PreAlloc: []templates.PreAllocEntity{{
+			Address: common.HexToAddress("0x00000000000000000000000000000000deadbeef"),
+			Account: &types.StateAccount{
+				Nonce:    1,
+				Balance:  uint256.NewInt(42),
+				Root:     types.EmptyRootHash,
+				CodeHash: types.EmptyCodeHash[:],
+			},
+			Storage: func(yield func(common.Hash, common.Hash) bool) {
+				for k, v := range specStorage {
+					if !yield(k, v) {
+						return
+					}
+				}
+			},
+		}},
+	}
+	if _, err := RunCgo(context.Background(), cfg, Options{}); err != nil {
+		t.Fatalf("RunCgo: %v", err)
+	}
+
+	env, err := mdbx.NewEnv()
+	if err != nil {
+		t.Fatalf("mdbx.NewEnv: %v", err)
+	}
+	defer env.Close()
+	if err := env.SetOption(mdbx.OptMaxDB, 64); err != nil {
+		t.Fatalf("SetOption: %v", err)
+	}
+	if err := env.Open(filepath.Join(tmp, "db"), mdbx.Readonly, 0o644); err != nil {
+		t.Fatalf("env.Open: %v", err)
+	}
+
+	if err := env.View(func(txn *mdbx.Txn) error {
+		checkAccountsTrieNoRoot(t, txn)
+		checkStoragesTrieNoRoot(t, txn)
+		return nil
+	}); err != nil {
+		t.Fatalf("env.View: %v", err)
+	}
+}
+
+// checkAccountsTrieNoRoot asserts:
+//
+//  1. txn.Get(AccountsTrie, [33]byte{}) returns mdbx.NotFound (no explicit
+//     root-cache row at the 33-zero-byte packed key).
+//  2. cursor.First() returns either no rows (empty table) or a key with
+//     nibble count > 0 — i.e., for the 33-byte packed encoding, the last
+//     byte (count suffix) is non-zero.
+func checkAccountsTrieNoRoot(t *testing.T, txn *mdbx.Txn) {
+	t.Helper()
+	dbi, err := txn.OpenDBI("AccountsTrie", 0, nil, nil)
+	if err != nil {
+		t.Fatalf("OpenDBI AccountsTrie: %v", err)
+	}
+
+	rootKey := make([]byte, 33) // 32 zero padding + nibble-count = 0
+	if val, err := txn.Get(dbi, rootKey); err == nil {
+		t.Errorf("AccountsTrie has root-cache row at 33-zero-byte key (value %d bytes); reth's writer at provider.rs would never produce this row. value hex: %s",
+			len(val), hex.EncodeToString(val))
+	}
+
+	cur, err := txn.OpenCursor(dbi)
+	if err != nil {
+		t.Fatalf("OpenCursor AccountsTrie: %v", err)
+	}
+	defer cur.Close()
+	k, _, err := cur.Get(nil, nil, mdbx.First)
+	if err != nil {
+		// Empty table — vacuously satisfies the invariant.
+		return
+	}
+	// In packed-key encoding the last byte is the nibble count. 0 = root.
+	if len(k) == 33 && k[32] == 0 {
+		t.Errorf("AccountsTrie cursor.First() returned a packed key with nibble count == 0 (root): %s", hex.EncodeToString(k))
+	}
+}
+
+// checkStoragesTrieNoRoot asserts that no StoragesTrie entry has an
+// all-zero packed SubKey (i.e., the first 33 bytes of the value are zero,
+// meaning packed SubKey with nibble count = 0 = the storage-trie root).
+func checkStoragesTrieNoRoot(t *testing.T, txn *mdbx.Txn) {
+	t.Helper()
+	dbi, err := txn.OpenDBI("StoragesTrie", 0, nil, nil)
+	if err != nil {
+		t.Fatalf("OpenDBI StoragesTrie: %v", err)
+	}
+	cur, err := txn.OpenCursor(dbi)
+	if err != nil {
+		t.Fatalf("OpenCursor StoragesTrie: %v", err)
+	}
+	defer cur.Close()
+
+	zero33 := make([]byte, 33)
+	var examined uint64
+	var rootRows uint64
+	k, v, err := cur.Get(nil, nil, mdbx.First)
+	for ; err == nil; k, v, err = cur.Get(nil, nil, mdbx.Next) {
+		examined++
+		if len(v) >= 33 && bytes.Equal(v[:33], zero33) {
+			rootRows++
+			if rootRows <= 3 {
+				t.Errorf("StoragesTrie has root-cache row (key=%s, packed SubKey all-zero); reth's writer at trie_cursor.rs would never produce this row",
+					hex.EncodeToString(k))
+			}
+		}
+	}
+	if rootRows > 0 {
+		t.Errorf("StoragesTrie has %d root-cache rows across %d examined entries (want 0)", rootRows, examined)
+	}
+	t.Logf("StoragesTrie: %d entries examined, %d root-cache rows", examined, rootRows)
+}

--- a/client/reth/oracle_test.go
+++ b/client/reth/oracle_test.go
@@ -67,7 +67,7 @@ func TestRethDbStats(t *testing.T) {
 	dd, cleanup := e2e.AcquireDatadir(t, "RETH")
 	defer cleanup()
 
-	cfg := generator.Config{DBPath: dd.HostPath}
+	cfg := generator.Config{DBPath: dd.HostPath, AutoFill: rethTestPlan(t, 512<<10), Seed: 12345}
 	if _, err := RunCgo(context.Background(), cfg, Options{}); err != nil {
 		t.Fatalf("RunCgo: %v", err)
 	}
@@ -83,7 +83,8 @@ func TestRethDbStats(t *testing.T) {
 		t.Fatalf("reth db stats failed:\noutput:\n%s\nerr: %v", out, err)
 	}
 	output := string(out)
-	for _, table := range []string{"PlainAccountState", "HashedAccounts", "Bytecodes"} {
+	// HashedAccounts + Bytecodes are the v2-canonical existence signals.
+	for _, table := range []string{"HashedAccounts", "Bytecodes"} {
 		if !strings.Contains(output, table) {
 			t.Errorf("expected table %q in db stats output, got:\n%s", table, output)
 		}
@@ -124,10 +125,12 @@ func TestRethDbStatsSyntheticEOAs(t *testing.T) {
 		t.Fatalf("reth db stats failed:\noutput:\n%s\nerr: %v", out, err)
 	}
 	output := string(out)
+	// Under v2: PlainAccountState is empty (drop from checks). AccountsHistory
+	// has moved to a RocksDB column family which `reth db stats` does NOT
+	// enumerate as an MDBX table — also drop. HashedAccounts (canonical v2
+	// state) and AccountChangeSets (still MDBX in archive mode) remain.
 	checks := map[string]int{
-		"PlainAccountState": plan.NumEOAs,
 		"HashedAccounts":    plan.NumEOAs,
-		"AccountsHistory":   plan.NumEOAs,
 		"AccountChangeSets": plan.NumEOAs,
 	}
 	for table, minEntries := range checks {
@@ -155,7 +158,7 @@ func TestRethNodeBootEmptyAlloc(t *testing.T) {
 	dd, cleanup := e2e.AcquireDatadir(t, "RETH")
 	defer cleanup()
 
-	cfg := generator.Config{DBPath: dd.HostPath} // empty alloc
+	cfg := generator.Config{DBPath: dd.HostPath, AutoFill: rethTestPlan(t, 512<<10), Seed: 12345}
 	if _, err := RunCgo(context.Background(), cfg, Options{}); err != nil {
 		t.Fatalf("RunCgo: %v", err)
 	}
@@ -246,9 +249,9 @@ func TestE2ESuite(t *testing.T) {
 		TargetSize: e2eBudget,
 		Genesis:    g,
 	}
-	// Spec-driven pre-alloc via examples/full-matrix-spec-feature.yaml exercises
-	// every schema variant (including the spamoor sender). The Spec is
-	// also passed to RunSuitePhases for the Phase 4 erc20 oracle.
+	// Spec-driven pre-alloc via examples/full-matrix-spec-feature.yaml
+	// exercises every schema variant (including the spamoor sender). The
+	// Spec is also passed to RunSuitePhases for the Phase 4 erc20 oracle.
 	specDoc, preAlloc := e2e.LoadCISpec(t, "../../examples/full-matrix-spec-feature.yaml", "reth")
 	cfg.PreAlloc = preAlloc
 	// Deploy EIP-4788/2935/7002/7251 system contracts at their canonical

--- a/client/reth/run_cgo.go
+++ b/client/reth/run_cgo.go
@@ -176,13 +176,10 @@ func RunCgo(ctx context.Context, cfg generator.Config, opts Options) (*generator
 	}
 
 	if accountsCreated+contractsCreated > 0 {
-		// Wrap state-root computation in an MDBX write txn so per-branch
-		// emissions populate AccountsTrie; without it, reth's payload builder
-		// falls back to a linear HashedAccounts walk per block. cursor.Put
-		// (flag=0) accepts any key order: HashBuilder emissions arrive in
-		// descending-depth order during unwinds, and the variable-length
-		// AccountsTrie key layout means shallow paths sort smaller than
-		// deeper ones — cursor.Append would silently drop shallow rows.
+		// Persist HashBuilder trie-node emissions into AccountsTrie alongside
+		// state-root computation so reth's payload builder finds them on
+		// boot. Keys use the 33-byte PackedStoredNibbles form (reth v2);
+		// cursor.Put is correct regardless of emission order.
 		var root common.Hash
 		err := envs.Mdbx.Update(func(txn *mdbx.Txn) error {
 			cur, cerr := txn.OpenCursor(envs.MdbxDBIs["AccountsTrie"])
@@ -190,18 +187,15 @@ func RunCgo(ctx context.Context, cfg generator.Config, opts Options) (*generator
 				return fmt.Errorf("open AccountsTrie cursor: %w", cerr)
 			}
 			defer cur.Close()
-			// AccountsTrie key uses the VARIABLE-length StoredNibbles
-			// encoding (path.Nibbles[:path.Length], 0..=64 bytes, no
-			// padding, no length suffix). This matches reth's
-			// tables::AccountsTrie Key = StoredNibbles where
-			// Encode::Encoded = ArrayVec<u8, 64> (see
-			// reth/crates/storage/db-api/src/models/mod.rs:121-127).
-			// Using the fixed 65-byte form (path.EncodeKey) would
-			// produce keys reth misreads as 65-NIBBLE paths and the
-			// walker eventually SIGSEGVs at block-time.
 			emit := func(path iReth.StoredNibbles, node iReth.BranchNodeCompact) error {
+				if path.Length == 0 {
+					// Skip root branch — reth's writer never caches it
+					// (provider.rs `if !key.is_empty()`). See
+					// TestNoRootCacheRows for the proof_v2 panic rationale.
+					return nil
+				}
 				var keyBuf, valBuf bytes.Buffer
-				path.EncodeAccountKey(&keyBuf)
+				path.EncodePackedAccountKey(&keyBuf)
 				node.EncodeCompact(&valBuf)
 				return cur.Put(keyBuf.Bytes(), valBuf.Bytes(), 0)
 			}
@@ -224,7 +218,6 @@ func RunCgo(ctx context.Context, cfg generator.Config, opts Options) (*generator
 	}
 
 	gen := genesis.OrDefault(cfg.Genesis)
-	chainID := gen.Config.ChainID.Int64()
 
 	chainspecPath := filepath.Join(cfg.DBPath, "chainspec.json")
 	if err := writeChainSpec(gen, chainspecPath); err != nil {
@@ -237,7 +230,7 @@ func RunCgo(ctx context.Context, cfg generator.Config, opts Options) (*generator
 	}
 	header.Root = stateRoot
 
-	if err := WriteMetadata(envs, header, uint64(chainID), cfg.Archive); err != nil {
+	if err := WriteMetadata(envs, header, cfg.Archive); err != nil {
 		return nil, fmt.Errorf("RunCgo: WriteMetadata: %w", err)
 	}
 

--- a/client/reth/run_cgo_test.go
+++ b/client/reth/run_cgo_test.go
@@ -23,10 +23,12 @@ func rethTestPlan(tb testing.TB, budget uint64) *autofill.Plan {
 	return p
 }
 
-func TestRunCgoEmptyAlloc(t *testing.T) {
+func TestRunCgoMinimalAlloc(t *testing.T) {
 	tmp := t.TempDir()
 	cfg := generator.Config{
-		DBPath: tmp,
+		DBPath:   tmp,
+		AutoFill: rethTestPlan(t, 512<<10),
+		Seed:     12345,
 	}
 	stats, err := RunCgo(context.Background(), cfg, Options{})
 	if err != nil {
@@ -40,9 +42,8 @@ func TestRunCgoEmptyAlloc(t *testing.T) {
 			t.Errorf("expected %s: %v", p, err)
 		}
 	}
-	want := "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
-	if got := stats.StateRoot.Hex(); got != want {
-		t.Errorf("state root: got=%s want=%s", got, want)
+	if (stats.StateRoot == common.Hash{}) {
+		t.Errorf("state root is zero hash")
 	}
 }
 

--- a/client/reth/sidecars.go
+++ b/client/reth/sidecars.go
@@ -13,7 +13,7 @@ import (
 // reth schema-version string (currently "2"). dbDir is the MDBX directory
 // (typically <datadir>/db/), NOT the parent datadir.
 //
-// Reth boot opens this file via crates/storage/db/src/version.rs:9-12;
+// Reth boot opens this file via crates/storage/db/src/version.rs;
 // mismatch fails with VersionMismatch.
 func WriteDatabaseVersion(dbDir string) error {
 	path := filepath.Join(dbDir, "database.version")

--- a/client/reth/spec_storage_streaming_cgo.go
+++ b/client/reth/spec_storage_streaming_cgo.go
@@ -31,36 +31,35 @@ const chunkSlots = 1024
 // per-txn commit latency without unbounded RAM growth.
 const chunkChanCap = 4
 
-// slotPrepared holds the four pre-encoded byte buffers a single slot
-// contributes to MDBX. Produced on the worker goroutine, consumed on
-// the main goroutine inside Mdbx.Update — no encoding work in the
-// hot write path.
+// slotPrepared holds the per-slot byte buffers + raw key a single slot
+// contributes. Produced on the worker goroutine, consumed on the main
+// goroutine inside Mdbx.Update — no encoding work in the hot write path.
+// rawKey lets the consumer route an archive-mode StoragesHistory put
+// into the RocksDB CF (envs.HistorySink builds the StorageShardedKey
+// internally).
 type slotPrepared struct {
-	plainEntry  []byte // PlainStorageState value (encoded rawKey || value)
-	hashedEntry []byte // HashedStorages value (encoded keyHash || value)
-	changeEntry []byte // StorageChangeSets value (encoded rawKey || 0); nil in full mode
-	sskKey      []byte // StoragesHistory key (StorageShardedKey-encoded); nil in full mode
+	rawKey      common.Hash // slot key (untouched); StoragesHistory sink arg
+	hashedEntry []byte      // HashedStorages value (encoded keyHash || value)
+	changeEntry []byte      // StorageChangeSets value (encoded rawKey || 0); nil in full mode
 }
 
 // preparedEntity carries everything the consumer needs to commit one
-// entity's storage to MDBX. The worker fills chunkCh in keccak-
-// ascending order, then sends the computed root via rootCh and closes
-// chunkCh. errCh carries any IterateRoot failure surfacing on the
-// worker side. trieRows are pre-encoded StoragesTrie DupSort values
-// (each entry = SubKey(33 bytes) || BranchNodeCompact bytes); the
-// consumer writes them under the DupSort main key ent.addrHash after
-// the per-slot rows land. Emitted in path-lex order so cursor.AppendDup
-// takes the fast path.
+// entity's storage. The worker fills chunkCh in keccak-ascending order,
+// then sends the computed root via rootCh and closes chunkCh. errCh
+// carries any IterateRoot failure surfacing on the worker side. trieRows
+// are pre-encoded StoragesTrie DupSort values (each entry = packed
+// SubKey(33 bytes) || BranchNodeCompact bytes); the consumer writes them
+// under the DupSort main key ent.addrHash after the per-slot rows land.
+// Emitted in path-lex order so cursor.AppendDup takes the fast path.
 type preparedEntity struct {
-	idx        int
-	addr       common.Address
-	addrHash   common.Hash
-	blockKey   []byte         // BlockNumberAddress-encoded
-	historyVal []byte         // EncodeIntegerList([0]) — fixed per entity for genesis pre-state
-	chunkCh    chan []slotPrepared
-	rootCh     chan common.Hash
-	errCh      chan error
-	trieRows   [][]byte
+	idx      int
+	addr     common.Address
+	addrHash common.Hash
+	blockKey []byte // BlockNumberAddress-encoded
+	chunkCh  chan []slotPrepared
+	rootCh   chan common.Hash
+	errCh    chan error
+	trieRows [][]byte
 }
 
 // streamSpecStorage writes each PreAlloc entity's Storage into reth's
@@ -108,18 +107,10 @@ func streamSpecStorage(ctx context.Context, envs *Envs, cfg *generator.Config, s
 	defer cancelDrain(nil)
 
 	entityCh := make(chan int, workers*2)
-	// drainedCh is unbuffered — the consumer applies back-pressure on
-	// the workers (only one entity in flight on the writer side beyond
-	// the workers' local chunk buffers). Buffer of workers*2 to absorb
-	// small latency spikes.
+	// preparedCh buffer of workers*2 absorbs small latency spikes; the
+	// consumer applies back-pressure via the per-entity chunkCh inside
+	// each preparedEntity.
 	preparedCh := make(chan *preparedEntity, workers*2)
-
-	// EncodeIntegerList([0]) is identical for every slot in a genesis
-	// pre-state import — encode once on the caller goroutine, reuse
-	// across all workers.
-	var sharedHistoryBuf bytes.Buffer
-	iReth.EncodeIntegerList(&sharedHistoryBuf, []uint64{0})
-	historyVal := sharedHistoryBuf.Bytes()
 
 	var wg sync.WaitGroup
 	for w := 0; w < workers; w++ {
@@ -130,7 +121,7 @@ func streamSpecStorage(ctx context.Context, envs *Envs, cfg *generator.Config, s
 				if drainCtx.Err() != nil {
 					return
 				}
-				if err := drainAndEncodeEntity(drainCtx, cfg, i, historyVal, preparedCh); err != nil {
+				if err := drainAndEncodeEntity(drainCtx, cfg, i, preparedCh); err != nil {
 					cancelDrain(err)
 					return
 				}
@@ -202,13 +193,12 @@ func streamSpecStorage(ctx context.Context, envs *Envs, cfg *generator.Config, s
 
 // drainAndEncodeEntity runs on a worker goroutine. It drains the
 // entity's storage iter into a streamsort, then walks the sorted store
-// driving the HashBuilder AND pre-encoding all 4 per-slot byte buffers
+// driving the HashBuilder AND pre-encoding the per-slot byte buffers
 // into chunks sent to the consumer via ent.chunkCh.
 func drainAndEncodeEntity(
 	drainCtx context.Context,
 	cfg *generator.Config,
 	idx int,
-	historyVal []byte,
 	preparedCh chan<- *preparedEntity,
 ) error {
 	pe := &cfg.PreAlloc[idx]
@@ -225,14 +215,13 @@ func drainAndEncodeEntity(
 	blockKey.EncodeKey(&blockKeyBuf)
 
 	ent := &preparedEntity{
-		idx:        idx,
-		addr:       addr,
-		addrHash:   addrHash,
-		blockKey:   blockKeyBuf.Bytes(),
-		historyVal: historyVal,
-		chunkCh:    make(chan []slotPrepared, chunkChanCap),
-		rootCh:     make(chan common.Hash, 1),
-		errCh:      make(chan error, 1),
+		idx:      idx,
+		addr:     addr,
+		addrHash: addrHash,
+		blockKey: blockKeyBuf.Bytes(),
+		chunkCh:  make(chan []slotPrepared, chunkChanCap),
+		rootCh:   make(chan common.Hash, 1),
+		errCh:    make(chan error, 1),
 	}
 
 	// Hand the preparedEntity to the consumer BEFORE starting iteration
@@ -249,17 +238,21 @@ func drainAndEncodeEntity(
 	archive := cfg.Archive
 
 	// Per-entity trie emissions: HashBuilder emits in path-lex order as
-	// it walks the sorted slots. Worker pre-encodes each emission into a
-	// StorageTrieEntry value (SubKey||BNC) and accumulates into
-	// trieRows. The consumer drains trieRows into StoragesTrie within
-	// the same per-entity Mdbx.Update txn AFTER the slot rows land —
-	// keeping the cursor.AppendDup fast path intact for both sides.
+	// it walks the sorted slots. Worker pre-encodes each emission as a
+	// packed StorageTrieEntry value (33-byte SubKey || BNC; v2 format)
+	// and accumulates into trieRows. The consumer drains trieRows into
+	// StoragesTrie within the same per-entity Mdbx.Update txn AFTER the
+	// slot rows land — keeping the cursor.AppendDup fast path intact.
 	// Memory per entity: O(trie nodes) ≈ small multiple of slot count.
 	trieRows := make([][]byte, 0, 64)
 	emit := func(path iReth.StoredNibbles, node iReth.BranchNodeCompact) error {
+		if path.Length == 0 {
+			// Skip root branch — see TestNoRootCacheRows.
+			return nil
+		}
 		var valBuf bytes.Buffer
 		entry := iReth.StorageTrieEntry{SubKey: path, Node: node}
-		entry.EncodeCompact(&valBuf)
+		entry.EncodePackedCompact(&valBuf)
 		trieRows = append(trieRows, valBuf.Bytes())
 		return nil
 	}
@@ -282,12 +275,7 @@ func drainAndEncodeEntity(
 	sink := func(keyHash, rawKey, value common.Hash) error {
 		slotValueU256 := uint256.NewInt(0).SetBytes(value[:])
 
-		prep := slotPrepared{}
-
-		plainEntry := iReth.StorageEntry{Key: rawKey, Value: slotValueU256}
-		var plainBuf bytes.Buffer
-		plainEntry.EncodeCompact(&plainBuf)
-		prep.plainEntry = plainBuf.Bytes()
+		prep := slotPrepared{rawKey: rawKey}
 
 		hashedEntry := iReth.StorageEntry{Key: keyHash, Value: slotValueU256}
 		var hashedBuf bytes.Buffer
@@ -299,17 +287,6 @@ func drainAndEncodeEntity(
 			var changeBuf bytes.Buffer
 			changeEntry.EncodeCompact(&changeBuf)
 			prep.changeEntry = changeBuf.Bytes()
-
-			// StoragesHistory key is only built in archive mode; in full
-			// mode the consumer skips the Put entirely.
-			ssk := iReth.StorageShardedKey{
-				Address:     addr,
-				StorageKey:  rawKey,
-				BlockNumber: ^uint64(0),
-			}
-			var sskBuf bytes.Buffer
-			ssk.EncodeKey(&sskBuf)
-			prep.sskKey = sskBuf.Bytes()
 		}
 
 		pending = append(pending, prep)
@@ -357,38 +334,29 @@ func consumeEntity(
 		}
 		for chunk := range ent.chunkCh {
 			for _, prep := range chunk {
-				if err := txn.Put(envs.MdbxDBIs["PlainStorageState"], ent.addr[:], prep.plainEntry, 0); err != nil {
-					return fmt.Errorf("PlainStorageState %s: %w", ent.addr.Hex(), err)
-				}
 				if err := txn.Put(envs.MdbxDBIs["HashedStorages"], ent.addrHash[:], prep.hashedEntry, 0); err != nil {
 					return fmt.Errorf("HashedStorages %s: %w", ent.addrHash.Hex(), err)
 				}
 				if prep.changeEntry != nil {
-					// Archive mode: write the StorageChangeSets row.
+					// Archive mode: write StorageChangeSets (MDBX) + route
+					// StoragesHistory to RocksDB CF (v2).
 					if err := txn.Put(envs.MdbxDBIs["StorageChangeSets"], ent.blockKey, prep.changeEntry, 0); err != nil {
 						return fmt.Errorf("StorageChangeSets %s: %w", ent.addr.Hex(), err)
 					}
-				}
-				if prep.sskKey != nil {
-					// Archive mode: write the StoragesHistory row.
-					if err := txn.Put(envs.MdbxDBIs["StoragesHistory"], prep.sskKey, ent.historyVal, 0); err != nil {
+					if err := envs.HistorySink().PutStorageHistory(ent.addr, prep.rawKey, 0); err != nil {
 						return fmt.Errorf("StoragesHistory %s: %w", ent.addr.Hex(), err)
 					}
 				}
-				localBytes += uint64(len(prep.plainEntry))
+				// Stats: bank HashedStorages entry bytes.
+				localBytes += uint64(len(prep.hashedEntry))
 			}
 		}
-		// Drain pre-encoded trie rows into StoragesTrie under the
-		// DupSort main key keccak(address). Worker emitted them in
-		// path-lex order WITHIN each entity, but entities themselves
-		// are processed in PreAlloc index order (not addrHash-sorted),
-		// so AppendDup's "main key >= last key in DB" precondition
-		// fails on cross-entity boundaries (MDBX_EKEYMISMATCH).
-		// Plain Put is correct: the sub-key (path) is encoded inside
-		// the row's first 33 bytes and stays in DupSort order via
-		// MDBX's own dup-set sorting. Without these rows reth's
-		// payload builder falls back to a linear HashedStorages walk
-		// per block.
+		// Drain pre-encoded trie rows into StoragesTrie keyed by
+		// keccak(address). Plain Put (not AppendDup): entities are
+		// processed in PreAlloc index order (not addrHash-sorted), so
+		// AppendDup would trip MDBX_EKEYMISMATCH on cross-entity
+		// boundaries. Sub-key ordering is preserved by MDBX's per-key
+		// dup-sort regardless.
 		if len(ent.trieRows) > 0 {
 			for _, row := range ent.trieRows {
 				if err := txn.Put(envs.MdbxDBIs["StoragesTrie"], ent.addrHash[:], row, 0); err != nil {

--- a/client/reth/spec_storage_streaming_test.go
+++ b/client/reth/spec_storage_streaming_test.go
@@ -72,9 +72,11 @@ func TestStreamSpecStorageParallelDeterminism(t *testing.T) {
 	}
 }
 
-// TestStreamSpecStorageNoStorageEntities: empty PreAlloc and pure-EOA
-// PreAlloc must skip the writer loop entirely — stats.StorageBytes
-// stays zero, no MDBX txn for storage opens.
+// TestStreamSpecStorageNoStorageEntities: a pure-EOA PreAlloc must skip
+// the storage writer loop entirely — stats.StorageBytes stays zero, no
+// MDBX txn for storage opens. (The empty-PreAlloc case is now redundant
+// — generator.Config.Validate rejects empty configs at the top of
+// RunCgo, so the writer loop is unreachable for nil PreAlloc anyway.)
 func TestStreamSpecStorageNoStorageEntities(t *testing.T) {
 	addr := common.HexToAddress("0xaabbccddeeff00112233445566778899aabbccdd")
 	pureEOA := []templates.PreAllocEntity{{
@@ -88,22 +90,15 @@ func TestStreamSpecStorageNoStorageEntities(t *testing.T) {
 		Storage: nil,
 	}}
 
-	for name, preAlloc := range map[string][]templates.PreAllocEntity{
-		"empty":   nil,
-		"pureEOA": pureEOA,
-	} {
-		t.Run(name, func(t *testing.T) {
-			stats, err := RunCgo(context.Background(), generator.Config{
-				DBPath:   t.TempDir(),
-				PreAlloc: preAlloc,
-			}, Options{})
-			if err != nil {
-				t.Fatalf("RunCgo: %v", err)
-			}
-			if stats.StorageBytes != 0 {
-				t.Errorf("StorageBytes = %d, want 0", stats.StorageBytes)
-			}
-		})
+	stats, err := RunCgo(context.Background(), generator.Config{
+		DBPath:   t.TempDir(),
+		PreAlloc: pureEOA,
+	}, Options{})
+	if err != nil {
+		t.Fatalf("RunCgo: %v", err)
+	}
+	if stats.StorageBytes != 0 {
+		t.Errorf("StorageBytes = %d, want 0", stats.StorageBytes)
 	}
 }
 

--- a/client/reth/static_files_cgo.go
+++ b/client/reth/static_files_cgo.go
@@ -14,6 +14,8 @@ package reth
 //       static_file_{segment}_0_499999          — LZ4-compressed column data (NO extension)
 //       static_file_{segment}_0_499999.off      — offset table (1+n*8 bytes)
 //       static_file_{segment}_0_499999.conf     — bincode NippyJar<SegmentHeader>
+//   - Change-based segments (account/storage changesets) additionally produce:
+//       static_file_{segment}_0_499999.csoff    — 16-byte changeset offset records
 //
 //   - Data file: each column value is independently LZ4-compressed (raw block format,
 //     matching lz4_flex::block::compress — no size prefix). Columns are concatenated.
@@ -37,10 +39,16 @@ package reth
 //     See headerCompactBytes for a detailed layout derivation.
 //
 // Segments written:
-//   - headers:             3 columns, 1 row  (genesis header)
-//   - transactions:        1 column,  0 rows
-//   - receipts:            1 column,  0 rows
-//   - transaction-senders: 1 column,  0 rows
+//   - headers:              3 columns, 1 row  (genesis header)
+//   - transactions:         1 column,  0 rows
+//   - receipts:             1 column,  0 rows
+//   - transaction-senders:  1 column,  0 rows
+//   - account-change-sets:  1 column,  1 row  (empty bootstrap shell + .csoff)
+//   - storage-change-sets:  1 column,  1 row  (empty bootstrap shell + .csoff)
+//
+// The change-based shells are required for reth's persistence service to accept
+// block-1 appends; without them reth crashes at the first block with
+// UnexpectedStaticFileBlockNumber(AccountChangeSets, 1, 0).
 //
 // file naming: DEFAULT_BLOCKS_PER_STATIC_FILE = 500_000 so block 0 lives in
 // the range 0..=499999. The filename contains the segment string (kebab-case).
@@ -85,11 +93,21 @@ type staticFileSegment struct {
 }
 
 var (
-	segHeaders      = staticFileSegment{"headers", 0, 3}
-	segTransactions = staticFileSegment{"transactions", 1, 1}
-	segReceipts     = staticFileSegment{"receipts", 2, 1}
-	segTxSenders    = staticFileSegment{"transaction-senders", 3, 1}
+	segHeaders           = staticFileSegment{"headers", 0, 3}
+	segTransactions      = staticFileSegment{"transactions", 1, 1}
+	segReceipts          = staticFileSegment{"receipts", 2, 1}
+	segTxSenders         = staticFileSegment{"transaction-senders", 3, 1}
+	segAccountChangeSets = staticFileSegment{"account-change-sets", 4, 1}
+	segStorageChangeSets = staticFileSegment{"storage-change-sets", 5, 1}
 )
+
+// isChangeBased mirrors reth's StaticFileSegment::is_change_based
+// (crates/static-file/types/src/segment.rs). Change-based segments
+// (AccountChangeSets, StorageChangeSets) carry a 5th SegmentHeader field
+// (changeset_offsets_len) and a .csoff sidecar file.
+func (s staticFileSegment) isChangeBased() bool {
+	return s.enumIdx == 4 || s.enumIdx == 5
+}
 
 // WriteStaticFiles writes block-0 segments under <datadir>/static_files/.
 //
@@ -121,6 +139,17 @@ func WriteStaticFiles(datadir string, header *types.Header) error {
 	// 2–4. Empty tx/receipt/senders segments — 0 rows.
 	for _, seg := range []staticFileSegment{segTransactions, segReceipts, segTxSenders} {
 		if err := writeSegment(sfDir, seg, header, nil); err != nil {
+			return fmt.Errorf("WriteStaticFiles: %s: %w", seg.name, err)
+		}
+	}
+
+	// 5–6. Empty AccountChangeSets / StorageChangeSets bootstrap shells (1 row,
+	// empty content + .csoff). Reth's persistence service expects these
+	// segments at block_range=Some(0..=0) so block-1 appends pass
+	// writer.rs's check_next_block_number. Not history data — a
+	// minimum-viable shell, correct for both archive and full-node modes.
+	for _, seg := range []staticFileSegment{segAccountChangeSets, segStorageChangeSets} {
+		if err := writeSegment(sfDir, seg, header, [][]byte{nil}); err != nil {
 			return fmt.Errorf("WriteStaticFiles: %s: %w", seg.name, err)
 		}
 	}
@@ -186,12 +215,30 @@ func writeSegment(dir string, seg staticFileSegment, header *types.Header, colDa
 	}
 
 	// ---- .conf configuration file ---------------------------
-	confBytes, err := buildConfFile(seg, header, rows, uncompressedSize)
+	// changeset_offsets_len: 1 record (block 0 = empty changeset) for the change-based
+	// bootstrap shell; 0 / unused for non-change-based segments.
+	var changesetOffsetsLen uint64
+	if seg.isChangeBased() {
+		changesetOffsetsLen = 1
+	}
+	confBytes, err := buildConfFile(seg, header, rows, uncompressedSize, changesetOffsetsLen)
 	if err != nil {
 		return fmt.Errorf("build .conf: %w", err)
 	}
 	if err := os.WriteFile(base+".conf", confBytes, 0o644); err != nil {
 		return fmt.Errorf("write .conf: %w", err)
+	}
+
+	// ---- .csoff sidecar (change-based segments only) --------
+	// Fixed-width 16-byte records: [offset u64 LE | num_changes u64 LE]. For the
+	// block-0 bootstrap shell we write a single record of zeros: the changeset
+	// starts at offset 0 in the data file and contains 0 changes. Mirrors
+	// reth crates/static-file/types/src/changeset_offsets.rs (RECORD_SIZE=16).
+	if seg.isChangeBased() {
+		csoffBytes := make([]byte, 16) // single 16-byte zero record
+		if err := os.WriteFile(base+".csoff", csoffBytes, 0o644); err != nil {
+			return fmt.Errorf("write .csoff: %w", err)
+		}
 	}
 
 	return nil
@@ -257,12 +304,14 @@ func buildOffsetsFile(columns uint64, colData [][]byte) []byte {
 //
 // For non-empty segments: compressor = Some(Lz4) → [0x01, 0x01, 0x00, 0x00, 0x00].
 // For empty segments (rows=0): compressor = None → [0x00].
-func buildConfFile(seg staticFileSegment, header *types.Header, rows uint64, uncompressedSize uint64) ([]byte, error) {
+func buildConfFile(seg staticFileSegment, header *types.Header, rows uint64, uncompressedSize uint64, changesetOffsetsLen uint64) ([]byte, error) {
 	// --- SegmentHeader ---
 	// For headers: block_range=Some(0..=0), tx_range=None
 	// For tx/receipt/senders: block_range=Some(0..=0), tx_range=Some(0..=0)
 	//   (even with 0 rows, block_range=Some tells reth the segment covers block 0)
-	userHeaderBytes := buildSegmentHeaderBytes(seg)
+	// For change-based (account/storage changesets): block_range=Some(0..=0),
+	//   tx_range=None, plus a 5th changeset_offsets_len field.
+	userHeaderBytes := buildSegmentHeaderBytes(seg, changesetOffsetsLen)
 
 	// --- NippyJar ---
 	out := make([]byte, 0, 85+len(userHeaderBytes))
@@ -293,10 +342,14 @@ func buildConfFile(seg staticFileSegment, header *types.Header, rows uint64, unc
 //
 // All genesis segments use block_range=Some(0..=0) so that iter_static_files
 // finds them. Tx-based segments (transactions, receipts, senders) additionally
-// use tx_range=Some(0..=0).
+// use tx_range=Some(0..=0). Change-based segments (account/storage changesets)
+// have tx_range=None AND a 5th changeset_offsets_len:u64 field.
 //
 // The expected_block_range spans the full file slot: 0..=499_999.
-func buildSegmentHeaderBytes(seg staticFileSegment) []byte {
+//
+// changesetOffsetsLen is the record count in the matching .csoff sidecar;
+// for non-change-based segments it must be 0 and is not serialized.
+func buildSegmentHeaderBytes(seg staticFileSegment, changesetOffsetsLen uint64) []byte {
 	out := make([]byte, 0, 64)
 
 	// expected_block_range: 0..=499_999
@@ -308,9 +361,11 @@ func buildSegmentHeaderBytes(seg staticFileSegment) []byte {
 	out = appendLE64(out, 0) // start
 	out = appendLE64(out, 0) // end
 
-	// tx_range: None for headers (block-based), Some(0..=0) for tx-based
+	// tx_range: None for block-based (Headers) and change-based (AccountChangeSets,
+	// StorageChangeSets) per StaticFileSegment::is_tx_based. Some(0..=0) for the
+	// three tx-based segments (Transactions, Receipts, TransactionSenders).
 	switch seg.enumIdx {
-	case 0: // Headers — block based, no tx range
+	case 0, 4, 5: // Headers, AccountChangeSets, StorageChangeSets — no tx range
 		out = append(out, 0x00) // None
 	default: // Transactions, Receipts, TransactionSenders — tx-based
 		out = append(out, 0x01) // Some
@@ -320,6 +375,13 @@ func buildSegmentHeaderBytes(seg staticFileSegment) []byte {
 
 	// segment enum discriminant (u32 LE)
 	out = appendLE32(out, seg.enumIdx)
+
+	// changeset_offsets_len: 5th field, only for change-based segments. Reth's
+	// SegmentHeader Serialize impl (crates/static-file/types/src/segment.rs)
+	// uses len=5 when segment.is_change_based() and serialize_field("changeset_offsets", ...).
+	if seg.isChangeBased() {
+		out = appendLE64(out, changesetOffsetsLen)
+	}
 
 	return out
 }
@@ -377,43 +439,13 @@ func buildSegmentHeaderBytes(seg staticFileSegment) []byte {
 // 11. parent_beacon_block_root (Option<B256>): specialized_to_compact, writes B256 raw if Some.
 //
 //  12. extra_fields (Option<HeaderExt>): when Some (Prague-active genesis).
-//     Option<HeaderExt> uses reth's NON-specialized Compact encoding —
-//     unlike the four sibling Option fields above (withdrawals_root /
-//     base_fee_per_gas / blob_gas_used / excess_blob_gas /
-//     parent_beacon_block_root) which use specialized_to_compact and
-//     emit raw bytes only. The non-specialized form
-//     (reth-codecs-0.3.1 lib.rs:302-322 Option<T>::to_compact) writes:
-//
-//     varuint(N) || HeaderExt_bytes      (N = len(HeaderExt_bytes))
-//
-//     HeaderExt is itself Compact-derived with three optional fields
-//     (requests_hash, block_access_list_hash, slot_number) and a 1-byte
-//     inner bitflag (HeaderExt::bitflag_encoded_bytes() == 1, per
-//     reth-codecs-0.3.1 alloy/header.rs:191):
-//
-//     - inner_bitflag bit 0 = requests_hash presence
-//     - inner_bitflag bit 1 = block_access_list_hash presence
-//     - inner_bitflag bit 2 = slot_number presence
-//     - then, in declaration order:
-//     requests_hash         (Option<B256>, specialized — 32 bytes raw)
-//     block_access_list_hash (Option<B256>, specialized — 32 bytes raw)
-//     slot_number           (Option<u64>,  varuint(len) + BE bytes)
-//
-//     For Prague-active genesis genesisheader.Build sets only RequestsHash,
-//     so the inner HeaderExt is 33 bytes (0x01 + 32-byte B256). varuint(33)
-//     is a single byte 0x21 — total per-field 34 bytes appended.
-//
-//     This is REQUIRED for reth's RPC layer to decode the genesis header
-//     correctly. Omitting the entire HeaderExt produced "block not found"
-//     for every eth_call against block "0x0" — the col-2 sidecar and
-//     HeaderNumbers entry reference the full-RLP header hash (RequestsHash
-//     included), and reth's decoder recomputes the keccak from the
-//     static-file bytes; without RequestsHash in the stream that recompute
-//     landed on a different hash than HeaderNumbers indexes by. Omitting
-//     the varuint prefix (a previous attempt) caused
-//     Option<HeaderExt>::from_compact to misread the inner bitflag as
-//     varuint(N), then run off the end of buf inside `Compact for [u8;N]`
-//     at lib.rs:448:20.
+//     Uses the NON-specialized Option<T> form (reth-codecs-0.3.1
+//     lib.rs): `varuint(N) || HeaderExt_bytes`. HeaderExt is itself
+//     Compact-derived with three optional fields (requests_hash,
+//     block_access_list_hash, slot_number) prefixed by a 1-byte inner
+//     bitflag (bits 0/1/2 = presence). For Prague-active genesis only
+//     RequestsHash is set, so inner = 0x01 || 32-byte B256 (33 bytes),
+//     varuint(33) = 0x21 → 34 bytes appended.
 //
 // 13. extra_data (Bytes): written verbatim (last field, length = buf.len() - consumed).
 //
@@ -526,18 +558,8 @@ func headerCompactBytes(h *types.Header) ([]byte, error) {
 	}
 
 	// 12. extra_fields = Some(HeaderExt{requests_hash: Some(B256)}) when
-	//     Prague is active.
-	//     Option<HeaderExt> is the first NON-specialized Option in the
-	//     parent Header struct, so reth-codecs-0.3.1 Option<T>::to_compact
-	//     (lib.rs:302-322) prefixes the inner bytes with varuint(len).
-	//     Specialized Option<B256> / Option<u64> elsewhere in this header
-	//     have NO length prefix — only the generic Compact-derived struct
-	//     case does. Omitting the prefix mis-aligns reth's decoder and
-	//     panics at lib.rs:448:20 (Compact for [u8;N]).
-	//
-	//     For a Prague-active genesis we only set requests_hash, so the
-	//     inner HeaderExt is 33 bytes (1-byte bitflag = 0x01 + 32-byte
-	//     B256) and varuint(33) is a single byte 0x21 — total 34 bytes.
+	//     Prague is active. Non-specialized Option<T> form: varuint(len) ||
+	//     inner. See doc-comment header for the wire-format rationale.
 	if hasExtraFields {
 		var inner []byte
 		inner = append(inner, 0x01) // bitflag: requests_hash = Some
@@ -577,6 +599,12 @@ func tdCompactBytes() []byte {
 // With a CompressBlockBound-sized destination buffer, compression always succeeds
 // (n > 0) regardless of input incompressibility.
 func lz4CompressBlock(src []byte) ([]byte, error) {
+	// Empty input → empty output. Matches lz4_flex::block::compress (Vec::new() in,
+	// Vec::new() out) and the writer path that reth's append_account_changeset
+	// (Vec::new(), 0) exercises when appending an empty block-0 changeset row.
+	if len(src) == 0 {
+		return nil, nil
+	}
 	bound := lz4.CompressBlockBound(len(src))
 	dst := make([]byte, bound)
 	var c lz4.Compressor
@@ -585,7 +613,7 @@ func lz4CompressBlock(src []byte) ([]byte, error) {
 		return nil, err
 	}
 	if n == 0 {
-		// Should never happen with a CompressBlockBound-sized buffer, but guard anyway.
+		// Should never happen with a CompressBlockBound-sized buffer for non-empty src.
 		return nil, fmt.Errorf("lz4CompressBlock: unexpected n=0 for src len=%d", len(src))
 	}
 	return dst[:n], nil

--- a/client/reth/static_files_cgo_test.go
+++ b/client/reth/static_files_cgo_test.go
@@ -95,14 +95,18 @@ func TestWriteStaticFilesGenesis(t *testing.T) {
 
 	// --- verify all expected files exist ---
 	// Data file has NO extension; .off and .conf retain extensions.
+	// Change-based segments additionally have a .csoff sidecar.
 	segments := []struct {
-		name    string
-		columns uint64
+		name        string
+		columns     uint64
+		changeBased bool
 	}{
-		{"headers", 3},
-		{"transactions", 1},
-		{"receipts", 1},
-		{"transaction-senders", 1},
+		{"headers", 3, false},
+		{"transactions", 1, false},
+		{"receipts", 1, false},
+		{"transaction-senders", 1, false},
+		{"account-change-sets", 1, true},
+		{"storage-change-sets", 1, true},
 	}
 
 	for _, seg := range segments {
@@ -114,6 +118,11 @@ func TestWriteStaticFilesGenesis(t *testing.T) {
 		for _, ext := range []string{".off", ".conf"} {
 			if _, err := os.Stat(base + ext); err != nil {
 				t.Errorf("missing %s%s: %v", staticFileName(seg.name), ext, err)
+			}
+		}
+		if seg.changeBased {
+			if _, err := os.Stat(base + ".csoff"); err != nil {
+				t.Errorf("missing %s.csoff: %v", staticFileName(seg.name), err)
 			}
 		}
 	}
@@ -337,7 +346,7 @@ func TestHeaderCompactBytesGenesis(t *testing.T) {
 
 // TestHeaderCompactBytesPragueExtraFields verifies that a Prague-active
 // header (RequestsHash set) emits the Option<HeaderExt> wire-form at the
-// tail per reth-codecs-0.3.1 (lib.rs:302-322 Option<T>::to_compact for
+// tail per reth-codecs-0.3.1 (lib.rs Option<T>::to_compact for
 // the non-specialized branch):
 //
 //   - bit 31 of the LE bitfield (byte 3, bit 7) is set
@@ -350,7 +359,7 @@ func TestHeaderCompactBytesGenesis(t *testing.T) {
 // a custom (non-specialized) Compact-derived struct — specialized Options
 // (Option<B256>, Option<u64>) elsewhere in the parent header skip it.
 // Omitting the prefix mis-aligns reth's decoder and panics in
-// `Compact for [u8;N]::from_compact` at lib.rs:448:20.
+// `Compact for [u8;N]::from_compact` at lib.rs.
 func TestHeaderCompactBytesPragueExtraFields(t *testing.T) {
 	// Build the minimal genesis header from TestHeaderCompactBytesGenesis,
 	// then add the Prague RequestsHash. Compare lengths and byte structure.
@@ -468,11 +477,11 @@ func TestTdCompactBytes(t *testing.T) {
 
 // TestBuildSegmentHeaderBytesHeaders checks that headers SegmentHeader uses tx_range=None.
 func TestBuildSegmentHeaderBytesHeaders(t *testing.T) {
-	b := buildSegmentHeaderBytes(segHeaders)
+	b := buildSegmentHeaderBytes(segHeaders, 0)
 
 	// expected_block_range: start=0 (8 LE), end=499999 (8 LE) = 16 bytes
 	// block_range: Some (0x01) + start=0 (8) + end=0 (8) = 17 bytes
-	// tx_range: None (0x01)  — actually 0x00 for None
+	// tx_range: None (0x00) = 1 byte
 	// segment: 0 (4 LE)
 	// Total = 16 + 17 + 1 + 4 = 38 bytes
 	const wantLen = 38
@@ -495,7 +504,7 @@ func TestBuildSegmentHeaderBytesHeaders(t *testing.T) {
 
 // TestBuildSegmentHeaderBytesTransactions checks that transactions SegmentHeader uses tx_range=Some.
 func TestBuildSegmentHeaderBytesTransactions(t *testing.T) {
-	b := buildSegmentHeaderBytes(segTransactions)
+	b := buildSegmentHeaderBytes(segTransactions, 0)
 
 	// expected_block_range(16) + Some(1)+block_range(16) + Some(1)+tx_range(16) + u32(4)
 	const wantLen = 16 + 17 + 17 + 4
@@ -513,6 +522,175 @@ func TestBuildSegmentHeaderBytesTransactions(t *testing.T) {
 	segDiscr := binary.LittleEndian.Uint32(b[len(b)-4:])
 	if segDiscr != 1 {
 		t.Errorf("segment discriminant = %d, want 1 (Transactions)", segDiscr)
+	}
+}
+
+// TestBuildSegmentHeaderBytesChangesets verifies the 5-field SegmentHeader
+// layout for change-based segments (AccountChangeSets, StorageChangeSets):
+// expected_block_range(16) + Some(block_range)(17) + None(tx_range)(1)
+// + segment_u32(4) + changeset_offsets_len_u64(8) = 46 bytes.
+func TestBuildSegmentHeaderBytesChangesets(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		seg     staticFileSegment
+		wantDis uint32
+	}{
+		{"account-change-sets", segAccountChangeSets, 4},
+		{"storage-change-sets", segStorageChangeSets, 5},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b := buildSegmentHeaderBytes(tc.seg, 1)
+
+			// expected_block_range(16) + Some(1)+block_range(16) + None(1) + u32(4) + u64(8)
+			const wantLen = 16 + 17 + 1 + 4 + 8
+			if len(b) != wantLen {
+				t.Fatalf("len = %d, want %d", len(b), wantLen)
+			}
+
+			// tx_range presence byte at offset 33 must be 0x00 (None).
+			if got := b[16+1+16]; got != 0x00 {
+				t.Errorf("tx_range byte = %#x, want 0x00 (None) for change-based segment", got)
+			}
+
+			// segment discriminant occupies bytes 34..38.
+			segDiscr := binary.LittleEndian.Uint32(b[34:38])
+			if segDiscr != tc.wantDis {
+				t.Errorf("segment discriminant = %d, want %d", segDiscr, tc.wantDis)
+			}
+
+			// changeset_offsets_len occupies the trailing 8 bytes; we passed 1.
+			csOffLen := binary.LittleEndian.Uint64(b[38:46])
+			if csOffLen != 1 {
+				t.Errorf("changeset_offsets_len = %d, want 1", csOffLen)
+			}
+		})
+	}
+}
+
+// TestWriteStaticFilesChangesetShells verifies the empty bootstrap shell for
+// AccountChangeSets and StorageChangeSets — exactly what reth's persistence
+// service expects to find at boot so it can append block 1 cleanly.
+//
+// Each shell consists of:
+//   - data file: 0 bytes (1 row, empty content — LZ4 of empty = empty)
+//   - .off:      17 bytes ([8, 0×8 (row-0 start), 0×8 (row-0 end = empty)])
+//   - .conf:     5-field SegmentHeader with changeset_offsets_len=1, rows=1,
+//     columns=1, compressor=Some(Lz4), max_row_size=0
+//   - .csoff:    16 bytes (single record [offset=0, num_changes=0])
+func TestWriteStaticFilesChangesetShells(t *testing.T) {
+	tmp := t.TempDir()
+	header := makeGenesisHeader()
+	if err := WriteStaticFiles(tmp, header); err != nil {
+		t.Fatalf("WriteStaticFiles: %v", err)
+	}
+	sfDir := filepath.Join(tmp, staticFilesDir)
+
+	for _, tc := range []struct {
+		segName string
+		segDis  uint32
+	}{
+		{"account-change-sets", 4},
+		{"storage-change-sets", 5},
+	} {
+		t.Run(tc.segName, func(t *testing.T) {
+			base := filepath.Join(sfDir, staticFileName(tc.segName))
+
+			// Data file: 0 bytes (empty content for the single row).
+			dataInfo, err := os.Stat(base)
+			if err != nil {
+				t.Fatalf("data file stat: %v", err)
+			}
+			if dataInfo.Size() != 0 {
+				t.Errorf("data file size = %d, want 0", dataInfo.Size())
+			}
+
+			// .off: 17 bytes. byte 0 = 8 (offset_size). bytes 1..9 = row-0 start = 0.
+			// bytes 9..17 = end-of-row-0 = 0 (empty).
+			offBytes, err := os.ReadFile(base + ".off")
+			if err != nil {
+				t.Fatalf(".off read: %v", err)
+			}
+			if len(offBytes) != 17 {
+				t.Errorf(".off len = %d, want 17", len(offBytes))
+			}
+			if offBytes[0] != 8 {
+				t.Errorf(".off[0] = %d, want 8", offBytes[0])
+			}
+			if got := binary.LittleEndian.Uint64(offBytes[1:9]); got != 0 {
+				t.Errorf(".off row-0 start = %d, want 0", got)
+			}
+			if got := binary.LittleEndian.Uint64(offBytes[9:17]); got != 0 {
+				t.Errorf(".off row-0 end   = %d, want 0", got)
+			}
+
+			// .conf: parse the trailing fixed-size fields.
+			// Tail layout for non-empty compressed segments:
+			//   columns(u64) + rows(u64) + Some(1) + Lz4_variant(u32) + max_row_size(u64)
+			confBytes, err := os.ReadFile(base + ".conf")
+			if err != nil {
+				t.Fatalf(".conf read: %v", err)
+			}
+			const confTailLen = 8 + 8 + 1 + 4 + 8
+			if len(confBytes) < 8+confTailLen {
+				t.Fatalf(".conf too short: %d bytes", len(confBytes))
+			}
+			version := binary.LittleEndian.Uint64(confBytes[:8])
+			if version != nippyJarVersion {
+				t.Errorf("NippyJar version = %d, want %d", version, nippyJarVersion)
+			}
+			tail := confBytes[len(confBytes)-confTailLen:]
+			cols := binary.LittleEndian.Uint64(tail[0:8])
+			rows := binary.LittleEndian.Uint64(tail[8:16])
+			compressorPresence := tail[16]
+			compressorVariant := binary.LittleEndian.Uint32(tail[17:21])
+			maxRowSize := binary.LittleEndian.Uint64(tail[21:29])
+			if cols != 1 {
+				t.Errorf(".conf columns = %d, want 1", cols)
+			}
+			if rows != 1 {
+				t.Errorf(".conf rows = %d, want 1 (the empty block-0 shell)", rows)
+			}
+			if compressorPresence != 0x01 {
+				t.Errorf(".conf compressor presence = %#x, want 0x01 (Some)", compressorPresence)
+			}
+			if compressorVariant != 1 {
+				t.Errorf(".conf compressor variant = %d, want 1 (Lz4)", compressorVariant)
+			}
+			if maxRowSize != 0 {
+				t.Errorf(".conf max_row_size = %d, want 0 (empty content)", maxRowSize)
+			}
+
+			// The bytes between version(8) and the tail are the user_header
+			// (5-field SegmentHeader for change-based segments). Length =
+			// 16 (expected_block_range) + 17 (Some block_range) + 1 (None tx_range)
+			// + 4 (segment u32) + 8 (changeset_offsets_len) = 46.
+			userHeader := confBytes[8 : len(confBytes)-confTailLen]
+			if len(userHeader) != 46 {
+				t.Fatalf("user_header len = %d, want 46", len(userHeader))
+			}
+			segDiscr := binary.LittleEndian.Uint32(userHeader[34:38])
+			if segDiscr != tc.segDis {
+				t.Errorf("segment discriminant = %d, want %d", segDiscr, tc.segDis)
+			}
+			csOffLen := binary.LittleEndian.Uint64(userHeader[38:46])
+			if csOffLen != 1 {
+				t.Errorf("changeset_offsets_len = %d, want 1", csOffLen)
+			}
+
+			// .csoff sidecar: 16 bytes of zeros (single record: offset=0, num_changes=0).
+			csoffBytes, err := os.ReadFile(base + ".csoff")
+			if err != nil {
+				t.Fatalf(".csoff read: %v", err)
+			}
+			if len(csoffBytes) != 16 {
+				t.Errorf(".csoff len = %d, want 16", len(csoffBytes))
+			}
+			for i, b := range csoffBytes {
+				if b != 0 {
+					t.Errorf(".csoff[%d] = %#x, want 0x00", i, b)
+				}
+			}
+		})
 	}
 }
 

--- a/client/reth/storage_writer_cgo.go
+++ b/client/reth/storage_writer_cgo.go
@@ -14,34 +14,27 @@ import (
 	iReth "github.com/nerolation/state-actor/internal/reth"
 )
 
-// WriteContractStorage writes per-slot rows across the four storage tables
-// for a single contract. accounts must be a contract account (StateAccount
+// WriteContractStorage writes per-slot rows for a single contract across
+// the v2 storage tables. accounts must be a contract account (StateAccount
 // + Storage slots populated). blockNum is the block at which storage was
-// newly written (0 for genesis).
+// newly written (0 for genesis). All slots are written within ONE MDBX
+// transaction (the caller's).
 //
-// All slots written within ONE MDBX transaction (the caller's). Per-slot
-// writes are 4 rows:
-//   - PlainStorageState (DupSort): Address → StorageEntry{slot_key, slot_value}
-//   - HashedStorages (DupSort): keccak(Address) → StorageEntry{keccak(slot_key), slot_value}
-//   - StorageChangeSets (DupSort): BlockNumberAddress → StorageEntry{slot_key, prev=0}
-//   - StoragesHistory: StorageShardedKey{addr, slot_key, u64::MAX} → IntegerList([block])
+// Per-slot writes:
+//   - HashedStorages (DupSort): keccak(Address) → StorageEntry{keccak(slot_key), slot_value} — canonical v2 state, always.
+//   - StorageChangeSets (DupSort): BlockNumberAddress → StorageEntry{slot_key, prev=0} — archive only.
+//   - StoragesHistory: StorageShardedKey{addr, slot_key, u64::MAX} → IntegerList([block]) — archive only; routed to the RocksDB CF via envs.HistorySink().
 //
 // For genesis (blockNum=0) the "before" value in StorageChangeSets is 0 —
-// the slot was newly set. Composable with WriteEOAs / future WriteContracts.
+// the slot was newly set.
 //
-// Returns the per-slot StorageEntry size (PlainStorageState compact encoding)
-// summed over all slots. This is the byte unit reth's writer commits to the
-// primary storage table — used by the caller's stats accumulator. The
-// auxiliary tables (HashedStorages / StorageChangeSets / StoragesHistory) and
-// their keys are not counted, mirroring nethermind's "value-bytes" semantics.
-// Caller is responsible for transferring the returned count to *generator.Stats
-// only after the enclosing MDBX transaction commits.
-//
-// archive=false skips StorageChangeSets + StoragesHistory (no genesis history
-// to preserve); archive=true writes both per the reth archive schema.
+// Returns the sum of HashedStorages entry sizes (compact encoding) across
+// all slots, for the caller's stats accumulator. Auxiliary tables and
+// their keys are not counted. Caller transfers the count to
+// *generator.Stats only after the enclosing MDBX txn commits.
 func WriteContractStorage(
+	envs *Envs,
 	txn *mdbx.Txn,
-	dbis map[string]mdbx.DBI,
 	contract *entitygen.Account,
 	blockNum uint64,
 	archive bool,
@@ -55,55 +48,39 @@ func WriteContractStorage(
 	for _, slot := range contract.Storage {
 		slotValueU256 := uint256.NewInt(0).SetBytes(slot.Value[:])
 
-		// 1. PlainStorageState: Address → StorageEntry{slot_key, slot_value}
-		plainEntry := iReth.StorageEntry{Key: slot.Key, Value: slotValueU256}
-		var plainBuf bytes.Buffer
-		plainEntry.EncodeCompact(&plainBuf)
-		plainEntryBytes := plainBuf.Bytes()
-		if err := txn.Put(dbis["PlainStorageState"], contract.Address[:], plainEntryBytes, 0); err != nil {
-			return 0, fmt.Errorf("PlainStorageState %s slot %s: %w",
-				contract.Address.Hex(), slot.Key.Hex(), err)
-		}
-
-		// 2. HashedStorages: keccak(Address) → StorageEntry{keccak(slot_key), slot_value}
+		// HashedStorages: keccak(Address) → StorageEntry{keccak(slot_key), slot_value}.
+		// Canonical v2 storage table.
 		hashedSlotKey := crypto.Keccak256Hash(slot.Key[:])
 		hashedEntry := iReth.StorageEntry{Key: hashedSlotKey, Value: slotValueU256}
 		var hashedBuf bytes.Buffer
 		hashedEntry.EncodeCompact(&hashedBuf)
-		if err := txn.Put(dbis["HashedStorages"], contract.AddrHash[:], hashedBuf.Bytes(), 0); err != nil {
+		hashedEntryBytes := hashedBuf.Bytes()
+		if err := txn.Put(envs.MdbxDBIs["HashedStorages"], contract.AddrHash[:], hashedEntryBytes, 0); err != nil {
 			return 0, fmt.Errorf("HashedStorages %s slot %s: %w",
 				contract.AddrHash.Hex(), slot.Key.Hex(), err)
 		}
 
 		if archive {
-			// 3. StorageChangeSets: BlockNumberAddress → StorageEntry{slot_key, prev_value=0}
+			// StorageChangeSets: BlockNumberAddress → StorageEntry{slot_key, prev_value=0}
 			// For genesis (block 0), the "before" value is 0 — slot was newly set.
 			changeEntry := iReth.StorageEntry{Key: slot.Key, Value: uint256.NewInt(0)}
 			var changeBuf bytes.Buffer
 			changeEntry.EncodeCompact(&changeBuf)
-			if err := txn.Put(dbis["StorageChangeSets"], blockKeyBytes, changeBuf.Bytes(), 0); err != nil {
+			if err := txn.Put(envs.MdbxDBIs["StorageChangeSets"], blockKeyBytes, changeBuf.Bytes(), 0); err != nil {
 				return 0, fmt.Errorf("StorageChangeSets %s slot %s: %w",
 					contract.Address.Hex(), slot.Key.Hex(), err)
 			}
 
-			// 4. StoragesHistory: StorageShardedKey{addr, slot_key, u64::MAX} → IntegerList([block])
-			// u64::MAX marks the latest (open) shard; the bitmap contains the block
-			// numbers at which this slot was first touched.
-			ssk := iReth.StorageShardedKey{
-				Address:     contract.Address,
-				StorageKey:  slot.Key,
-				BlockNumber: ^uint64(0),
-			}
-			var sskBuf bytes.Buffer
-			ssk.EncodeKey(&sskBuf)
-			var listBuf bytes.Buffer
-			iReth.EncodeIntegerList(&listBuf, []uint64{blockNum})
-			if err := txn.Put(dbis["StoragesHistory"], sskBuf.Bytes(), listBuf.Bytes(), 0); err != nil {
+			// StoragesHistory → RocksDB CF (v2 routing per
+			// EitherReader::new_storages_history). Wire format:
+			// StorageShardedKey(addr, slot_key, u64::MAX) → EncodeIntegerList([blockNum]).
+			if err := envs.HistorySink().PutStorageHistory(contract.Address, slot.Key, blockNum); err != nil {
 				return 0, fmt.Errorf("StoragesHistory %s slot %s: %w",
 					contract.Address.Hex(), slot.Key.Hex(), err)
 			}
 		}
-		storageBytes += uint64(len(plainEntryBytes))
+		// Stats: bank HashedStorages compact-encoded entry bytes.
+		storageBytes += uint64(len(hashedEntryBytes))
 	}
 	return storageBytes, nil
 }

--- a/client/reth/storage_writer_cgo_test.go
+++ b/client/reth/storage_writer_cgo_test.go
@@ -11,10 +11,30 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/holiman/uint256"
+	"github.com/linxGnu/grocksdb"
 
 	"github.com/nerolation/state-actor/internal/entitygen"
 	iReth "github.com/nerolation/state-actor/internal/reth"
 )
+
+// countMDBXRows returns the row count of an MDBX table by full scan. Used
+// by both the FullMode and Archive tests below.
+func countMDBXRows(t *testing.T, envs *Envs, table string) int {
+	t.Helper()
+	var count int
+	_ = envs.Mdbx.View(func(txn *mdbx.Txn) error {
+		cur, err := txn.OpenCursor(envs.MdbxDBIs[table])
+		if err != nil {
+			return err
+		}
+		defer cur.Close()
+		for _, _, err := cur.Get(nil, nil, mdbx.First); err == nil; _, _, err = cur.Get(nil, nil, mdbx.Next) {
+			count++
+		}
+		return nil
+	})
+	return count
+}
 
 func TestWriteContractStorageRoundtrip(t *testing.T) {
 	tmp := t.TempDir()
@@ -41,36 +61,19 @@ func TestWriteContractStorageRoundtrip(t *testing.T) {
 	}
 
 	err = envs.Mdbx.Update(func(txn *mdbx.Txn) error {
-		_, err := WriteContractStorage(txn, envs.MdbxDBIs, contract, 0, true /* archive */)
+		_, err := WriteContractStorage(envs, txn, contract, 0, true /* archive */)
 		return err
 	})
 	if err != nil {
 		t.Fatalf("WriteContractStorage: %v", err)
 	}
 
-	// Verify PlainStorageState — count entries under contract.Address.
-	if err := envs.Mdbx.View(func(txn *mdbx.Txn) error {
-		cur, err := txn.OpenCursor(envs.MdbxDBIs["PlainStorageState"])
-		if err != nil {
-			return err
-		}
-		defer cur.Close()
-		count := 0
-		for k, _, err := cur.Get(addr[:], nil, mdbx.SetKey); err == nil; k, _, err = cur.Get(nil, nil, mdbx.NextDup) {
-			if !bytes.Equal(k, addr[:]) {
-				break
-			}
-			count++
-		}
-		if count != len(contract.Storage) {
-			t.Errorf("PlainStorageState: %d entries for %s, want %d", count, addr.Hex(), len(contract.Storage))
-		}
-		return nil
-	}); err != nil {
-		t.Errorf("verify PlainStorageState: %v", err)
+	// v2 invariant: PlainStorageState MUST be empty.
+	if got := countMDBXRows(t, envs, "PlainStorageState"); got != 0 {
+		t.Errorf("PlainStorageState rows = %d, want 0 (empty on v2)", got)
 	}
 
-	// Verify HashedStorages similarly under addrHash.
+	// HashedStorages: count under addrHash via DupSort cursor.
 	if err := envs.Mdbx.View(func(txn *mdbx.Txn) error {
 		cur, err := txn.OpenCursor(envs.MdbxDBIs["HashedStorages"])
 		if err != nil {
@@ -92,33 +95,41 @@ func TestWriteContractStorageRoundtrip(t *testing.T) {
 		t.Errorf("verify HashedStorages: %v", err)
 	}
 
-	// Spot-check StoragesHistory exists for slot 0x01.
-	if err := envs.Mdbx.View(func(txn *mdbx.Txn) error {
-		var keyBuf bytes.Buffer
-		ssk := iReth.StorageShardedKey{
-			Address:     addr,
-			StorageKey:  common.HexToHash("0x01"),
-			BlockNumber: ^uint64(0),
-		}
-		ssk.EncodeKey(&keyBuf)
-		val, err := txn.Get(envs.MdbxDBIs["StoragesHistory"], keyBuf.Bytes())
-		if err != nil {
-			return err
-		}
-		list, _ := iReth.DecodeIntegerList(val)
-		if len(list) != 1 || list[0] != 0 {
-			t.Errorf("StoragesHistory: list = %v, want [0]", list)
-		}
-		return nil
-	}); err != nil {
-		t.Errorf("verify StoragesHistory: %v", err)
+	// Spot-check StoragesHistory in the RocksDB CF (v2 routing) for slot
+	// 0x01. Flush the sink first so the WAL-disabled batch lands in the
+	// memtable where GetCF can see it.
+	if err := envs.HistorySink().Flush(); err != nil {
+		t.Fatalf("historySink.Flush: %v", err)
+	}
+	ro := grocksdb.NewDefaultReadOptions()
+	defer ro.Destroy()
+	ssk := iReth.StorageShardedKey{
+		Address:     addr,
+		StorageKey:  common.HexToHash("0x01"),
+		BlockNumber: ^uint64(0),
+	}
+	var keyBuf bytes.Buffer
+	ssk.EncodeKey(&keyBuf)
+	val, err := envs.RocksDB.GetCF(ro, envs.RocksCFs["StoragesHistory"], keyBuf.Bytes())
+	if err != nil {
+		t.Fatalf("GetCF StoragesHistory: %v", err)
+	}
+	defer val.Free()
+	list, _ := iReth.DecodeIntegerList(val.Data())
+	if len(list) != 1 || list[0] != 0 {
+		t.Errorf("StoragesHistory list = %v, want [0]", list)
+	}
+
+	// MDBX StoragesHistory MUST be empty under v2 (data lives in RocksDB).
+	if got := countMDBXRows(t, envs, "StoragesHistory"); got != 0 {
+		t.Errorf("MDBX StoragesHistory rows = %d, want 0 (v2 routes to RocksDB CF)", got)
 	}
 }
 
 // TestWriteContractStorage_FullMode: with archive=false (full mode, the
-// default), WriteContractStorage must populate PlainStorageState and
-// HashedStorages but elide BOTH archive-only tables (StorageChangeSets
-// and StoragesHistory).
+// default), WriteContractStorage populates HashedStorages and elides both
+// archive-only tables. Under v2, PlainStorageState is empty regardless of
+// archive mode.
 func TestWriteContractStorage_FullMode(t *testing.T) {
 	envs, err := OpenEnvs(t.TempDir(), true)
 	if err != nil {
@@ -141,47 +152,31 @@ func TestWriteContractStorage_FullMode(t *testing.T) {
 	}
 
 	err = envs.Mdbx.Update(func(txn *mdbx.Txn) error {
-		_, err := WriteContractStorage(txn, envs.MdbxDBIs, contract, 0, false /* archive */)
+		_, err := WriteContractStorage(envs, txn, contract, 0, false /* archive */)
 		return err
 	})
 	if err != nil {
 		t.Fatalf("WriteContractStorage(archive=false): %v", err)
 	}
 
-	countRows := func(t *testing.T, table string) int {
-		t.Helper()
-		var count int
-		_ = envs.Mdbx.View(func(txn *mdbx.Txn) error {
-			cur, err := txn.OpenCursor(envs.MdbxDBIs[table])
-			if err != nil {
-				return err
-			}
-			defer cur.Close()
-			for _, _, err := cur.Get(nil, nil, mdbx.First); err == nil; _, _, err = cur.Get(nil, nil, mdbx.Next) {
-				count++
-			}
-			return nil
-		})
-		return count
-	}
-
-	if got := countRows(t, "StorageChangeSets"); got != 0 {
+	if got := countMDBXRows(t, envs, "StorageChangeSets"); got != 0 {
 		t.Errorf("StorageChangeSets rows = %d, want 0 (full mode skips)", got)
 	}
-	if got := countRows(t, "StoragesHistory"); got != 0 {
-		t.Errorf("StoragesHistory rows = %d, want 0 (full mode skips)", got)
+	if got := countMDBXRows(t, envs, "StoragesHistory"); got != 0 {
+		t.Errorf("MDBX StoragesHistory rows = %d, want 0 (full mode skips + v2 routes to RocksDB)", got)
 	}
-	if got := countRows(t, "PlainStorageState"); got != len(contract.Storage) {
-		t.Errorf("PlainStorageState rows = %d, want %d", got, len(contract.Storage))
+	if got := countMDBXRows(t, envs, "PlainStorageState"); got != 0 {
+		t.Errorf("PlainStorageState rows = %d, want 0 (empty on v2)", got)
 	}
-	if got := countRows(t, "HashedStorages"); got != len(contract.Storage) {
+	if got := countMDBXRows(t, envs, "HashedStorages"); got != len(contract.Storage) {
 		t.Errorf("HashedStorages rows = %d, want %d", got, len(contract.Storage))
 	}
 }
 
-// TestWriteContractStorage_Archive: with archive=true, all four tables
-// populate at the expected counts. Mirror of _FullMode for the opt-in
-// archive-mode path.
+// TestWriteContractStorage_Archive: with archive=true, HashedStorages,
+// StorageChangeSets, and the RocksDB StoragesHistory CF populate at the
+// expected counts. PlainStorageState stays empty (v2 invariant) and MDBX
+// StoragesHistory stays empty (v2 routes to RocksDB).
 func TestWriteContractStorage_Archive(t *testing.T) {
 	envs, err := OpenEnvs(t.TempDir(), true)
 	if err != nil {
@@ -204,33 +199,41 @@ func TestWriteContractStorage_Archive(t *testing.T) {
 	}
 
 	err = envs.Mdbx.Update(func(txn *mdbx.Txn) error {
-		_, err := WriteContractStorage(txn, envs.MdbxDBIs, contract, 0, true /* archive */)
+		_, err := WriteContractStorage(envs, txn, contract, 0, true /* archive */)
 		return err
 	})
 	if err != nil {
 		t.Fatalf("WriteContractStorage(archive=true): %v", err)
 	}
 
-	countRows := func(t *testing.T, table string) int {
-		t.Helper()
-		var count int
-		_ = envs.Mdbx.View(func(txn *mdbx.Txn) error {
-			cur, err := txn.OpenCursor(envs.MdbxDBIs[table])
-			if err != nil {
-				return err
-			}
-			defer cur.Close()
-			for _, _, err := cur.Get(nil, nil, mdbx.First); err == nil; _, _, err = cur.Get(nil, nil, mdbx.Next) {
-				count++
-			}
-			return nil
-		})
-		return count
+	// Drain the RocksDB sink so the StoragesHistory CF read returns rows.
+	if err := envs.HistorySink().Flush(); err != nil {
+		t.Fatalf("historySink.Flush: %v", err)
 	}
 
-	for _, table := range []string{"PlainStorageState", "HashedStorages", "StorageChangeSets", "StoragesHistory"} {
-		if got := countRows(t, table); got != len(contract.Storage) {
-			t.Errorf("%s rows = %d, want %d", table, got, len(contract.Storage))
-		}
+	if got := countMDBXRows(t, envs, "PlainStorageState"); got != 0 {
+		t.Errorf("PlainStorageState rows = %d, want 0 (empty on v2)", got)
+	}
+	if got := countMDBXRows(t, envs, "HashedStorages"); got != len(contract.Storage) {
+		t.Errorf("HashedStorages rows = %d, want %d", got, len(contract.Storage))
+	}
+	if got := countMDBXRows(t, envs, "StorageChangeSets"); got != len(contract.Storage) {
+		t.Errorf("StorageChangeSets rows = %d, want %d", got, len(contract.Storage))
+	}
+	if got := countMDBXRows(t, envs, "StoragesHistory"); got != 0 {
+		t.Errorf("MDBX StoragesHistory rows = %d, want 0 (v2 routes to RocksDB CF)", got)
+	}
+
+	// RocksDB CF: should have one row per storage slot.
+	ro := grocksdb.NewDefaultReadOptions()
+	defer ro.Destroy()
+	iter := envs.RocksDB.NewIteratorCF(ro, envs.RocksCFs["StoragesHistory"])
+	defer iter.Close()
+	cfCount := 0
+	for iter.SeekToFirst(); iter.Valid(); iter.Next() {
+		cfCount++
+	}
+	if cfCount != len(contract.Storage) {
+		t.Errorf("RocksDB StoragesHistory CF rows = %d, want %d", cfCount, len(contract.Storage))
 	}
 }

--- a/internal/reth/golden_test.go
+++ b/internal/reth/golden_test.go
@@ -91,21 +91,53 @@ func TestGoldenIntegerList(t *testing.T) {
 	}
 }
 
-// TestGoldenStorageTrieEntry is skipped: the Rust fixture generator at
-// testdata/gen/src/main.rs uses PackedStorageTrieEntry (33-byte packed SubKey,
-// storage v2). Our writer now produces the 65-byte legacy StoredNibblesSubKey
-// because reth's ProviderFactory defaults to StorageSettings::v1() when the
-// Metadata table has no storage_settings row (see
-// crates/storage/provider/src/providers/database/mod.rs:132). v1 reads via
-// StorageTrieEntry::from_compact (storage.rs:38-43), which expects 65-byte
-// SubKeys; v2 (packed) also pulls in RocksDB sidecars and static-file
-// changesets that a one-shot genesis writer does not produce.
-//
-// Algorithmic correctness is now covered by TestHashBuilderRootMatchesStackTrieProperty
-// (hash_builder_test.go) which cross-validates the root hash against
-// go-ethereum's StackTrie across 50 random trials, independent of wire format.
+// TestGoldenStorageTrieEntry cross-validates EncodePackedCompact against the
+// Rust fixture generator at testdata/gen/src/main.rs (PackedStorageTrieEntry,
+// the wire format reth's PackedStorageTrieEntry::from_compact decodes under
+// storage_v2). Catches encoder drift on every reth-codecs bump.
 func TestGoldenStorageTrieEntry(t *testing.T) {
-	t.Skip("Rust fixtures are pinned to packed v2 33-byte SubKey; writer now uses legacy v1 65-byte SubKey")
+	cases := loadFixtures(t)["StorageTrieEntry"]
+	if len(cases) == 0 {
+		t.Fatal("no StorageTrieEntry fixtures (regenerate via testdata/gen/)")
+	}
+
+	bncMinimal := BranchNodeCompact{StateMask: 0, TreeMask: 0, HashMask: 0}
+	hAA := common.HexToHash("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	hBB := common.HexToHash("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
+	inputs := map[string]StorageTrieEntry{
+		"ste_minimal": {
+			SubKey: StoredNibbles{Length: 0},
+			Node:   bncMinimal,
+		},
+		"ste_basic": {
+			SubKey: StoredNibbles{Length: 4, Nibbles: [64]byte{1, 2, 3, 4}},
+			Node: BranchNodeCompact{
+				StateMask: 0x0001, TreeMask: 0, HashMask: 0x0001,
+				Hashes: []common.Hash{hAA},
+			},
+		},
+		"ste_with_root": {
+			SubKey: StoredNibbles{Length: 8, Nibbles: [64]byte{1, 2, 3, 4, 5, 6, 7, 8}},
+			Node: BranchNodeCompact{
+				StateMask: 0x0003, TreeMask: 0x0002, HashMask: 0x0003,
+				Hashes: []common.Hash{hAA, hBB}, RootHash: &hBB,
+			},
+		},
+	}
+
+	for _, fx := range cases {
+		in, ok := inputs[fx.Label]
+		if !ok {
+			t.Fatalf("unknown fixture label %q — Rust and Go are out of sync", fx.Label)
+		}
+		var buf bytes.Buffer
+		in.EncodePackedCompact(&buf)
+		got := hex.EncodeToString(buf.Bytes())
+		if got != fx.Hex {
+			t.Errorf("%s:\n  go   = %s\n  rust = %s", fx.Label, got, fx.Hex)
+		}
+	}
 }
 
 // unpackNibbles converts a byte slice to individual nibbles (each byte → 2 nibbles,

--- a/internal/reth/trie_format.go
+++ b/internal/reth/trie_format.go
@@ -6,39 +6,22 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// StoredNibbles is reth's legacy v1 65-byte nibble path used as the AccountsTrie
-// key and as the StoragesTrie sub-key. One nibble per byte (low 4 bits used),
-// right-padded with zeros to 64 bytes, followed by a length byte.
+// StoredNibbles is a nibble path with a fixed-64-byte buffer + an
+// explicit Length suffix. Two encoders use the same struct:
 //
-// Wire (MDBX key, fixed 65 bytes):
-//
-//	nibbles[64] (one nibble per byte, low 4 bits, right-padded zeros) || length[1]
-//
-// Matches StoredNibbles::to_compact / StoredNibblesSubKey::to_compact in
-// reth-trie-common (nibbles.rs lines 101-128). Reth's ProviderFactory defaults
-// to StorageSettings::v1() when no metadata row is present (see
-// crates/storage/provider/src/providers/database/mod.rs:132), which selects the
-// LegacyKeyAdapter and reads this 65-byte form via StorageTrieEntry::from_compact
-// (storage.rs:38-43). The 33-byte PackedStoredNibbles variant is only used when
-// storage_v2 = true is explicitly written into the Metadata table — that mode
-// also expects RocksDB history sidecars + static-file changesets, which a
-// one-shot genesis writer does not produce.
+//   - EncodeKey: 65-byte form (nibbles[64] || length[1]). Used as the
+//     StoragesTrie DupSort SubKey inside StorageTrieEntry. See reth-
+//     trie-common nibbles.rs.
+//   - EncodePackedAccountKey / EncodePackedCompact: 33-byte packed form
+//     (two nibbles per byte, padded to 32 bytes + 1 nibble-count byte).
+//     This is what reth v2's PackedKeyAdapter expects for AccountsTrie /
+//     StoragesTrie reads.
 type StoredNibbles struct {
 	Length  byte
 	Nibbles [64]byte
 }
 
-// EncodeKey writes the FIXED 65-byte form (nibbles[64] || length[1]). This is
-// the wire layout reth uses for StoredNibblesSubKey (StoragesTrie DupSort
-// sub-key, inside the StorageTrieEntry value) — see reth-trie-common
-// nibbles.rs:113-128 and reth/crates/storage/db-api/src/models/mod.rs:135-141
-// (Encoded = [u8; 65]).
-//
-// NOTE: this is NOT the right encoder for an AccountsTrie KEY. Reth's
-// tables::AccountsTrie uses StoredNibbles::Encode = ArrayVec<u8, 64> (variable
-// length, raw nibbles, no padding, no length byte) — see
-// reth/crates/storage/db-api/src/models/mod.rs:121-127. For AccountsTrie
-// keys, use EncodeAccountKey below.
+// EncodeKey writes the 65-byte form (nibbles[64] || length[1]).
 func (s *StoredNibbles) EncodeKey(buf *bytes.Buffer) {
 	buf.Write(s.Nibbles[:])
 	buf.WriteByte(s.Length)
@@ -52,33 +35,36 @@ func (s *StoredNibbles) DecodeKey(b []byte) {
 	s.Length = b[64]
 }
 
-// EncodeAccountKey writes the VARIABLE-length form (just s.Nibbles[:s.Length],
-// 0..=64 bytes, no padding, no length suffix). This is the wire layout reth's
-// tables::AccountsTrie expects for keys (StoredNibbles::Encode in
-// reth/crates/storage/db-api/src/models/mod.rs:121-127 returns
-// ArrayVec<u8, 64>; decoding reconstructs Length = len(value) via
-// from_compact at line 131).
-func (s *StoredNibbles) EncodeAccountKey(buf *bytes.Buffer) {
-	if int(s.Length) > 64 {
-		panic("StoredNibbles: Length > 64")
-	}
-	buf.Write(s.Nibbles[:s.Length])
-}
-
-// DecodeAccountKey is the inverse: every byte of b is one nibble, Length =
-// len(b). Mirrors reth's StoredNibbles::from_compact(value, value.len()).
-func (s *StoredNibbles) DecodeAccountKey(b []byte) {
-	if len(b) > 64 {
-		panic("StoredNibbles: account key longer than 64 bytes")
-	}
-	*s = StoredNibbles{}
-	s.Length = byte(len(b))
-	copy(s.Nibbles[:], b)
-}
-
 // StoredNibblesSubKey is the StoragesTrie DupSort sub-key (after the 32-byte
 // hashed-address main key). Same 65-byte layout as StoredNibbles.
 type StoredNibblesSubKey = StoredNibbles
+
+// EncodePackedAccountKey writes the 33-byte packed form to buf — the wire
+// layout reth's PackedAccountsTrie key uses under storage_v2. Two nibbles
+// per byte (high nibble in upper 4 bits, low nibble in lower 4 bits), right-
+// padded to 32 bytes; the 33rd byte carries the actual nibble count.
+//
+// Mirrors PackedStoredNibbles::to_compact_array in reth-trie-common
+// (nibbles.rs).
+//
+// SAFE under storage_v2=true only — a non-v2 reader would decode this as a
+// 33-NIBBLE path (one nibble per byte) and silently corrupt the trie.
+func (s *StoredNibbles) EncodePackedAccountKey(buf *bytes.Buffer) {
+	if int(s.Length) > 64 {
+		panic("StoredNibbles: Length > 64")
+	}
+	var out [33]byte
+	n := int(s.Length)
+	pairs := n / 2
+	for i := 0; i < pairs; i++ {
+		out[i] = (s.Nibbles[2*i] << 4) | s.Nibbles[2*i+1]
+	}
+	if n%2 == 1 {
+		out[pairs] = s.Nibbles[2*pairs] << 4
+	}
+	out[32] = s.Length
+	buf.Write(out[:])
+}
 
 // BranchNodeCompact mirrors alloy_trie::BranchNodeCompact (alloy-trie 0.9.5,
 // nodes/branch.rs). Used as the value of AccountsTrie / StoragesTrie.
@@ -188,43 +174,36 @@ func readBEU16(b []byte) uint16 {
 	return uint16(b[0])<<8 | uint16(b[1])
 }
 
-// StorageTrieEntry is the DupSort value of StoragesTrie. The 65-byte SubKey is
-// also encoded inside the value so reth's StorageTrieEntry::from_compact can
-// self-describe (storage.rs:38-43).
-//
-// Wire:
-//
-//	65 bytes SubKey (StoredNibblesSubKey) || BranchNodeCompact bytes
-//
-// SubKey layout matches StoredNibblesSubKey::to_compact (reth-trie-common
-// nibbles.rs:113-129): nibbles[64] (one nibble per byte, right-padded) ||
-// length[1]. Length byte is at byte 64 (the end).
+// StorageTrieEntry is the DupSort value of StoragesTrie. Under v2 we use the
+// 33-byte packed SubKey form via EncodePackedCompact; reth's
+// PackedStorageTrieEntry::from_compact decodes it (storage.rs).
 type StorageTrieEntry struct {
 	SubKey StoredNibblesSubKey
 	Node   BranchNodeCompact
 }
 
-func (e *StorageTrieEntry) EncodeCompact(buf *bytes.Buffer) int {
-	written := 0
-	written += copy(bufWrite(buf, 64), e.SubKey.Nibbles[:])
-	written += copy(bufWrite(buf, 1), []byte{e.SubKey.Length})
+// EncodePackedCompact writes the v2 StoragesTrie DupSort value layout: 33-byte
+// PackedStoredNibblesSubKey (32 packed nibble pairs + 1 nibble-count byte)
+// followed by the BranchNodeCompact bytes.
+//
+// SAFE to use with storage_v2=true only — see EncodePackedAccountKey for the
+// gating rationale.
+func (e *StorageTrieEntry) EncodePackedCompact(buf *bytes.Buffer) int {
+	if int(e.SubKey.Length) > 64 {
+		panic("StorageTrieEntry: SubKey.Length > 64")
+	}
+	var out [33]byte
+	n := int(e.SubKey.Length)
+	pairs := n / 2
+	for i := 0; i < pairs; i++ {
+		out[i] = (e.SubKey.Nibbles[2*i] << 4) | e.SubKey.Nibbles[2*i+1]
+	}
+	if n%2 == 1 {
+		out[pairs] = e.SubKey.Nibbles[2*pairs] << 4
+	}
+	out[32] = e.SubKey.Length
+	buf.Write(out[:])
+	written := 33
 	written += e.Node.EncodeCompact(buf)
 	return written
-}
-
-func (e *StorageTrieEntry) DecodeCompact(data []byte, totalLen int) int {
-	if totalLen < 65 {
-		panic("StorageTrieEntry: totalLen < 65 (SubKey truncated)")
-	}
-	if len(data) < totalLen {
-		panic("StorageTrieEntry: buffer shorter than totalLen")
-	}
-	copy(e.SubKey.Nibbles[:], data[0:64])
-	e.SubKey.Length = data[64]
-	nodeLen := totalLen - 65
-	consumed := e.Node.DecodeCompact(data[65:], nodeLen)
-	if consumed != nodeLen {
-		panic("StorageTrieEntry: inner node consumed != totalLen-65")
-	}
-	return totalLen
 }

--- a/internal/reth/trie_format_test.go
+++ b/internal/reth/trie_format_test.go
@@ -41,43 +41,6 @@ func TestStoredNibblesRoundtrip(t *testing.T) {
 	}
 }
 
-// TestStoredNibblesEncodeAccountKey_VariableLength asserts the AccountsTrie
-// key wire format: raw nibbles (one byte per nibble), no padding, no length
-// suffix. Matches reth's StoredNibbles::Encode = ArrayVec<u8, 64>
-// (reth/crates/storage/db-api/src/models/mod.rs:121-127).
-func TestStoredNibblesEncodeAccountKey_VariableLength(t *testing.T) {
-	cases := [][]byte{
-		{},                                                     // empty path = depth 0 (root)
-		{0xa},                                                  // 1 nibble
-		{0xa, 0xb, 0xc},                                        // 3 nibbles
-		bytes.Repeat([]byte{0x0f}, 32),                         // 32 nibbles
-		func() []byte { b := make([]byte, 64); for i := range b { b[i] = byte(i % 16) }; return b }(), // full 64-nibble leaf
-	}
-	for i, nibbles := range cases {
-		sn := StoredNibbles{Length: byte(len(nibbles))}
-		copy(sn.Nibbles[:], nibbles)
-		var buf bytes.Buffer
-		sn.EncodeAccountKey(&buf)
-		if buf.Len() != len(nibbles) {
-			t.Errorf("case %d: encoded len=%d, want %d (no padding, no length byte)", i, buf.Len(), len(nibbles))
-		}
-		if !bytes.Equal(buf.Bytes(), nibbles) {
-			t.Errorf("case %d: encoded=%x want=%x", i, buf.Bytes(), nibbles)
-		}
-
-		var out StoredNibbles
-		out.DecodeAccountKey(buf.Bytes())
-		if out.Length != sn.Length {
-			t.Errorf("case %d: length %d -> %d", i, sn.Length, out.Length)
-		}
-		for j := 0; j < int(sn.Length); j++ {
-			if out.Nibbles[j] != sn.Nibbles[j] {
-				t.Errorf("case %d: nibble[%d] %d -> %d", i, j, sn.Nibbles[j], out.Nibbles[j])
-			}
-		}
-	}
-}
-
 func TestBranchNodeCompactRoundtrip(t *testing.T) {
 	h1 := common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
 	h2 := common.HexToHash("0x2222222222222222222222222222222222222222222222222222222222222222")
@@ -130,28 +93,132 @@ func branchNodeEqual(a, b BranchNodeCompact) bool {
 	return true
 }
 
-func TestStorageTrieEntryRoundtrip(t *testing.T) {
-	h := common.HexToHash("0xabc")
-	subKey := StoredNibbles{Length: 4}
-	copy(subKey.Nibbles[:], []byte{1, 2, 3, 4})
-	in := StorageTrieEntry{
-		SubKey: subKey,
-		Node: BranchNodeCompact{
-			StateMask: 0x0001, TreeMask: 0, HashMask: 0x0001,
-			Hashes: []common.Hash{h}, RootHash: nil,
+// TestEncodePackedAccountKeyShape pins the 33-byte fixed-size layout reth's
+// PackedAccountsTrie expects. Byte 32 is the nibble count; bytes 0..32 carry
+// packed nibble pairs (high nibble in upper 4 bits, low nibble in lower 4
+// bits) right-padded with zeros after the actual nibble count.
+//
+// Ground truth hand-derived from reth-trie-common
+// PackedStoredNibbles::to_compact_array (nibbles.rs:178-189). Any
+// future change to the encoder must update these golden bytes
+// in lock-step or reth's v2 reader will misdecode.
+func TestEncodePackedAccountKeyShape(t *testing.T) {
+	type tc struct {
+		name    string
+		nibbles []byte
+		want    [33]byte
+	}
+	cases := []tc{
+		{
+			name:    "empty",
+			nibbles: []byte{},
+			want:    [33]byte{}, // 32 zeros + count=0
+		},
+		{
+			name:    "single nibble (odd)",
+			nibbles: []byte{0xA},
+			want:    [33]byte{0xA0, 32: 1}, // 0xA in high nibble, rest zero; count=1
+		},
+		{
+			name:    "two nibbles (even)",
+			nibbles: []byte{0xA, 0xB},
+			want:    [33]byte{0xAB, 32: 2}, // packed; count=2
+		},
+		{
+			name:    "three nibbles (odd, two pairs needed)",
+			nibbles: []byte{0x1, 0x2, 0x3},
+			want:    [33]byte{0x12, 0x30, 32: 3},
+		},
+		{
+			name:    "four nibbles (even)",
+			nibbles: []byte{0xA, 0xB, 0xC, 0xD},
+			want:    [33]byte{0xAB, 0xCD, 32: 4},
 		},
 	}
-	var buf bytes.Buffer
-	n := in.EncodeCompact(&buf)
-	var out StorageTrieEntry
-	consumed := out.DecodeCompact(buf.Bytes(), n)
-	if consumed != n {
-		t.Errorf("consumed %d, encoded %d", consumed, n)
+	// 64 nibbles → fills all 32 packed bytes, count=64
+	full := tc{name: "max (64 nibbles)", nibbles: make([]byte, 64)}
+	for i := range full.nibbles {
+		full.nibbles[i] = byte(i % 16) // 0,1,2,..,F,0,1,2,..
 	}
-	if in.SubKey != out.SubKey {
-		t.Errorf("SubKey roundtrip mismatch")
+	// Hand-pack: each pair (2i,2i+1) → (2i<<4)|(2i+1) % 16
+	for i := 0; i < 32; i++ {
+		full.want[i] = (full.nibbles[2*i] << 4) | full.nibbles[2*i+1]
 	}
-	if !branchNodeEqual(in.Node, out.Node) {
-		t.Errorf("Node roundtrip mismatch hex=%x", buf.Bytes())
+	full.want[32] = 64
+	cases = append(cases, full)
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			sn := StoredNibbles{Length: byte(len(c.nibbles))}
+			copy(sn.Nibbles[:], c.nibbles)
+			var buf bytes.Buffer
+			sn.EncodePackedAccountKey(&buf)
+			if buf.Len() != 33 {
+				t.Fatalf("packed key = %d bytes, want 33", buf.Len())
+			}
+			if !bytes.Equal(buf.Bytes(), c.want[:]) {
+				t.Errorf("packed key = %x\n  want      %x", buf.Bytes(), c.want[:])
+			}
+		})
+	}
+}
+
+// TestEncodePackedCompactShape pins the StoragesTrie DupSort value layout
+// under storage_v2: 33-byte PackedStoredNibblesSubKey followed by
+// BranchNodeCompact bytes. The packing is reimplemented inline in
+// EncodePackedCompact (does not delegate to EncodePackedAccountKey) so
+// both encoders need parallel coverage to catch drift between them.
+func TestEncodePackedCompactShape(t *testing.T) {
+	h := common.HexToHash("0xdeadbeef")
+	node := BranchNodeCompact{
+		StateMask: 0x0001, TreeMask: 0, HashMask: 0x0001,
+		Hashes: []common.Hash{h}, RootHash: nil,
+	}
+	cases := []struct {
+		name        string
+		nibbles     []byte
+		wantSubKey  [33]byte
+	}{
+		{"empty", []byte{}, [33]byte{}}, // 32 zeros + count=0
+		{"single (odd)", []byte{0xA}, [33]byte{0xA0, 32: 1}},
+		{"two (even)", []byte{0xA, 0xB}, [33]byte{0xAB, 32: 2}},
+		{"three (odd, two pairs)", []byte{0x1, 0x2, 0x3}, [33]byte{0x12, 0x30, 32: 3}},
+		{"four (even)", []byte{0xA, 0xB, 0xC, 0xD}, [33]byte{0xAB, 0xCD, 32: 4}},
+	}
+	// max 64 nibbles → fills all 32 packed bytes, count=64.
+	full := struct {
+		name       string
+		nibbles    []byte
+		wantSubKey [33]byte
+	}{name: "max (64)", nibbles: make([]byte, 64)}
+	for i := range full.nibbles {
+		full.nibbles[i] = byte(i % 16)
+	}
+	for i := 0; i < 32; i++ {
+		full.wantSubKey[i] = (full.nibbles[2*i] << 4) | full.nibbles[2*i+1]
+	}
+	full.wantSubKey[32] = 64
+	cases = append(cases, full)
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			in := StorageTrieEntry{
+				SubKey: StoredNibblesSubKey{Length: byte(len(c.nibbles))},
+				Node:   node,
+			}
+			copy(in.SubKey.Nibbles[:], c.nibbles)
+			var buf bytes.Buffer
+			n := in.EncodePackedCompact(&buf)
+			if n < 33 {
+				t.Fatalf("encoded %d bytes, want >= 33", n)
+			}
+			if !bytes.Equal(buf.Bytes()[:33], c.wantSubKey[:]) {
+				t.Errorf("packed subkey = %x\n  want         %x", buf.Bytes()[:33], c.wantSubKey[:])
+			}
+			// BNC payload: 6-byte mask header + 32-byte hash.
+			if n-33 != 6+32 {
+				t.Errorf("BNC payload = %d bytes, want %d", n-33, 6+32)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Migrates state-actor's reth client to reth's v2 storage layout (closes #79 and #80). Net effect on the bloatnet bench: ~78.5 GiB saved per run (188 GiB → ~109 GiB observed in the 100 GB target spec). State-actor now produces a datadir reth's v2 reader walks directly through `HashedAccounts`/`HashedStorages` instead of the `PlainAccountState`/`PlainStorageState` mirror tables it ignores.
