### PR TITLE
fix(nethermind): chainspec emits stateRoot + stateUnavailable=true

### DIFF
--- a/client/nethermind/chainspec.go
+++ b/client/nethermind/chainspec.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/nerolation/state-actor/genesis"
@@ -48,13 +49,18 @@ var osakaParamKeys = []string{
 // rejects the DB at boot with "Supplied genesis block does not match chain
 // data stored".
 //
+// stateRoot is the writer-computed state root; it is stamped into the
+// emitted "genesis" block alongside stateUnavailable: true so Nethermind's
+// GenesisBuilder.Build() does NOT recompute the root from chainspec.accounts
+// (which is {}) and overwrite the on-disk header with the empty-trie hash.
+//
 // Engine is Ethash + terminalTotalDifficulty=0 — the Kiln/Kintsugi merge-
 // from-genesis recipe. MergePlugin wraps EthashPlugin and routes every
 // block through the engine API; EthashPlugin's PoW path never runs because
 // TTD=0 means post-merge from block 0. MergePlugin's SealEngineType
 // allowlist is {BeaconChain, Clique, Ethash}, which is why we don't use
 // NethDev here.
-func writeChainSpec(dbPath string, g *genesis.Genesis) (string, error) {
+func writeChainSpec(dbPath string, g *genesis.Genesis, stateRoot common.Hash) (string, error) {
 	if g == nil {
 		return "", fmt.Errorf("nethermind writeChainSpec: nil genesis")
 	}
@@ -84,7 +90,7 @@ func writeChainSpec(dbPath string, g *genesis.Genesis) (string, error) {
 		}
 	}
 
-	spec["genesis"] = genesisBlockFromG(g)
+	spec["genesis"] = genesisBlockFromG(g, stateRoot)
 
 	out, err := json.MarshalIndent(spec, "", "  ")
 	if err != nil {
@@ -103,7 +109,11 @@ func writeChainSpec(dbPath string, g *genesis.Genesis) (string, error) {
 // nonce width. Every value is sourced from g so the chainspec and the
 // on-disk header (built by internal/genesisheader.Build from the same g)
 // cannot diverge.
-func genesisBlockFromG(g *genesis.Genesis) map[string]any {
+//
+// stateRoot + stateUnavailable=true are emitted so Nethermind's
+// GenesisBuilder.Build() treats the writer's root as authoritative instead
+// of recomputing from chainspec.accounts (= {}) and overwriting the header.
+func genesisBlockFromG(g *genesis.Genesis, stateRoot common.Hash) map[string]any {
 	difficulty := big.NewInt(0)
 	if g.Difficulty != nil {
 		difficulty = g.Difficulty.ToInt()
@@ -116,11 +126,13 @@ func genesisBlockFromG(g *genesis.Genesis) map[string]any {
 				"mixHash": g.Mixhash.Hex(),
 			},
 		},
-		"difficulty": fmt.Sprintf("0x%x", difficulty),
-		"author":     g.Coinbase.Hex(),
-		"timestamp":  fmt.Sprintf("0x%x", uint64(g.Timestamp)),
-		"parentHash": g.ParentHash.Hex(),
-		"extraData":  hexutil.Encode([]byte(g.ExtraData)),
-		"gasLimit":   fmt.Sprintf("0x%x", uint64(g.GasLimit)),
+		"difficulty":       fmt.Sprintf("0x%x", difficulty),
+		"author":           g.Coinbase.Hex(),
+		"timestamp":        fmt.Sprintf("0x%x", uint64(g.Timestamp)),
+		"parentHash":       g.ParentHash.Hex(),
+		"extraData":        hexutil.Encode([]byte(g.ExtraData)),
+		"gasLimit":         fmt.Sprintf("0x%x", uint64(g.GasLimit)),
+		"stateRoot":        stateRoot.Hex(),
+		"stateUnavailable": true,
 	}
 }

--- a/client/nethermind/chainspec_test.go
+++ b/client/nethermind/chainspec_test.go
@@ -23,7 +23,7 @@ func readWrittenSpec(t *testing.T, fork string) map[string]any {
 		t.Fatalf("BuildSynthetic(%q): %v", fork, err)
 	}
 	dir := t.TempDir()
-	outPath, err := writeChainSpec(dir, g)
+	outPath, err := writeChainSpec(dir, g, common.Hash{})
 	if err != nil {
 		t.Fatalf("writeChainSpec: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestWriteChainSpec_OverrideChainID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildSynthetic: %v", err)
 	}
-	outPath, err := writeChainSpec(t.TempDir(), g)
+	outPath, err := writeChainSpec(t.TempDir(), g, common.Hash{})
 	if err != nil {
 		t.Fatalf("writeChainSpec: %v", err)
 	}
@@ -143,7 +143,7 @@ func TestWriteChainSpec_ParityChainIDFormat(t *testing.T) {
 }
 
 func TestWriteChainSpec_NilGenesisRejected(t *testing.T) {
-	if _, err := writeChainSpec(t.TempDir(), nil); err == nil {
+	if _, err := writeChainSpec(t.TempDir(), nil, common.Hash{}); err == nil {
 		t.Error("writeChainSpec(nil) returned no error")
 	}
 }
@@ -153,7 +153,7 @@ func TestWriteChainSpec_NilGenesisRejected(t *testing.T) {
 func TestWriteChainSpec_FilePathIsConventional(t *testing.T) {
 	g, _ := genesis.BuildSynthetic("osaka", big.NewInt(1337), 30_000_000, 0, nil)
 	dir := t.TempDir()
-	out, err := writeChainSpec(dir, g)
+	out, err := writeChainSpec(dir, g, common.Hash{})
 	if err != nil {
 		t.Fatalf("writeChainSpec: %v", err)
 	}
@@ -173,7 +173,8 @@ func TestWriteChainSpec_ByteForByteDeterministic(t *testing.T) {
 		if err != nil {
 			t.Fatalf("BuildSynthetic: %v", err)
 		}
-		out, err := writeChainSpec(t.TempDir(), g)
+		// Fixed stateRoot so the byte-for-byte comparison stays deterministic.
+		out, err := writeChainSpec(t.TempDir(), g, common.HexToHash("0xabcd"))
 		if err != nil {
 			t.Fatalf("writeChainSpec: %v", err)
 		}
@@ -221,8 +222,9 @@ func TestWriteChainSpec_GenesisBlockFromG(t *testing.T) {
 	// the chainspec/header contract — POTENTIAL-divergence coverage.
 	g.Mixhash = common.HexToHash("0x1111222233334444555566667777888899990000aaaabbbbccccddddeeeeffff")
 	g.Coinbase = common.HexToAddress("0xcafe000000000000000000000000000000000000")
+	wantStateRoot := common.HexToHash("0xe86fef3b0000000000000000000000000000000000000000000000000032b900")
 
-	outPath, err := writeChainSpec(t.TempDir(), g)
+	outPath, err := writeChainSpec(t.TempDir(), g, wantStateRoot)
 	if err != nil {
 		t.Fatalf("writeChainSpec: %v", err)
 	}
@@ -272,5 +274,14 @@ func TestWriteChainSpec_GenesisBlockFromG(t *testing.T) {
 	// Nethermind's parser requires fixed 8-byte / 16-hex-char nonce width.
 	if got, _ := eth["nonce"].(string); got != "0x0000000000000000" || len(got) != 18 {
 		t.Errorf("nonce = %q; want exactly %q (18 chars / 0x + 16 hex)", got, "0x0000000000000000")
+	}
+	// stateRoot + stateUnavailable=true gate Nethermind's GenesisBuilder
+	// recompute path — without both, boot overwrites the on-disk root with
+	// the empty-trie hash (issue #81).
+	if got := gen["stateRoot"]; got != wantStateRoot.Hex() {
+		t.Errorf("stateRoot = %v; want %s", got, wantStateRoot.Hex())
+	}
+	if got := gen["stateUnavailable"]; got != true {
+		t.Errorf("stateUnavailable = %v (%T); want bool true", got, got)
 	}
 }

--- a/client/nethermind/e2e_test.go
+++ b/client/nethermind/e2e_test.go
@@ -59,8 +59,6 @@ const nethermindE2EConfigTemplate = `{
     "MemoryHint": 256000000
   },
   "Sync": {
-    "NetworkingEnabled": false,
-    "SynchronizationEnabled": false,
     "PivotNumber": 0
   },
   "TxPool": {

--- a/client/nethermind/run_cgo.go
+++ b/client/nethermind/run_cgo.go
@@ -111,7 +111,7 @@ func runImpl(ctx context.Context, cfg generator.Config, opts Options) (*generato
 	// Write Parity-style chainspec next to the DB so --chain-id is honoured
 	// at boot (closes the B7 loop). Smoke scripts point Nethermind at this
 	// via the Init config's ChainSpecPath.
-	if _, err := writeChainSpec(cfg.DBPath, g); err != nil {
+	if _, err := writeChainSpec(cfg.DBPath, g, header.Root); err != nil {
 		return nil, fmt.Errorf("nethermind: %w", err)
 	}
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -237,8 +237,6 @@ docker run --rm \
     "MemoryHint": 256000000
   },
   "Sync": {
-    "NetworkingEnabled": false,
-    "SynchronizationEnabled": false,
     "PivotNumber": 0
   },
   "TxPool": { "Size": 128, "BlobsSupport": "Disabled" },

--- a/scripts/run-bloatnet.sh
+++ b/scripts/run-bloatnet.sh
@@ -159,8 +159,6 @@ boot_client() {
     "MemoryHint": 256000000
   },
   "Sync": {
-    "NetworkingEnabled": false,
-    "SynchronizationEnabled": false,
     "PivotNumber": 0
   },
   "TxPool": { "Size": 128, "BlobsSupport": "Disabled" },


### PR DESCRIPTION
## Summary
Closes #81.

`client/nethermind/chainspec.go`'s `genesisBlockFromG` emits a Parity-style genesis JSON without `stateRoot` or `stateUnavailable: true`. On boot, Nethermind's `GenesisBuilder.Build()` sees `GenesisStateUnavailable == false`, recomputes state-root from the chainspec's `accounts: {}` block (= empty-trie hash `0x56e81f17…`), and overwrites the on-disk header. The bug was masked only by `Sync.NetworkingEnabled=false` + `Sync.SynchronizationEnabled=false` in the bench/CI boot configs.

This PR fixes it at the writer:

- `writeChainSpec` + `genesisBlockFromG` now take `stateRoot common.Hash` and emit `stateRoot` + `stateUnavailable: true` in the genesis JSON.
- `run_cgo.go` threads `header.Root` through.
- `chainspec_test.go` updates 6 call sites and asserts on the new fields.
- `e2e_test.go`, `scripts/run-bloatnet.sh`, and `docs/RUNBOOK.md` drop `Sync.NetworkingEnabled=false` and `SynchronizationEnabled=false` — the workarounds the bug forced. `PivotNumber: 0` stays (snap-sync defense, independent of this bug); `Init.{DiscoveryEnabled,PeerManagerEnabled}=false` stay (P2P hygiene).
