### PR TITLE
fix(templates): erc20 honors approximate_size_bytes as fallback sizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+### Fixed
+- **`erc20` template now honors `approximate_size_bytes`.** Previously
+  the universal entity-level sizing knob was silently ignored on the
+  `erc20` template (only `raw` and `eoa` consumed it), even though
+  [`docs/SPEC.md`](docs/SPEC.md) described it as the cross-template
+  storage-budget control. Now the slot budget falls back to deriving
+  `total_owners` (one slot per random holder, minus the three fixed
+  metadata slots: `_name`, `_symbol`, `_totalSupply`). Explicit
+  `total_owners` / `total_allowances` continue to win — precedence is
+  "explicit > implicit", matching the existing `owners` + `total_owners`
+  composition pattern. Adds four regression tests in
+  `internal/templates/erc20_test.go` pinning the new derivation,
+  equivalence with explicit `total_owners`, explicit-precedence, and
+  the floor against shrinking explicit owners.
+
 ### Breaking
 - **Removed `--accounts`, `--contracts`, `--max-slots`, `--min-slots`,
   `--distribution`, `--code-size` flags.** Synthetic state generation is

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -95,6 +95,21 @@ genesis-root invariance gate). Slots are populated with deterministic
 - **Accuracy**: ±25% versus the realised on-disk size, set by the
   global `bytesPerSlot` constant.
 
+### Per-template precedence
+
+When a template defines its own sizing parameter (e.g. `erc20`'s
+`total_owners`, `storage_pattern`'s `final`, `create_preimage_deploys`'s
+`count`), the **explicit template parameter always wins** over
+`approximate_size_bytes`. `approximate_size_bytes` is a fallback that
+applies only when none of the template-specific sizing parameters are
+set. This matches the principle that explicit user input always takes
+precedence over implicit byte budgets.
+
+For `erc20` specifically: if neither `total_owners` nor
+`total_allowances` is set, `approximate_size_bytes` derives the random
+owner count (one slot per holder, minus the three fixed metadata slots:
+name, symbol, totalSupply).
+
 ## Templates
 
 | Template | Required parameters | Optional | Notes |
@@ -133,6 +148,26 @@ genesis-root invariance gate). Slots are populated with deterministic
     # as total_owners.
     total_allowances: 5000000
 ```
+
+`approximate_size_bytes` (set at the entity level, not inside
+`parameters:`) works as a fallback: when neither `total_owners` nor
+`total_allowances` is set, the slot budget is converted to a random
+holder count (one slot per holder, minus three fixed metadata slots).
+The example below produces ~71.4M random `_balances` entries at the
+calibrated 140 B/slot trie cost:
+
+```yaml
+- kind: contract
+  template: erc20
+  approximate_size_bytes: 10_000_000_000      # ~10 GB trie → ~71.4M slots
+  parameters:
+    symbol: BIG
+    name: BigToken
+    decimals: 18
+```
+
+If `total_owners` (or `total_allowances`) is also set, the explicit
+value wins and `approximate_size_bytes` is ignored.
 
 `_totalSupply` is auto-summed from every planted balance (explicit +
 random). Users cannot override it — the ERC-20 conservation invariant

--- a/internal/templates/erc20.go
+++ b/internal/templates/erc20.go
@@ -163,6 +163,27 @@ func (erc20Template) Expand(ctx Context, e spec.Entity) ([]PreAllocEntity, error
 		}
 		totalAllowances = n
 	}
+
+	// Fallback sizing via approximate_size_bytes. Honors the universal
+	// storage-sizing knob (docs/SPEC.md) only when neither total_owners
+	// nor total_allowances is set; explicit sizing always wins. Slot
+	// budget translates to additional random owners (one slot per
+	// holder); the metadata cost (name + symbol + totalSupply) is
+	// subtracted so the resulting on-disk footprint stays within the
+	// requested budget.
+	if e.ApproximateSizeBytes > 0 {
+		_, hasTotalOwners := e.Parameters["total_owners"]
+		_, hasTotalAllowances := e.Parameters["total_allowances"]
+		if !hasTotalOwners && !hasTotalAllowances {
+			slotsBudget := ctx.Sizer.SlotsForBytes(ctx.ClientName, e.ApproximateSizeBytes)
+			const fixedSlotsOverhead = 3 // name, symbol, totalSupply
+			derived := slotsBudget - fixedSlotsOverhead
+			if derived > totalOwners {
+				totalOwners = derived
+			}
+		}
+	}
+
 	randomOwnerCount := totalOwners - len(owners)
 	randomAllowanceCount := totalAllowances - len(allowances)
 

--- a/internal/templates/erc20_test.go
+++ b/internal/templates/erc20_test.go
@@ -526,6 +526,149 @@ func TestERC20SynthesizedAllowanceDeterminism(t *testing.T) {
 	}
 }
 
+// TestERC20ApproximateSizeBytesDrivesTotalOwners pins the fallback-sizing
+// behavior: when neither total_owners nor total_allowances is set,
+// approximate_size_bytes derives totalOwners via the Sizer, matching the
+// universal sizing semantics raw/eoa already implement.
+func TestERC20ApproximateSizeBytesDrivesTotalOwners(t *testing.T) {
+	tokenAddr := common.HexToAddress("0x0000000000000000000000000000000000000ab1")
+	// With Sizer.bytesPerSlot=64: 6400 bytes → 100 slots → 100-3 fixed
+	// = 97 random owners + 3 fixed metadata slots = 100 entries total.
+	ent := spec.Entity{
+		Kind:                 spec.KindContract,
+		Template:             "erc20",
+		ApproximateSizeBytes: 6400,
+		Parameters: map[string]any{
+			"symbol": "BIG", "name": "BigToken", "decimals": 18,
+		},
+	}
+	ctx := Context{Seed: 1, Sizer: fixedSizer{bytesPerSlot: 64}, ResolvedAddress: tokenAddr}
+	out, err := erc20Template{}.Expand(ctx, ent)
+	if err != nil {
+		t.Fatalf("Expand: %v", err)
+	}
+	storage := collectMap(out[0].Storage)
+	if len(storage) != 100 {
+		t.Errorf("storage count: got %d, want 100", len(storage))
+	}
+}
+
+// TestERC20ApproximateSizeBytesEquivalentToTotalOwners pins the
+// equivalence: setting only approximate_size_bytes must produce the same
+// storage stream as setting an explicit total_owners equal to the
+// derived value. This is the cross-template invariance gate
+// (truncateForTargetSize's projection math already assumed this).
+func TestERC20ApproximateSizeBytesEquivalentToTotalOwners(t *testing.T) {
+	tokenAddr := common.HexToAddress("0x0000000000000000000000000000000000000ab2")
+	const bytesPerSlot uint64 = 64
+	const targetBytes uint64 = 6400
+	// Derived count: (6400 / 64) - 3 fixed = 100 - 3 = 97.
+	const expectedTotalOwners = 97
+
+	ctx := Context{Seed: 7, Sizer: fixedSizer{bytesPerSlot: bytesPerSlot}, ResolvedAddress: tokenAddr}
+
+	approxEnt := spec.Entity{
+		Kind: spec.KindContract, Template: "erc20",
+		ApproximateSizeBytes: targetBytes,
+		Parameters: map[string]any{
+			"symbol": "X", "name": "X", "decimals": 18,
+		},
+	}
+	explicitEnt := spec.Entity{
+		Kind: spec.KindContract, Template: "erc20",
+		Parameters: map[string]any{
+			"symbol": "X", "name": "X", "decimals": 18,
+			"total_owners": expectedTotalOwners,
+		},
+	}
+
+	approxOut, err := erc20Template{}.Expand(ctx, approxEnt)
+	if err != nil {
+		t.Fatalf("approx Expand: %v", err)
+	}
+	explicitOut, err := erc20Template{}.Expand(ctx, explicitEnt)
+	if err != nil {
+		t.Fatalf("explicit Expand: %v", err)
+	}
+
+	approxStorage := collectMap(approxOut[0].Storage)
+	explicitStorage := collectMap(explicitOut[0].Storage)
+
+	if len(approxStorage) != len(explicitStorage) {
+		t.Fatalf("storage count diverged: approx=%d explicit=%d",
+			len(approxStorage), len(explicitStorage))
+	}
+	for k, v := range approxStorage {
+		if got, ok := explicitStorage[k]; !ok || got != v {
+			t.Errorf("slot %s diverged: approx=%x explicit=%x (present=%v)",
+				k.Hex(), v, got, ok)
+		}
+	}
+}
+
+// TestERC20ApproximateSizeBytesExplicitWins verifies precedence:
+// total_owners (or total_allowances) explicitly set always wins over
+// approximate_size_bytes — matching the documented "explicit > implicit"
+// rule.
+func TestERC20ApproximateSizeBytesExplicitWins(t *testing.T) {
+	tokenAddr := common.HexToAddress("0x0000000000000000000000000000000000000ab3")
+	ent := spec.Entity{
+		Kind: spec.KindContract, Template: "erc20",
+		ApproximateSizeBytes: 1_000_000, // ~15,625 slots at 64 B/slot
+		Parameters: map[string]any{
+			"symbol": "X", "name": "X", "decimals": 18,
+			"total_owners": 5, // explicit — wins
+		},
+	}
+	ctx := Context{Seed: 1, Sizer: fixedSizer{bytesPerSlot: 64}, ResolvedAddress: tokenAddr}
+	out, err := erc20Template{}.Expand(ctx, ent)
+	if err != nil {
+		t.Fatalf("Expand: %v", err)
+	}
+	storage := collectMap(out[0].Storage)
+	// 5 explicit-driven random owners + 3 fixed (name, symbol, totalSupply).
+	if len(storage) != 8 {
+		t.Errorf("storage count: got %d, want 8 (5 random + 3 fixed)", len(storage))
+	}
+}
+
+// TestERC20ApproximateSizeBytesNeverShrinksExplicitOwners verifies the
+// floor: explicit owners always land, even when the derived totalOwners
+// from approximate_size_bytes is smaller than len(owners).
+func TestERC20ApproximateSizeBytesNeverShrinksExplicitOwners(t *testing.T) {
+	tokenAddr := common.HexToAddress("0x0000000000000000000000000000000000000ab4")
+	a := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	b := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	c := common.HexToAddress("0x3333333333333333333333333333333333333333")
+	d := common.HexToAddress("0x4444444444444444444444444444444444444444")
+	// approximate_size_bytes = 256 B → 4 slots → 4-3 fixed = 1 derived owner.
+	// But 4 explicit owners are set; the floor must keep all 4.
+	ent := spec.Entity{
+		Kind: spec.KindContract, Template: "erc20",
+		ApproximateSizeBytes: 256,
+		Parameters: map[string]any{
+			"symbol": "X", "name": "X", "decimals": 18,
+			"owners": []any{
+				map[string]any{"address": a.Hex(), "balance": "100"},
+				map[string]any{"address": b.Hex(), "balance": "200"},
+				map[string]any{"address": c.Hex(), "balance": "300"},
+				map[string]any{"address": d.Hex(), "balance": "400"},
+			},
+		},
+	}
+	ctx := Context{Seed: 1, Sizer: fixedSizer{bytesPerSlot: 64}, ResolvedAddress: tokenAddr}
+	out, err := erc20Template{}.Expand(ctx, ent)
+	if err != nil {
+		t.Fatalf("Expand: %v", err)
+	}
+	storage := collectMap(out[0].Storage)
+	for _, addr := range []common.Address{a, b, c, d} {
+		if _, ok := storage[balanceSlotKey(addr)]; !ok {
+			t.Errorf("explicit owner %s dropped", addr.Hex())
+		}
+	}
+}
+
 func TestERC20RuntimeBytecodePinned(t *testing.T) {
 	// Guards against unintentional changes to the vendored OZ v5.6.1
 	// ERC20 deployed runtime bytecode (internal/templates/erc20_oz_v5.hex).


### PR DESCRIPTION
The universal entity-level approximate_size_bytes knob was silently ignored on the erc20 template (only raw and eoa consumed it) even though docs/SPEC.md described it as the cross-template storage-budget control. Setting `template: erc20` with `approximate_size_bytes: 10GB` produced two metadata slots instead of the requested ~71M holders, because erc20.Expand() never consulted e.ApproximateSizeBytes.

Wire it as a fallback: when neither total_owners nor total_allowances is set, derive totalOwners from the Sizer's slot count (minus three fixed metadata slots: name, symbol, totalSupply). Explicit total_owners / total_allowances continue to win — precedence is "explicit > implicit", matching the existing owners + total_owners composition pattern.

Adds four regression tests:
  * TestERC20ApproximateSizeBytesDrivesTotalOwners — pins the derivation from the slot budget.
  * TestERC20ApproximateSizeBytesEquivalentToTotalOwners — pins that approximate_size_bytes and an equivalently-sized explicit total_owners produce byte-identical storage streams.
  * TestERC20ApproximateSizeBytesExplicitWins — pins precedence.
  * TestERC20ApproximateSizeBytesNeverShrinksExplicitOwners — pins the len(owners) floor so explicit owners can't be silently dropped when the slot budget underflows.

Updates docs/SPEC.md with the per-template precedence rule + an erc20-specific example, and adds a CHANGELOG entry.