### PR TITLE
fix(templates): clarify erc20 metadata-slot accounting + harden fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
   `erc20` template (only `raw` and `eoa` consumed it), even though
   [`docs/SPEC.md`](docs/SPEC.md) described it as the cross-template
   storage-budget control. Now the slot budget falls back to deriving
-  `total_owners` (one slot per random holder, minus the three fixed
-  metadata slots: `_name`, `_symbol`, `_totalSupply`). Explicit
+  `total_owners` (one slot per random holder, minus up to three metadata
+  slots — `_name`/`_symbol` always, `_totalSupply` only when supply > 0).
+  Explicit
   `total_owners` / `total_allowances` continue to win — precedence is
   "explicit > implicit", matching the existing `owners` + `total_owners`
   composition pattern. Adds four regression tests in

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -107,8 +107,9 @@ precedence over implicit byte budgets.
 
 For `erc20` specifically: if neither `total_owners` nor
 `total_allowances` is set, `approximate_size_bytes` derives the random
-owner count (one slot per holder, minus the three fixed metadata slots:
-name, symbol, totalSupply).
+owner count (one slot per holder, minus up to three metadata slots:
+`_name` and `_symbol` are always written; `_totalSupply` only when at
+least one holder has a non-zero balance).
 
 ## Templates
 
@@ -152,9 +153,10 @@ name, symbol, totalSupply).
 `approximate_size_bytes` (set at the entity level, not inside
 `parameters:`) works as a fallback: when neither `total_owners` nor
 `total_allowances` is set, the slot budget is converted to a random
-holder count (one slot per holder, minus three fixed metadata slots).
+holder count (one slot per holder, minus up to three metadata slots —
+`_name`/`_symbol` always, `_totalSupply` when supply > 0).
 The example below produces ~71.4M random `_balances` entries at the
-calibrated 140 B/slot trie cost:
+calibrated 140 B/slot cost:
 
 ```yaml
 - kind: contract

--- a/internal/templates/erc20.go
+++ b/internal/templates/erc20.go
@@ -27,6 +27,14 @@ const (
 	erc20SlotSymbol      = 4 // string (short-string layout when ≤31 bytes)
 )
 
+// erc20MetadataSlots is the maximum number of non-holder storage slots the
+// template writes: _totalSupply (slot 2), _name (slot 3), _symbol (slot 4).
+// _name and _symbol are always written; _totalSupply only when supply > 0 (see
+// the !totalSupply.IsZero() guard in Expand). The approximate_size_bytes
+// fallback reserves this many slots from the budget. Keep in sync with the
+// metadata writes in Expand.
+const erc20MetadataSlots = 3
+
 // erc20FixedDecimals is the only accepted value for the `decimals`
 // parameter. OZ v5's `decimals()` is a pure function returning 18;
 // planting a different value in storage has no effect at the RPC. Users
@@ -166,18 +174,22 @@ func (erc20Template) Expand(ctx Context, e spec.Entity) ([]PreAllocEntity, error
 
 	// Fallback sizing via approximate_size_bytes. Honors the universal
 	// storage-sizing knob (docs/SPEC.md) only when neither total_owners
-	// nor total_allowances is set; explicit sizing always wins. Slot
-	// budget translates to additional random owners (one slot per
-	// holder); the metadata cost (name + symbol + totalSupply) is
-	// subtracted so the resulting on-disk footprint stays within the
-	// requested budget.
+	// nor total_allowances is set; explicit sizing always wins. The slot
+	// budget translates to additional random owners (one slot per holder),
+	// minus the metadata slots the contract also occupies (up to
+	// erc20MetadataSlots — _name/_symbol always, _totalSupply when supply > 0)
+	// so the resulting on-disk footprint stays within the requested budget.
 	if e.ApproximateSizeBytes > 0 {
 		_, hasTotalOwners := e.Parameters["total_owners"]
 		_, hasTotalAllowances := e.Parameters["total_allowances"]
 		if !hasTotalOwners && !hasTotalAllowances {
 			slotsBudget := ctx.Sizer.SlotsForBytes(ctx.ClientName, e.ApproximateSizeBytes)
-			const fixedSlotsOverhead = 3 // name, symbol, totalSupply
-			derived := slotsBudget - fixedSlotsOverhead
+			derived := slotsBudget - erc20MetadataSlots
+			// max(), not assignment: a budget-derived count must never shrink
+			// an explicit owners floor (totalOwners starts at len(owners)). A
+			// sub-metadata budget makes derived <= 0, which this guard
+			// harmlessly ignores (SlotsForBytes returns a signed int, so no
+			// unsigned underflow).
 			if derived > totalOwners {
 				totalOwners = derived
 			}

--- a/internal/templates/erc20_test.go
+++ b/internal/templates/erc20_test.go
@@ -669,6 +669,64 @@ func TestERC20ApproximateSizeBytesNeverShrinksExplicitOwners(t *testing.T) {
 	}
 }
 
+// TestERC20ApproximateSizeBytesBelowMetadataFloor pins the boundary: when the
+// slot budget is <= the metadata reservation (erc20MetadataSlots), the fallback
+// derives <= 0 random owners and leaves the contract at its metadata floor.
+// With zero holders _totalSupply is suppressed, so only _name + _symbol land —
+// two entries, not three. (Documents the off-by-one the build.go projection
+// tolerates around 3 slots; immaterial at GB scale.)
+func TestERC20ApproximateSizeBytesBelowMetadataFloor(t *testing.T) {
+	tokenAddr := common.HexToAddress("0x0000000000000000000000000000000000000ab5")
+	// bytesPerSlot=64: 128 B -> 2 slots (< floor), 192 B -> 3 slots (== floor).
+	// Both yield 0 random owners -> 0 supply -> _totalSupply unwritten.
+	for _, budget := range []uint64{128, 192} {
+		ent := spec.Entity{
+			Kind: spec.KindContract, Template: "erc20",
+			ApproximateSizeBytes: budget,
+			Parameters: map[string]any{
+				"symbol": "X", "name": "X", "decimals": 18,
+			},
+		}
+		ctx := Context{Seed: 1, Sizer: fixedSizer{bytesPerSlot: 64}, ResolvedAddress: tokenAddr}
+		out, err := erc20Template{}.Expand(ctx, ent)
+		if err != nil {
+			t.Fatalf("Expand(%d): %v", budget, err)
+		}
+		storage := collectMap(out[0].Storage)
+		if len(storage) != 2 {
+			t.Errorf("approximate_size_bytes=%d: storage count got %d, want 2 (_name + _symbol only)", budget, len(storage))
+		}
+	}
+}
+
+// TestERC20ApproximateSizeBytesSuppressedByTotalAllowances pins the precedence
+// guard's cross-dimension behaviour: setting total_allowances (which sizes a
+// different mapping) suppresses the approximate_size_bytes owner fallback
+// entirely, because the guard requires BOTH total_owners and total_allowances
+// to be unset. The large byte budget must be ignored.
+func TestERC20ApproximateSizeBytesSuppressedByTotalAllowances(t *testing.T) {
+	tokenAddr := common.HexToAddress("0x0000000000000000000000000000000000000ab6")
+	ent := spec.Entity{
+		Kind: spec.KindContract, Template: "erc20",
+		ApproximateSizeBytes: 1_000_000, // ~15,625 slots at 64 B/slot — must be ignored
+		Parameters: map[string]any{
+			"symbol": "X", "name": "X", "decimals": 18,
+			"total_allowances": 5, // suppresses the owner fallback
+		},
+	}
+	ctx := Context{Seed: 1, Sizer: fixedSizer{bytesPerSlot: 64}, ResolvedAddress: tokenAddr}
+	out, err := erc20Template{}.Expand(ctx, ent)
+	if err != nil {
+		t.Fatalf("Expand: %v", err)
+	}
+	storage := collectMap(out[0].Storage)
+	// _name + _symbol (no random owners -> _totalSupply suppressed) + 5 random
+	// allowances = 7. NOT the ~15,625 the byte budget would imply.
+	if len(storage) != 7 {
+		t.Errorf("storage count got %d, want 7 (2 metadata + 5 random allowances; owner fallback suppressed)", len(storage))
+	}
+}
+
 func TestERC20RuntimeBytecodePinned(t *testing.T) {
 	// Guards against unintentional changes to the vendored OZ v5.6.1
 	// ERC20 deployed runtime bytecode (internal/templates/erc20_oz_v5.hex).


### PR DESCRIPTION
Follow-up to #88, addressing review feedback on the `approximate_size_bytes` fallback in the `erc20` template.

- **`docs/SPEC.md` (×2), `CHANGELOG.md`, code comment** — "three fixed metadata slots" → "up to three" (`_name`/`_symbol` are always written; `_totalSupply` only when supply > 0).
- **`internal/templates/erc20.go`** — replace the inline magic `3` with a named `erc20MetadataSlots` const placed beside the storage-layout constants, documenting the `_totalSupply` conditionality so an OZ layout change can't silently staleify it.
- **`internal/templates/erc20.go`** — document the fallback guard's floor semantics: it is `>` (a max, not an assignment), and `SlotsForBytes` returns a signed `int`, so a sub-metadata budget yields a negative `derived` that's harmlessly ignored rather than underflowing.
- **`internal/templates/erc20_test.go`** — add two regression tests: a sub-metadata-floor boundary (budget ≤ 3 slots → 2 entries, not 3) and `total_allowances`-only suppression of the owner fallback.

No behavior change to the sizing math; this is documentation accuracy, a maintainability rename, and added edge-case test coverage.
