### PR TITLE
feat(geth): write informational geth-genesis.json 

### DIFF
--- a/client/geth/genesis_json.go
+++ b/client/geth/genesis_json.go
@@ -1,0 +1,72 @@
+package geth
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/nerolation/state-actor/genesis"
+)
+
+// GenesisJSONFileName is the informational geth-format genesis dropped at the
+// datadir root next to the populated DB.
+//
+// It is NOT load-bearing. geth boots from the chain config persisted inside
+// the Pebble DB (rawdb.WriteChainConfig in WriteGenesisBlock), not from this
+// file — that is the asymmetry vs besu/nethermind/reth, which each require an
+// external chainspec at boot and consume theirs directly. This sidecar exists
+// purely for parity/inspection: reading the chain config + genesis params, or
+// `geth init`-ing a separate node with the same chain parameters.
+const GenesisJSONFileName = "geth-genesis.json"
+
+// writeGenesisJSON renders an informational geth-format genesis.json to the
+// datadir root derived from dbPath (<datadir>/geth/chaindata → <datadir>) and
+// returns the path written.
+//
+// IMPORTANT: alloc is emitted empty ({}). state-actor direct-writes the
+// synthetic state into the trie rather than deriving it from alloc, so
+// `geth init` against this file produces a chain with the right config but an
+// EMPTY state — a different state root than the populated DB. The file
+// captures chain config + genesis block params (chainId, fork schedule,
+// gasLimit, timestamp, baseFee, …), never the generated state.
+func writeGenesisJSON(dbPath string, g *genesis.Genesis) (string, error) {
+	if g == nil {
+		return "", fmt.Errorf("geth writeGenesisJSON: nil genesis")
+	}
+
+	// Round-trip through a map so the caller's *Genesis is never mutated and
+	// alloc can be forced to an empty object rather than null. Mirrors
+	// client/reth.writeChainSpec's approach.
+	raw, err := json.Marshal(g)
+	if err != nil {
+		return "", fmt.Errorf("geth writeGenesisJSON marshal: %w", err)
+	}
+	var spec map[string]any
+	if err := json.Unmarshal(raw, &spec); err != nil {
+		return "", fmt.Errorf("geth writeGenesisJSON unmarshal: %w", err)
+	}
+	spec["alloc"] = map[string]any{}
+
+	out, err := json.MarshalIndent(spec, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("geth writeGenesisJSON marshal indent: %w", err)
+	}
+
+	outPath := filepath.Join(gethDatadir(dbPath), GenesisJSONFileName)
+	if err := os.WriteFile(outPath, append(out, '\n'), 0o644); err != nil {
+		return "", fmt.Errorf("geth writeGenesisJSON write: %w", err)
+	}
+	return outPath, nil
+}
+
+// gethDatadir derives the geth datadir root from the chaindata path. By
+// convention state-actor's --db ends in <datadir>/geth/chaindata, so the
+// datadir is two levels up. If dbPath does not follow that layout, the sidecar
+// lands next to dbPath instead — still discoverable, never an error.
+func gethDatadir(dbPath string) string {
+	if filepath.Base(filepath.Dir(dbPath)) == "geth" {
+		return filepath.Dir(filepath.Dir(dbPath))
+	}
+	return dbPath
+}

--- a/client/geth/genesis_json_test.go
+++ b/client/geth/genesis_json_test.go
@@ -1,0 +1,103 @@
+package geth
+
+import (
+	"encoding/json"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nerolation/state-actor/genesis"
+)
+
+// TestWriteGenesisJSON verifies the informational geth-genesis.json lands at
+// the datadir root, carries an empty alloc, round-trips as a valid geth
+// genesis, and does not mutate the caller's *Genesis.
+func TestWriteGenesisJSON(t *testing.T) {
+	g, err := genesis.BuildSynthetic("osaka", big.NewInt(1337), 60_000_000, 0, nil)
+	if err != nil {
+		t.Fatalf("BuildSynthetic(osaka): %v", err)
+	}
+
+	datadir := t.TempDir()
+	dbPath := filepath.Join(datadir, "geth", "chaindata")
+	if err := os.MkdirAll(dbPath, 0o755); err != nil {
+		t.Fatalf("mkdir chaindata: %v", err)
+	}
+
+	outPath, err := writeGenesisJSON(dbPath, g)
+	if err != nil {
+		t.Fatalf("writeGenesisJSON: %v", err)
+	}
+
+	// Sidecar belongs at the datadir root (two levels up from chaindata),
+	// not buried inside the chaindata dir.
+	wantPath := filepath.Join(datadir, GenesisJSONFileName)
+	if outPath != wantPath {
+		t.Errorf("outPath: got %q, want %q", outPath, wantPath)
+	}
+	if _, err := os.Stat(wantPath); err != nil {
+		t.Fatalf("expected genesis file at %q: %v", wantPath, err)
+	}
+
+	data, err := os.ReadFile(wantPath)
+	if err != nil {
+		t.Fatalf("read genesis file: %v", err)
+	}
+	var spec map[string]any
+	if err := json.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("unmarshal genesis file: %v", err)
+	}
+
+	// alloc must be an empty object — state is direct-written, not derived
+	// from alloc; a non-empty alloc here would misrepresent the DB.
+	alloc, ok := spec["alloc"].(map[string]any)
+	if !ok {
+		t.Fatalf("alloc: got %T, want object", spec["alloc"])
+	}
+	if len(alloc) != 0 {
+		t.Errorf("alloc: got %d entries, want 0 (empty)", len(alloc))
+	}
+
+	// config block present with the chain ID we built with.
+	cfg, ok := spec["config"].(map[string]any)
+	if !ok {
+		t.Fatalf("config: got %T, want object", spec["config"])
+	}
+	if cid, _ := cfg["chainId"].(float64); int64(cid) != 1337 {
+		t.Errorf("config.chainId: got %v, want 1337", cfg["chainId"])
+	}
+
+	// Round-trips back through the loader as a valid geth genesis.
+	if _, err := genesis.LoadGenesis(wantPath); err != nil {
+		t.Errorf("LoadGenesis(written file): %v", err)
+	}
+}
+
+// TestGethDatadir covers the chaindata→datadir derivation, including the
+// non-conventional fallback.
+func TestGethDatadir(t *testing.T) {
+	tests := []struct {
+		name   string
+		dbPath string
+		want   string
+	}{
+		{
+			name:   "conventional geth/chaindata layout",
+			dbPath: filepath.Join("/tmp", "sa-geth", "geth", "chaindata"),
+			want:   filepath.Join("/tmp", "sa-geth"),
+		},
+		{
+			name:   "non-conventional path falls back to dbPath",
+			dbPath: filepath.Join("/tmp", "sa-geth", "weird"),
+			want:   filepath.Join("/tmp", "sa-geth", "weird"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := gethDatadir(tt.dbPath); got != tt.want {
+				t.Errorf("gethDatadir(%q): got %q, want %q", tt.dbPath, got, tt.want)
+			}
+		})
+	}
+}

--- a/client/geth/run.go
+++ b/client/geth/run.go
@@ -75,5 +75,13 @@ func Populate(ctx context.Context, cfg generator.Config, opts Options) (*generat
 		return nil, fmt.Errorf("client/geth.Populate: write genesis block: %w", err)
 	}
 
+	// Informational geth-format genesis at the datadir root. Not used at
+	// boot (geth reads its config from the rawdb-persisted ChainConfig
+	// above) — written for parity with the other clients' chainspec
+	// sidecars and for inspection / `geth init` of a same-params node.
+	if _, err := writeGenesisJSON(cfg.DBPath, g); err != nil {
+		return nil, fmt.Errorf("client/geth.Populate: write genesis json: %w", err)
+	}
+
 	return stats, nil
 }

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -34,6 +34,8 @@ go run . \
 
 Note the `/geth/chaindata` suffix on `--db`: geth itself appends that path to its `--datadir`, so state-actor must write at exactly that location.
 
+Unlike the other clients, geth does not need an external genesis file at boot — its chain config is persisted inside the Pebble DB (`rawdb.WriteChainConfig`), so the geth boot command below carries no `--genesis`/`--chain` flag. For parity/inspection, state-actor still drops an informational `geth-genesis.json` at the datadir root (e.g. `/tmp/sa-geth/geth-genesis.json`). It is **not** read at boot. Its `alloc` is empty — state is direct-written into the trie, not derived from `alloc` — so `geth init`-ing from it yields the same chain *config* but an empty state, not a copy of the generated DB.
+
 **Boot.** Docker is one option; native geth works equally.
 
 ```bash


### PR DESCRIPTION
## What

geth's writer now drops an informational `geth-genesis.json` at the datadir root, alongside the populated DB.

## Why

besu / nethermind / reth each require an external chainspec as a **boot input**, so state-actor already writes one per client (`besu-chainspec.json`, `parity-chainspec.json`, `chainspec.json`). geth is the odd one out: it persists its chain config **inside** the Pebble DB via `rawdb.WriteChainConfig` and boots from `--datadir` with no `--genesis`/`--chain` flag. So there was no human-readable genesis artifact for geth.

This adds one for parity/inspection — without changing how geth boots. Having genesis/chainspec files for all clients can be useful for external tooling.

## Details

- Written to the **datadir root**, two levels up from `<datadir>/geth/chaindata` (e.g. `--db=/tmp/sa-spec/geth/chaindata` → `/tmp/sa-spec/geth-genesis.json`). Falls back to the `--db` dir for non-conventional paths.
- **Not load-bearing**: geth still boots from the in-DB `ChainConfig`. This file is never read at boot.
- `alloc` is emitted **empty** (`{}`): state-actor direct-writes synthetic state into the trie rather than deriving it from `alloc`. So `geth init` from this file reproduces the chain *config* (chainId, fork schedule, gasLimit, baseFee, blobSchedule, …) but **not** the generated state.
- Caller's `*genesis.Genesis` is never mutated (round-trips through a map, mirroring `client/reth.writeChainSpec`).

## Tests

- `TestWriteGenesisJSON`: file lands at the datadir root, empty alloc, correct `chainId`, re-parses via `genesis.LoadGenesis`.
- `TestGethDatadir`: conventional layout + non-conventional fallback.
- `go vet ./...` clean; full `client/geth` package passes. Verified end-to-end with a real `--client=geth` run.

Doc note added to `docs/RUNBOOK.md` (geth section).