### PR TITLE
fix(reth): write CodeHash for 7702-delegated auto-fill EOAs

### DIFF
--- a/client/reth/run_cgo.go
+++ b/client/reth/run_cgo.go
@@ -135,8 +135,31 @@ func RunCgo(ctx context.Context, cfg generator.Config, opts Options) (*generator
 			for i := 0; i < b; i++ {
 				batch[i] = plan.DrawEOA(rng)
 			}
-			if err := WriteEOAs(envs, batch, 0, cfg.Archive, stats); err != nil {
-				return nil, fmt.Errorf("RunCgo: WriteEOAs: %w", err)
+			// plan.DrawEOA can return 7702-delegating EOAs carrying a 23-byte
+			// 0xef0100<addr> code. Those must go through WriteContracts so their
+			// CodeHash lands in HashedAccounts — WriteEOAs writes BytecodeHash=nil,
+			// which would store them code-less and make reth's HashedAccounts
+			// leaves diverge from the committed state root (the streamsort uses
+			// acc.StateAccount.CodeHash, so the root would include the delegation
+			// while the leaf would not). Dispatch by shape, exactly like the alloc
+			// path above.
+			var plainEOAs, codeEOAs []*entitygen.Account
+			for _, acc := range batch {
+				if len(acc.Code) == 0 {
+					plainEOAs = append(plainEOAs, acc)
+				} else {
+					codeEOAs = append(codeEOAs, acc)
+				}
+			}
+			if len(plainEOAs) > 0 {
+				if err := WriteEOAs(envs, plainEOAs, 0, cfg.Archive, stats); err != nil {
+					return nil, fmt.Errorf("RunCgo: WriteEOAs: %w", err)
+				}
+			}
+			if len(codeEOAs) > 0 {
+				if err := WriteContracts(envs, codeEOAs, 0, cfg.Archive, stats); err != nil {
+					return nil, fmt.Errorf("RunCgo: WriteContracts(7702 EOA): %w", err)
+				}
 			}
 			for _, acc := range batch {
 				if err := putAccountRLP(acc); err != nil {
@@ -244,4 +267,3 @@ func RunCgo(ctx context.Context, cfg generator.Config, opts Options) (*generator
 	stats.TotalBytes = stats.AccountBytes + stats.StorageBytes + stats.CodeBytes
 	return stats, nil
 }
-


### PR DESCRIPTION
## Summary

The reth writer produces an **internally-inconsistent snapshot** whenever auto-fill generates an EIP-7702 delegated EOA: the genesis header commits state root `X`, but the on-disk `HashedAccounts` leaves hash to a different root `Y`. reth boots fine (it uses `--debug.skip-genesis-validation`, so it trusts the committed root and never re-derives), but the inconsistency surfaces the moment state is actually used.

## Root cause

In `RunCgo` (`client/reth/run_cgo.go`), the **explicit-alloc path dispatches accounts by shape** — code-bearing accounts go to `WriteContracts` (which writes `CodeHash`), plain EOAs go to `WriteEOAs` (which writes `BytecodeHash=nil`). The **auto-fill EOA loop did not**: it sent *every* `plan.DrawEOA` result to `WriteEOAs`.

`plan.DrawEOA` can return 7702-delegated EOAs carrying a 23-byte `0xef0100<addr>` delegation marker. Those were stored **code-less** in `HashedAccounts`, while the committed state root — computed from the streamsort of `rlp(acc.StateAccount)`, which *does* carry `CodeHash` — included the delegation. Leaves and committed root therefore disagree.

## Symptoms (how it shows up downstream)

On a 256MB osaka snapshot:
- `eth_getProof(addr, [], "0x0")` returns a **different root per account** (`keccak(proof[0])` ≠ each other and ≠ the committed root) — a consistent trie has exactly one root.
- Replaying an externally-built `engine_newPayload` (e.g. a block built by geth on the equivalent geth snapshot) fails with `mismatched block state root` on block 1, because reth executes against its real (inconsistent) leaves.

Diffing per-account state (reth vs geth) showed the mismatch is **exclusively** 7702 EOAs: geth `codeLen=23`, reth `codeLen=0`. Plain EOAs and contracts were byte-identical.

## Fix

Split the drawn EOA batch by shape and route code-bearing (7702) accounts to `WriteContracts`, exactly like the alloc path already does. One file, additive.

## Verification

- Rebuilt the snapshot with the fix: **every `eth_getProof` now hashes to the committed root** `0x120a6b…`.
- Replaying geth-built `engine_newPayload`s against reth now **passes 36/36** (was: state-root mismatch on block 1).
- Non-7702 EOAs and contracts (balance/nonce/code/storage) are unchanged.

## Follow-up (not in this PR)

A regression test that reads back `HashedAccounts`/`HashedStorages`, re-derives the MPT root, and asserts it equals the committed `header.Root` would have caught this. The existing oracle trusts reth's *reported* root (which equals the committed value under `--debug.skip-genesis-validation`), so it can't detect a leaves-vs-root inconsistency. Happy to add this in a follow-up.