### PR TITLE
docs(besu): note the p2p requirement for the Engine-API bootstrap FCU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Documentation
+- **RUNBOOK and `client/besu/doc.go` document Besu's p2p requirement for the Engine
+  API.** Besu accepts `engine_forkchoiceUpdated` on an isolated snapshot node only with
+  p2p enabled — its synchronizer must register the post-merge head as in-sync, otherwise
+  Besu answers `SYNCING`.
+
 ### Fixed
 - **`erc20` template now honors `approximate_size_bytes`.** Previously
   the universal entity-level sizing knob was silently ignored on the

--- a/client/besu/doc.go
+++ b/client/besu/doc.go
@@ -27,6 +27,11 @@
 // genesis configs. Sticking with 25.11.0 keeps single-binary block
 // production until the Engine-API path is plumbed.
 //
+// When the Engine-API path runs against a 26.x Besu, keep p2p enabled: Besu
+// accepts engine_forkchoiceUpdated on an isolated node only once its
+// synchronizer has registered the post-merge head as in-sync, which it does
+// only with p2p on — --p2p-enabled=false makes Besu answer SYNCING.
+//
 // # Build
 //
 // state-actor's Besu path is **Docker-only**. The cgo_besu build tag gates

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -181,11 +181,12 @@ docker run -d \
   --engine-jwt-disabled
 ```
 
-Three besu-specific subtleties:
+Four besu-specific subtleties:
 
 - `--genesis-state-hash-cache-enabled` tells besu to trust the stored state root rather than recompute it from `chainspec.alloc` — required, since state-actor writes synthetic state directly into RocksDB.
 - `--data-storage-format=BONSAI` matches state-actor's writer layout.
 - Besu has **no native post-Merge dev mode** (clique is broken post-Shanghai; the legacy `--miner-enabled` path was removed in 26.4.0). Block production must be driven via the Engine API by a mock consensus layer. The state-actor repo's `internal/engineapi/` package provides a Go-side driver; in CI, `internal/e2e_testing.StartEngineDriver` drives blocks via `engine_forkchoiceUpdated` / `getPayload` / `newPayload`.
+- besu accepts `engine_forkchoiceUpdated` on this isolated node only with **p2p enabled** (the default — the boot command above does not disable it). Its synchronizer must run to register the post-merge head as in-sync; with `--p2p-enabled=false` it never does, so besu answers `SYNCING` to every forkchoice update. Keep p2p on (peers stay at zero anyway).
 
 The flags above match `host-allowlist=all` (literal `all`, not `*` — `*` would glob-expand against `/opt/besu/` in the image's entrypoint).
 


### PR DESCRIPTION
## Summary

Documents a besu run-flag requirement for the Engine-API path: an isolated snapshot node accepts
`engine_forkchoiceUpdated` only with **p2p enabled**. Besu's synchronizer must run to register the
post-merge head as in-sync; with `--p2p-enabled=false` it never does, so besu answers `SYNCING` to
every forkchoice update. `--max-peers=0` / `--discovery-enabled=false` keep the node isolated with
zero real peers — the boot recipe already leaves p2p on, so this is a guardrail.

## Changes (docs only)

- `docs/RUNBOOK.md` — adds a besu subtlety covering the p2p requirement.
- `client/besu/doc.go` — notes the same for the Engine-API path.
- `CHANGELOG.md` — Unreleased entry.
