### PR TITLE
fix(docker): bump builder image to golang:1.25-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 RUN apk add --no-cache git make
 


### PR DESCRIPTION
## Problem

Building the `Dockerfile` fails:

```
go: go.mod requires go >= 1.25.7 (running go 1.24.13; GOTOOLCHAIN=local)
```

The builder stage pinned `golang:1.24-alpine`, which ships Go 1.24.13. Since `go.mod` requires `go 1.25.7` and the official Go images default to `GOTOOLCHAIN=local` (no auto-download of a newer toolchain), the build fails.

## Fix

Bump the builder base image to `golang:1.25-alpine`, which tracks the latest 1.25.x patch (≥ 1.25.7).