### PR TITLE
feat(progress): always-on heartbeat for long generation runs

### DIFF
--- a/client/besu/state_writer_cgo.go
+++ b/client/besu/state_writer_cgo.go
@@ -135,7 +135,15 @@ func writeStateAndCollectRoot(
 	}
 
 	// --- Phase 2: iterate sorted, drive Builder + flat-state writes. ---
+	// entitiesQueued is the exact count Put into the sorter above (synthetic
+	// EOAs/contracts + deduped genesis allocs) — the Phase-2 progress total.
+	var entitiesQueued int64
+	if plan != nil {
+		entitiesQueued += int64(plan.NumEOAs + plan.NumContracts)
+	}
+	entitiesQueued += int64(len(seenAlloc))
 	cfg.Progress.Stage("besu: phase 2/2 — building state trie")
+	var phase2Count int64
 	if err := sorter.Iterate(func(key, value []byte) error {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -218,6 +226,8 @@ func writeStateAndCollectRoot(
 			stats.ContractsCreated++
 		}
 		stats.AccountBytes += uint64(32 + len(accountRLP))
+		phase2Count++
+		cfg.Progress.Tick(phase2Count, entitiesQueued, "accounts")
 		return nil
 	}); err != nil {
 		return common.Hash{}, nil, nil, err
@@ -319,6 +329,13 @@ func runPhase0(ctx context.Context, cfg generator.Config, db *besuDB, stats *gen
 		return nil
 	}
 
+	// Phase 0 streams each spec entity's storage slots and is otherwise silent
+	// for hours on bloat specs. The count-only slot heartbeat funnels every
+	// worker's per-slot count through one SlotMeter; each worker holds its own
+	// SlotWorker so the hot per-slot path stays cheap (one non-atomic add + mask).
+	cfg.Progress.Stage("besu: phase 0 — spec storage")
+	slotMeter := cfg.Progress.SlotMeter()
+
 	workers := runtime.NumCPU()
 	if workers < 1 {
 		workers = 1
@@ -348,6 +365,7 @@ func runPhase0(ctx context.Context, cfg generator.Config, db *besuDB, stats *gen
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			slotW := slotMeter.Worker()
 			workerSink := newNodeSink(db)
 			defer func() {
 				// Best-effort flush at worker exit. Errors surface through
@@ -368,6 +386,7 @@ func runPhase0(ctx context.Context, cfg generator.Config, db *besuDB, stats *gen
 				sb := besutrie.NewStreamingStorageBuilder(workerSink, addrHash)
 				var entityStorageBytes uint64
 				streamSink := func(keyHash, _rawKey, value common.Hash) error {
+					slotW.Slot()
 					trimmed := besurlp.TrimStorageValue(value)
 					entityStorageBytes += uint64(len(trimmed))
 					return workerSink.PutFlatStorage(addrHash, keyHash, trimmed)

--- a/client/besu/state_writer_cgo.go
+++ b/client/besu/state_writer_cgo.go
@@ -68,6 +68,7 @@ func writeStateAndCollectRoot(
 
 	plan := cfg.AutoFill
 	if plan != nil {
+		cfg.Progress.Stage("besu: phase 1/2 — generating accounts")
 		for i := 0; i < plan.NumEOAs; i++ {
 			if err := ctx.Err(); err != nil {
 				return common.Hash{}, nil, nil, err
@@ -83,6 +84,7 @@ func writeStateAndCollectRoot(
 			if err := sorter.Put(addrHash[:], blob); err != nil {
 				return common.Hash{}, nil, nil, err
 			}
+			cfg.Progress.Tick(int64(i+1), int64(plan.NumEOAs), "EOAs")
 		}
 	}
 
@@ -113,6 +115,7 @@ func writeStateAndCollectRoot(
 	}
 
 	if plan != nil {
+		cfg.Progress.Stage("besu: phase 1/2 — generating contracts")
 		for i := 0; i < plan.NumContracts; i++ {
 			if err := ctx.Err(); err != nil {
 				return common.Hash{}, nil, nil, err
@@ -127,10 +130,12 @@ func writeStateAndCollectRoot(
 			if err := sorter.Put(addrHash[:], blob); err != nil {
 				return common.Hash{}, nil, nil, err
 			}
+			cfg.Progress.Tick(int64(i+1), int64(plan.NumContracts), "contracts")
 		}
 	}
 
 	// --- Phase 2: iterate sorted, drive Builder + flat-state writes. ---
+	cfg.Progress.Stage("besu: phase 2/2 — building state trie")
 	if err := sorter.Iterate(func(key, value []byte) error {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -286,20 +291,20 @@ func encodeEntityContract(nonce uint64, balance *uint256.Int, code []byte, slots
 // runPhase0 drives the spec-PreAlloc streaming-trie phase in parallel.
 //
 // For every entity with pe.Storage != nil, a worker:
-//   1. Owns its own *nodeSink wrapping a per-worker *grocksdb.WriteBatch.
-//      Flushes at flushThresholdBytes (64 MiB) via db.db.Write — Pebble's
-//      WAL is disabled on the bulk path, and grocksdb's Write is safe to
-//      call concurrently across workers (RocksDB serialises the commit
-//      pipeline internally).
-//   2. Constructs its own besutrie.StreamingStorageBuilder via
-//      NewStreamingStorageBuilder so trie-node writes route through the
-//      per-worker sink, not the shared outer-builder sink.
-//   3. Calls streamingtrie.StorageRoot to drain the iter into a per-call
-//      streamsort.Store (rooted under cfg.DBPath, not /tmp), walk it
-//      sorted, drive the streaming builder, and emit flat-state writes
-//      via a closure that calls workerSink.PutFlatStorage.
-//   4. Reports the computed storage root to the main goroutine via
-//      preparedCh; main assigns cfg.GenesisAccounts[addr].Root.
+//  1. Owns its own *nodeSink wrapping a per-worker *grocksdb.WriteBatch.
+//     Flushes at flushThresholdBytes (64 MiB) via db.db.Write — Pebble's
+//     WAL is disabled on the bulk path, and grocksdb's Write is safe to
+//     call concurrently across workers (RocksDB serialises the commit
+//     pipeline internally).
+//  2. Constructs its own besutrie.StreamingStorageBuilder via
+//     NewStreamingStorageBuilder so trie-node writes route through the
+//     per-worker sink, not the shared outer-builder sink.
+//  3. Calls streamingtrie.StorageRoot to drain the iter into a per-call
+//     streamsort.Store (rooted under cfg.DBPath, not /tmp), walk it
+//     sorted, drive the streaming builder, and emit flat-state writes
+//     via a closure that calls workerSink.PutFlatStorage.
+//  4. Reports the computed storage root to the main goroutine via
+//     preparedCh; main assigns cfg.GenesisAccounts[addr].Root.
 //
 // Across-entity Bonsai keyspaces are disjoint (every key prefixed by
 // addrHash for trie + flat), so parallel writes don't conflict.
@@ -444,4 +449,3 @@ func decodeEntity(blob []byte) entity {
 	}
 	return e
 }
-

--- a/client/erigon/snapshot_cgo.go
+++ b/client/erigon/snapshot_cgo.go
@@ -263,6 +263,7 @@ func writeSnapshots(
 	// contract rather than guard against it).
 	if pipelineErr == nil && cfg.AutoFill != nil {
 		rng := mrand.New(mrand.NewSource(cfg.Seed))
+		cfg.Progress.Stage("erigon: generating accounts")
 		for i := 0; i < cfg.AutoFill.NumEOAs && pipelineErr == nil; i++ {
 			acc := cfg.AutoFill.DrawEOA(rng)
 			for _, dup := genesisAddrs[acc.Address]; dup; {
@@ -291,6 +292,7 @@ func writeSnapshots(
 				break
 			}
 			stats.AccountsCreated++
+			cfg.Progress.Tick(int64(i+1), int64(cfg.AutoFill.NumEOAs), "EOAs")
 		}
 		for i := 0; i < cfg.AutoFill.NumContracts && pipelineErr == nil; i++ {
 			c := cfg.AutoFill.DrawContract(rng)
@@ -319,6 +321,7 @@ func writeSnapshots(
 			stats.StorageSlotsCreated += len(c.Storage)
 			stats.StorageBytes += uint64(len(c.Storage)) * 64
 			stats.ContractsCreated++
+			cfg.Progress.Tick(int64(i+1), int64(cfg.AutoFill.NumContracts), "contracts")
 		}
 	}
 	stats.TotalBytes = stats.StorageBytes + stats.CodeBytes
@@ -326,6 +329,8 @@ func writeSnapshots(
 	// Close entityCh → workers drain remaining items then exit.
 	close(entityCh)
 	encodeWg.Wait()
+
+	cfg.Progress.Stage("erigon: building snapshots & commitment")
 
 	// -- Step 3c: drain spec-PreAlloc Storage iters into storage +
 	// commitment-input streamsorts.

--- a/client/erigon/snapshot_cgo.go
+++ b/client/erigon/snapshot_cgo.go
@@ -352,6 +352,11 @@ func writeSnapshots(
 	// have their per-domain writer goroutines reading (they exit on
 	// close(chans.*) below).
 	if pipelineErr == nil {
+		// Count-only heartbeat for the spec-storage drain — the dominant phase
+		// on bloat specs (millions of slots), otherwise silent under the
+		// "building snapshots & commitment" banner above. Single goroutine here,
+		// so one SlotWorker; nil-safe when progress is unwired.
+		slotW := cfg.Progress.SlotMeter().Worker()
 		for i := range cfg.PreAlloc {
 			pe := &cfg.PreAlloc[i]
 			if pe.Storage == nil {
@@ -362,6 +367,7 @@ func writeSnapshots(
 					pipelineErr = err
 					return false
 				}
+				slotW.Slot()
 				// trimLeadingZeros may filter zero values; conservatively
 				// count by the unfiltered slot. Storage byte tally for
 				// stats includes raw 32-byte value capacity (matching

--- a/client/ethrex/phase0_cgo.go
+++ b/client/ethrex/phase0_cgo.go
@@ -60,6 +60,13 @@ func runPhase0Storage(
 		return nil
 	}
 
+	// Phase 0 streams each spec entity's storage slots and is otherwise silent
+	// for hours on bloat specs. The count-only slot heartbeat funnels every
+	// worker's per-slot count through one SlotMeter; each worker holds its own
+	// SlotWorker so the hot per-slot path stays cheap (one non-atomic add + mask).
+	cfg.Progress.Stage("ethrex: phase 0 — spec storage")
+	slotMeter := cfg.Progress.SlotMeter()
+
 	workers := runtime.NumCPU()
 	if workers < 1 {
 		workers = 1
@@ -86,6 +93,7 @@ func runPhase0Storage(
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			slotW := slotMeter.Worker()
 
 			// Each worker owns its own write batches targeting the two storage CFs.
 			// Per-worker batches avoid contention and keep each worker's writes
@@ -137,6 +145,7 @@ func runPhase0Storage(
 				var localSlots int
 				var localBytes uint64
 				statSink := func(_, _, value common.Hash) error {
+					slotW.Slot()
 					enc := ethrexinternal.EncodeStorageValue(new(uint256.Int).SetBytes32(value[:]))
 					localSlots++
 					localBytes += uint64(len(enc))

--- a/client/ethrex/state_writer_cgo.go
+++ b/client/ethrex/state_writer_cgo.go
@@ -122,6 +122,7 @@ func writeState(
 
 	plan := cfg.AutoFill
 	if plan != nil {
+		cfg.Progress.Stage("ethrex: phase 1/2 — generating accounts")
 		for i := 0; i < plan.NumEOAs; i++ {
 			if ctx.Err() != nil {
 				return common.Hash{}, nil, ctx.Err()
@@ -131,6 +132,7 @@ func writeState(
 			if err := sorter.Put(acc.AddrHash[:], blob); err != nil {
 				return common.Hash{}, nil, err
 			}
+			cfg.Progress.Tick(int64(i+1), int64(plan.NumEOAs), "EOAs")
 		}
 	}
 
@@ -157,6 +159,7 @@ func writeState(
 	}
 
 	if plan != nil {
+		cfg.Progress.Stage("ethrex: phase 1/2 — generating contracts")
 		for i := 0; i < plan.NumContracts; i++ {
 			if ctx.Err() != nil {
 				return common.Hash{}, nil, ctx.Err()
@@ -170,6 +173,7 @@ func writeState(
 			if err := sorter.Put(contract.AddrHash[:], blob); err != nil {
 				return common.Hash{}, nil, err
 			}
+			cfg.Progress.Tick(int64(i+1), int64(plan.NumContracts), "contracts")
 		}
 	}
 
@@ -197,6 +201,8 @@ func writeState(
 	//   Per account: (1) replay buffered storage rows into storageSink/storageFkvSink
 	//   (or build inline for big accounts); (2) dedup and write code; (3) add
 	//   account leaf to accountBuilder; (4) accumulate stats.
+
+	cfg.Progress.Stage("ethrex: phase 2/2 — building state trie")
 
 	accountBuilder := ethrexinternal.NewBuilder(accountTrieNodeSink)
 

--- a/client/ethrex/state_writer_cgo.go
+++ b/client/ethrex/state_writer_cgo.go
@@ -202,6 +202,13 @@ func writeState(
 	//   (or build inline for big accounts); (2) dedup and write code; (3) add
 	//   account leaf to accountBuilder; (4) accumulate stats.
 
+	// entitiesQueued is the exact count Put into the sorter above (synthetic
+	// EOAs/contracts + deduped genesis allocs) — the Phase-2 progress total.
+	var entitiesQueued int64
+	if plan != nil {
+		entitiesQueued += int64(plan.NumEOAs + plan.NumContracts)
+	}
+	entitiesQueued += int64(len(seenAlloc))
 	cfg.Progress.Stage("ethrex: phase 2/2 — building state trie")
 
 	accountBuilder := ethrexinternal.NewBuilder(accountTrieNodeSink)
@@ -394,6 +401,7 @@ func writeState(
 				break
 			}
 			nextSeq++
+			cfg.Progress.Tick(int64(nextSeq), entitiesQueued, "accounts")
 		}
 	}
 

--- a/client/geth/state_writer.go
+++ b/client/geth/state_writer.go
@@ -81,6 +81,8 @@ func writeStateAndCollectRoot(
 	// pre-allocated genesis addresses.
 	genesisAddrs := make(map[common.Address]struct{}, len(cfg.GenesisAccounts))
 
+	cfg.Progress.Stage("geth: phase 1/2 — generating accounts")
+
 	for addr, acc := range cfg.GenesisAccounts {
 		genesisAddrs[addr] = struct{}{}
 		addrHash := crypto.Keccak256Hash(addr[:])
@@ -135,6 +137,7 @@ func writeStateAndCollectRoot(
 			if len(stats.SampleEOAs) < 3 {
 				stats.SampleEOAs = append(stats.SampleEOAs, acc.Address)
 			}
+			cfg.Progress.Tick(int64(i+1), int64(plan.NumEOAs), "EOAs")
 		}
 
 		for i := 0; i < plan.NumContracts; i++ {
@@ -166,6 +169,8 @@ func writeStateAndCollectRoot(
 			if len(stats.SampleContracts) < 3 {
 				stats.SampleContracts = append(stats.SampleContracts, contract.Address)
 			}
+			cfg.Progress.Tick(int64(i+1), int64(plan.NumContracts),
+				fmt.Sprintf("contracts · %d slots", stats.StorageSlotsCreated))
 		}
 	}
 
@@ -177,6 +182,9 @@ func writeStateAndCollectRoot(
 	}
 
 	phase2Start := time.Now()
+
+	cfg.Progress.Stage("geth: phase 2/2 — building account trie")
+	phase2Total := int64(stats.AccountsCreated + stats.ContractsCreated)
 
 	// Outer account trie nodes are persisted under TrieNodeAccountPrefix.
 	// Geth's PathDB boot derives the trie root via
@@ -272,6 +280,7 @@ func writeStateAndCollectRoot(
 		}
 
 		count++
+		cfg.Progress.Tick(int64(count), phase2Total, "accounts")
 		return nil
 	})
 	if iterErr != nil {
@@ -534,17 +543,17 @@ func (g *gethStorageHashBuilder) Root() (common.Hash, error) {
 // runPhase0 drives the spec-PreAlloc streaming-trie phase in parallel.
 //
 // For every cfg.PreAlloc entity with pe.Storage != nil, a worker:
-//   1. Drains the entity's storage iter into a per-call streamsort.Store
-//      (rooted under cfg.DBPath so the temp lives on the production
-//      filesystem, not the docker container's /tmp overlay).
-//   2. Iterates the sorted store, building a per-account storage MPT
-//      via a scratch-batch HashBuilder. Per-slot snapshot rows and
-//      per-storage-trie-node writes go to the worker's own *pebble.Batch
-//      — no contention on the shared w.batch+batchMu hot path.
-//   3. Flushes its batch via w.CommitScratchBatch when it crosses
-//      scratchBatchFlushBytes, and one final flush at worker exit.
-//   4. Reports the computed storage root through preparedCh to the main
-//      goroutine, which assigns it to cfg.GenesisAccounts[addr].Root.
+//  1. Drains the entity's storage iter into a per-call streamsort.Store
+//     (rooted under cfg.DBPath so the temp lives on the production
+//     filesystem, not the docker container's /tmp overlay).
+//  2. Iterates the sorted store, building a per-account storage MPT
+//     via a scratch-batch HashBuilder. Per-slot snapshot rows and
+//     per-storage-trie-node writes go to the worker's own *pebble.Batch
+//     — no contention on the shared w.batch+batchMu hot path.
+//  3. Flushes its batch via w.CommitScratchBatch when it crosses
+//     scratchBatchFlushBytes, and one final flush at worker exit.
+//  4. Reports the computed storage root through preparedCh to the main
+//     goroutine, which assigns it to cfg.GenesisAccounts[addr].Root.
 //
 // Root assignment is single-writer on the main goroutine; workers
 // never touch cfg.GenesisAccounts. Across-entity Pebble keyspaces are

--- a/client/geth/state_writer.go
+++ b/client/geth/state_writer.go
@@ -571,6 +571,14 @@ func runPhase0(ctx context.Context, cfg generator.Config, w *Writer) error {
 		return nil
 	}
 
+	// Phase 0 streams each spec entity's storage slots (100M–1B per bloat
+	// entity) and is otherwise silent for hours. The count-only slot heartbeat
+	// funnels every worker's per-slot count through one SlotMeter; each worker
+	// holds its own SlotWorker so the hot per-slot path stays cheap (one
+	// non-atomic add + mask).
+	cfg.Progress.Stage("geth: phase 0 — spec storage")
+	slotMeter := cfg.Progress.SlotMeter()
+
 	workers := runtime.NumCPU()
 	if workers < 1 {
 		workers = 1
@@ -599,6 +607,7 @@ func runPhase0(ctx context.Context, cfg generator.Config, w *Writer) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			slotW := slotMeter.Worker()
 			sbw := newScratchBatchWriter(w, scratchBatchFlushBytes)
 			defer func() {
 				if err := sbw.Close(); err != nil {
@@ -620,6 +629,7 @@ func runPhase0(ctx context.Context, cfg generator.Config, w *Writer) error {
 					return
 				}
 				sink := func(keyHash, _rawKey, value common.Hash) error {
+					slotW.Slot()
 					valueRLP, encErr := encodeStorageValue(value)
 					if encErr != nil {
 						return encErr

--- a/client/nethermind/entitygen_cgo.go
+++ b/client/nethermind/entitygen_cgo.go
@@ -170,6 +170,7 @@ func writeSyntheticAccounts(
 	plan := cfg.AutoFill
 
 	if plan != nil {
+		cfg.Progress.Stage("nethermind: phase 1/2 — generating accounts")
 		for i := 0; i < plan.NumEOAs; i++ {
 			acc := plan.DrawEOA(rng)
 			data, err := gethrlp.EncodeToBytes(acc.StateAccount)
@@ -191,12 +192,16 @@ func writeSyntheticAccounts(
 					stats.CodeBytes += uint64(len(acc.Code))
 				}
 			}
+			cfg.Progress.Tick(int64(i+1), int64(plan.NumEOAs), "EOAs")
 		}
 	}
 
 	plannedContracts := 0
 	if plan != nil {
 		plannedContracts = plan.NumContracts
+	}
+	if plannedContracts > 0 {
+		cfg.Progress.Stage("nethermind: phase 1/2 — generating contracts")
 	}
 	for i := 0; i < plannedContracts; i++ {
 		contract := plan.DrawContract(rng)
@@ -257,8 +262,10 @@ func writeSyntheticAccounts(
 			stats.ContractsCreated++
 			stats.StorageSlotsCreated += numSlots
 		}
+		cfg.Progress.Tick(int64(i+1), int64(plannedContracts), "contracts")
 	}
 
+	cfg.Progress.Stage("nethermind: phase 2/2 — building state trie")
 	if err := sorter.Iterate(func(key, value []byte) error {
 		var ah [32]byte
 		copy(ah[:], key)

--- a/client/nethermind/entitygen_cgo.go
+++ b/client/nethermind/entitygen_cgo.go
@@ -265,7 +265,14 @@ func writeSyntheticAccounts(
 		cfg.Progress.Tick(int64(i+1), int64(plannedContracts), "contracts")
 	}
 
+	// entitiesQueued is the exact count Put into the sorter above (genesis
+	// allocs + synthetic EOAs/contracts) — the Phase-2 progress total.
+	entitiesQueued := int64(len(genesisAccounts) + plannedContracts)
+	if plan != nil {
+		entitiesQueued += int64(plan.NumEOAs)
+	}
 	cfg.Progress.Stage("nethermind: phase 2/2 — building state trie")
+	var phase2Count int64
 	if err := sorter.Iterate(func(key, value []byte) error {
 		var ah [32]byte
 		copy(ah[:], key)
@@ -280,6 +287,8 @@ func writeSyntheticAccounts(
 		if err := builder.AddAccount(ah, value); err != nil {
 			return fmt.Errorf("add account: %w", err)
 		}
+		phase2Count++
+		cfg.Progress.Tick(phase2Count, entitiesQueued, "accounts")
 		return nil
 	}); err != nil {
 		return common.Hash{}, fmt.Errorf("streamsort iterate: %w", err)

--- a/client/nethermind/phase0_cgo.go
+++ b/client/nethermind/phase0_cgo.go
@@ -40,6 +40,13 @@ func runPhase0(
 		return nil
 	}
 
+	// Phase 0 streams each spec entity's storage slots and is otherwise silent
+	// for hours on bloat specs. The count-only slot heartbeat funnels every
+	// worker's per-slot count through one SlotMeter; each worker holds its own
+	// SlotWorker so the hot per-slot path stays cheap (one non-atomic add + mask).
+	cfg.Progress.Stage("nethermind: phase 0 — spec storage")
+	slotMeter := cfg.Progress.SlotMeter()
+
 	// TODO: long-pole-first scheduling — pe.Storage is iter.Seq2 so len() is
 	// unavailable without consuming the iterator.
 
@@ -71,6 +78,7 @@ func runPhase0(
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			slotW := slotMeter.Worker()
 			workerSink := newStateDBSink(dbs.state)
 			defer func() {
 				if err := workerSink.close(); err != nil {
@@ -91,6 +99,7 @@ func runPhase0(
 
 				var entityStorageBytes uint64
 				statSink := func(_, _, value common.Hash) error {
+					slotW.Slot()
 					// RLP-of-trimmed-value byte count (1 prefix + len(trimmed)).
 					v := value[:]
 					for len(v) > 0 && v[0] == 0 {

--- a/client/reth/run_cgo.go
+++ b/client/reth/run_cgo.go
@@ -125,6 +125,8 @@ func RunCgo(ctx context.Context, cfg generator.Config, opts Options) (*generator
 	if plan != nil && (plan.NumEOAs > 0 || plan.NumContracts > 0) {
 		rng := mrand.New(mrand.NewSource(cfg.Seed))
 
+		cfg.Progress.Stage("reth: generating accounts")
+
 		remaining := plan.NumEOAs
 		for remaining > 0 {
 			b := batchSize
@@ -168,6 +170,7 @@ func RunCgo(ctx context.Context, cfg generator.Config, opts Options) (*generator
 			}
 			accountsCreated += b
 			remaining -= b
+			cfg.Progress.Tick(int64(plan.NumEOAs-remaining), int64(plan.NumEOAs), "EOAs")
 		}
 
 		if plan.NumContracts > 0 {
@@ -194,6 +197,7 @@ func RunCgo(ctx context.Context, cfg generator.Config, opts Options) (*generator
 				}
 				contractsCreated += b
 				remaining -= b
+				cfg.Progress.Tick(int64(plan.NumContracts-remaining), int64(plan.NumContracts), "contracts")
 			}
 		}
 	}

--- a/client/reth/run_cgo.go
+++ b/client/reth/run_cgo.go
@@ -207,6 +207,9 @@ func RunCgo(ctx context.Context, cfg generator.Config, opts Options) (*generator
 		// state-root computation so reth's payload builder finds them on
 		// boot. Keys use the 33-byte PackedStoredNibbles form (reth v2);
 		// cursor.Put is correct regardless of emission order.
+		cfg.Progress.Stage("reth: phase 2/2 — building account trie")
+		phase2Total := int64(accountsCreated + contractsCreated)
+		var phase2Count int64
 		var root common.Hash
 		err := envs.Mdbx.Update(func(txn *mdbx.Txn) error {
 			cur, cerr := txn.OpenCursor(envs.MdbxDBIs["AccountsTrie"])
@@ -226,7 +229,19 @@ func RunCgo(ctx context.Context, cfg generator.Config, opts Options) (*generator
 				node.EncodeCompact(&valBuf)
 				return cur.Put(keyBuf.Bytes(), valBuf.Bytes(), 0)
 			}
-			r, rerr := ComputeStateRootStreaming(sorter.Iterate, emit)
+			// Count-and-tick wrapper around the sorted account stream so the
+			// pure-Go account-trie build shows live progress. Single-goroutine
+			// (HashBuilder consumes the yield sequentially), so phase2Count is
+			// race-free; it forwards every pair unchanged, so the root is
+			// identical.
+			countingIter := func(yield func(addrHash, accountRLP []byte) error) error {
+				return sorter.Iterate(func(addrHash, accountRLP []byte) error {
+					phase2Count++
+					cfg.Progress.Tick(phase2Count, phase2Total, "accounts")
+					return yield(addrHash, accountRLP)
+				})
+			}
+			r, rerr := ComputeStateRootStreaming(countingIter, emit)
 			if rerr != nil {
 				return rerr
 			}

--- a/client/reth/spec_storage_streaming_cgo.go
+++ b/client/reth/spec_storage_streaming_cgo.go
@@ -15,6 +15,7 @@ import (
 	"github.com/holiman/uint256"
 
 	"github.com/ethereum/state-actor/generator"
+	"github.com/ethereum/state-actor/internal/progress"
 	iReth "github.com/ethereum/state-actor/internal/reth"
 	"github.com/ethereum/state-actor/internal/streamingtrie"
 )
@@ -92,6 +93,13 @@ func streamSpecStorage(ctx context.Context, envs *Envs, cfg *generator.Config, s
 		return nil
 	}
 
+	// Phase 0 streams each spec entity's storage slots and is otherwise silent
+	// for hours on bloat specs. The count-only slot heartbeat funnels every
+	// worker's per-slot count through one SlotMeter; each worker holds its own
+	// SlotWorker so the hot per-slot path stays cheap (one non-atomic add + mask).
+	cfg.Progress.Stage("reth: phase 0 — spec storage")
+	slotMeter := cfg.Progress.SlotMeter()
+
 	workers := runtime.NumCPU()
 	if workers < 1 {
 		workers = 1
@@ -117,11 +125,12 @@ func streamSpecStorage(ctx context.Context, envs *Envs, cfg *generator.Config, s
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			slotW := slotMeter.Worker()
 			for i := range entityCh {
 				if drainCtx.Err() != nil {
 					return
 				}
-				if err := drainAndEncodeEntity(drainCtx, cfg, i, preparedCh); err != nil {
+				if err := drainAndEncodeEntity(drainCtx, cfg, i, preparedCh, slotW); err != nil {
 					cancelDrain(err)
 					return
 				}
@@ -200,6 +209,7 @@ func drainAndEncodeEntity(
 	cfg *generator.Config,
 	idx int,
 	preparedCh chan<- *preparedEntity,
+	slotW *progress.SlotWorker,
 ) error {
 	pe := &cfg.PreAlloc[idx]
 	addr := pe.Address
@@ -273,6 +283,7 @@ func drainAndEncodeEntity(
 	}
 
 	sink := func(keyHash, rawKey, value common.Hash) error {
+		slotW.Slot()
 		slotValueU256 := uint256.NewInt(0).SetBytes(value[:])
 
 		prep := slotPrepared{rawKey: rawKey}

--- a/generator/config.go
+++ b/generator/config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum/state-actor/genesis"
 	"github.com/ethereum/state-actor/internal/autofill"
+	"github.com/ethereum/state-actor/internal/progress"
 	"github.com/ethereum/state-actor/internal/templates"
 )
 
@@ -40,6 +41,11 @@ type Config struct {
 
 	// Verbose enables verbose logging.
 	Verbose bool
+
+	// Progress, when non-nil, receives throttled heartbeat updates from each
+	// client's generation loop so a long run never looks frozen. main.go always
+	// wires a live reporter; library/test callers leave it nil for silence.
+	Progress *progress.Reporter
 
 	// TrieMode selects the trie algorithm for state root computation.
 	// Defaults to TrieModeMPT if empty.

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -20,7 +20,42 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/ethereum/state-actor/internal/entitygen"
+	"github.com/ethereum/state-actor/internal/progress"
 )
+
+// phase2TickStride gates how often the binary Phase-2 iterator samples the
+// wall clock for a progress heartbeat. Phase 2 streams one Next() per trie
+// entry (accounts×2 + every storage slot + code chunks → billions on bench
+// workloads), so calling progress.Tick — which reads time.Now() — on every
+// entry would add billions of clock reads to the hottest loop. Sampling once
+// per 2^16 entries bounds that overhead to a rounding error; the Reporter's
+// own 15 s throttle still decides when a line is actually printed.
+const phase2TickStride = 1 << 16
+
+// tickingIterator wraps an ethdb.Iterator to emit a throttled Phase-2 progress
+// heartbeat as entries stream past. It is observation-only: Key, Value, and
+// iteration order are forwarded verbatim, so the computed root is byte-
+// identical. total is the Phase-1 entry count — an upper bound when
+// --target-size stops the underlying iterator early (the bar just won't reach
+// 100%). A nil progress reporter makes Tick a no-op, so this stays silent for
+// library/test callers.
+type tickingIterator struct {
+	ethdb.Iterator
+	progress *progress.Reporter
+	total    int64
+	n        int64
+}
+
+func (it *tickingIterator) Next() bool {
+	ok := it.Iterator.Next()
+	if ok {
+		it.n++
+		if it.n&(phase2TickStride-1) == 0 {
+			it.progress.Tick(it.n, it.total, "entries")
+		}
+	}
+	return ok
+}
 
 // Generator handles state generation.
 type Generator struct {
@@ -445,6 +480,9 @@ func (g *Generator) generateStreamingBinary() (retStats *Stats, retErr error) {
 			shouldStop: tracker.ShouldStop,
 		}
 	}
+	// Outermost wrap: heartbeat on entries actually yielded to the builder
+	// (after any target-size early-stop), so Phase 2 isn't silent on long runs.
+	iter = &tickingIterator{Iterator: iter, progress: g.config.Progress, total: totalEntries}
 
 	// afterStem runs in the builder goroutine (the goroutine that owns the
 	// sbw + tnw Pebble batches) so MaybeCalibrate's synchronous flush

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -227,17 +227,7 @@ func (g *Generator) generateStreamingBinary() (retStats *Stats, retErr error) {
 		return nil
 	}
 
-	var lastLogTime = time.Now()
-	logProgress := func(phase string, current, total int, slots int64) {
-		if time.Since(lastLogTime) < 20*time.Second {
-			return
-		}
-		lastLogTime = time.Now()
-		totalEntries := preambleEntries + contractEntries
-		pct := float64(current) / float64(total) * 100
-		log.Printf("[%s] %d/%d (%.1f%%), %d storage slots, %d trie entries",
-			phase, current, total, pct, slots, totalEntries)
-	}
+	g.config.Progress.Stage("binary: phase 1/2 — generating accounts")
 
 	// Track genesis addresses for collision avoidance.
 	genesisAddrs := make(map[common.Address]bool, len(g.config.GenesisAccounts))
@@ -304,7 +294,8 @@ func (g *Generator) generateStreamingBinary() (retStats *Stats, retErr error) {
 			if len(stats.SampleEOAs) < 3 {
 				stats.SampleEOAs = append(stats.SampleEOAs, acc.address)
 			}
-			logProgress("EOA", i+1, plan.NumEOAs, 0)
+			g.config.Progress.Tick(int64(i+1), int64(plan.NumEOAs),
+				fmt.Sprintf("EOAs · %d trie entries", preambleEntries+contractEntries))
 		}
 	}
 
@@ -352,7 +343,8 @@ func (g *Generator) generateStreamingBinary() (retStats *Stats, retErr error) {
 		}
 		contractIdx++
 		if plan != nil {
-			logProgress("Contract", contractIdx, plan.NumContracts, int64(stats.StorageSlotsCreated))
+			g.config.Progress.Tick(int64(contractIdx), int64(plan.NumContracts),
+				fmt.Sprintf("contracts · %d slots", stats.StorageSlotsCreated))
 		}
 
 		// Phase 1 raw-byte safety cap: stop generating more entries once
@@ -389,6 +381,9 @@ func (g *Generator) generateStreamingBinary() (retStats *Stats, retErr error) {
 	// --- Phase 2: Stream sorted entries from temp DB → compute root hash ---
 
 	totalEntries := preambleEntries + contractEntries
+
+	g.config.Progress.Stage(fmt.Sprintf(
+		"binary: phase 2/2 — computing trie root from %d entries", totalEntries))
 
 	// Compact the temp DB to flatten LSM levels into a single sorted run.
 	// This makes the sequential iteration single-pass I/O instead of a
@@ -613,7 +608,6 @@ func trimLeftZeroes(s []byte) []byte {
 	}
 	return nil
 }
-
 
 func formatBytesInternal(b uint64) string {
 	const unit = 1024

--- a/generator/progress_iter_test.go
+++ b/generator/progress_iter_test.go
@@ -1,0 +1,89 @@
+package generator
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/state-actor/internal/progress"
+)
+
+// sliceIter is a minimal forward-only ethdb.Iterator over fixed (key, value)
+// pairs — just enough to exercise tickingIterator's forwarding contract.
+type sliceIter struct {
+	keys, vals [][]byte
+	pos        int
+}
+
+func (s *sliceIter) Next() bool    { s.pos++; return s.pos <= len(s.keys) }
+func (s *sliceIter) Error() error  { return nil }
+func (s *sliceIter) Key() []byte   { return s.keys[s.pos-1] }
+func (s *sliceIter) Value() []byte { return s.vals[s.pos-1] }
+func (s *sliceIter) Release()      {}
+
+var _ ethdb.Iterator = (*sliceIter)(nil)
+
+// TestTickingIteratorForwardsVerbatim is the determinism guard: the Phase-2
+// heartbeat wrapper must yield exactly the same keys/values in the same order
+// as the underlying iterator, so the computed root is unchanged. Emission
+// throttling itself is covered by internal/progress's own tests.
+func TestTickingIteratorForwardsVerbatim(t *testing.T) {
+	keys := [][]byte{[]byte("a"), []byte("bb"), []byte("ccc")}
+	vals := [][]byte{[]byte("1"), []byte("22"), []byte("333")}
+
+	it := &tickingIterator{Iterator: &sliceIter{keys: keys, vals: vals}, progress: progress.New(), total: int64(len(keys))}
+
+	var gotK, gotV [][]byte
+	for it.Next() {
+		// Copy: real iterators alias internal buffers, so callers must not
+		// retain the slices; copying here mirrors that contract.
+		gotK = append(gotK, append([]byte(nil), it.Key()...))
+		gotV = append(gotV, append([]byte(nil), it.Value()...))
+	}
+
+	if it.Next() { // exhausted iterator must keep returning false
+		t.Fatal("Next() returned true after exhaustion")
+	}
+	if len(gotK) != len(keys) {
+		t.Fatalf("yielded %d entries, want %d", len(gotK), len(keys))
+	}
+	for i := range keys {
+		if !bytes.Equal(gotK[i], keys[i]) || !bytes.Equal(gotV[i], vals[i]) {
+			t.Fatalf("entry %d = (%q,%q), want (%q,%q)", i, gotK[i], gotV[i], keys[i], vals[i])
+		}
+	}
+	if it.n != int64(len(keys)) {
+		t.Fatalf("counter n = %d, want %d", it.n, len(keys))
+	}
+}
+
+// TestTickingIteratorNilReporter confirms a nil reporter is a no-op on the hot
+// path (library/test callers leave Progress nil).
+func TestTickingIteratorNilReporter(t *testing.T) {
+	keys := [][]byte{[]byte("k")}
+	it := &tickingIterator{Iterator: &sliceIter{keys: keys, vals: keys}, total: 1}
+	// Force the stride boundary so the (nil) Tick path is exercised.
+	it.n = phase2TickStride - 1
+	if !it.Next() {
+		t.Fatal("Next() should yield the single entry")
+	}
+}
+
+// TestTickingIteratorCountOnly exercises the total<=0 (count-only) construction
+// — used when the entry total is unknown — and confirms forwarding is identical
+// to the known-total case and the stride-boundary Tick path doesn't panic.
+func TestTickingIteratorCountOnly(t *testing.T) {
+	keys := [][]byte{[]byte("x"), []byte("y")}
+	it := &tickingIterator{Iterator: &sliceIter{keys: keys, vals: keys}, progress: progress.New(), total: 0}
+	it.n = phase2TickStride - 1 // next advance crosses the stride boundary
+	var got int
+	for it.Next() {
+		if !bytes.Equal(it.Key(), keys[got]) {
+			t.Fatalf("entry %d key = %q, want %q", got, it.Key(), keys[got])
+		}
+		got++
+	}
+	if got != len(keys) {
+		t.Fatalf("yielded %d entries, want %d", got, len(keys))
+	}
+}

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -1,0 +1,144 @@
+// Package progress emits throttled, human-readable heartbeat lines for the
+// long-running state-generation phases. A multi-hour run otherwise prints
+// nothing between the startup banner and the final summary, which reads as
+// "frozen". The Reporter is deliberately tiny: every client funnels its
+// generation loop through Tick, and a nil *Reporter is a valid no-op so
+// library/test callers that don't wire one stay silent.
+package progress
+
+import (
+	"fmt"
+	"log"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// DefaultInterval is the minimum gap between two emitted progress lines for a
+// single stage. The hot loops call Tick on every iteration; the throttle keeps
+// output to a readable trickle regardless.
+const DefaultInterval = 15 * time.Second
+
+// Reporter emits throttled progress for the current stage. The zero value is
+// not usable; construct one with New. A nil *Reporter is a valid no-op.
+type Reporter struct {
+	interval time.Duration
+
+	// lastNano is the wall-clock nanos of the last emitted line. Read/written
+	// atomically so Tick's throttle check stays off the mutex on the hot path.
+	lastNano atomic.Int64
+
+	mu      sync.Mutex // guards stage/stageAt and serialises log output
+	stage   string
+	stageAt time.Time
+}
+
+// New returns a Reporter that emits at most one line per DefaultInterval.
+func New() *Reporter {
+	return &Reporter{interval: DefaultInterval}
+}
+
+// Stage announces a new phase, resets the rate/ETA baseline, and prints
+// immediately so the user gets instant feedback at every phase boundary.
+func (r *Reporter) Stage(name string) {
+	if r == nil {
+		return
+	}
+	now := time.Now()
+	r.mu.Lock()
+	r.stage = name
+	r.stageAt = now
+	r.mu.Unlock()
+	r.lastNano.Store(now.UnixNano())
+	log.Printf("▸ %s", name)
+}
+
+// Tick reports progress within the current stage. current/total are item
+// counts; pass total <= 0 when the total is unknown (a count-only line with no
+// percentage or ETA). detail is an optional suffix, e.g. "1.2M slots". Tick is
+// safe to call on every loop iteration: emission is throttled to one line per
+// interval and the throttle check is lock-free.
+func (r *Reporter) Tick(current, total int64, detail string) {
+	if r == nil {
+		return
+	}
+	now := time.Now()
+	last := r.lastNano.Load()
+	if now.UnixNano()-last < int64(r.interval) {
+		return
+	}
+	// CAS so that, under concurrent ticks, exactly one caller emits per window.
+	if !r.lastNano.CompareAndSwap(last, now.UnixNano()) {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	elapsed := now.Sub(r.stageAt).Seconds()
+	var rate float64
+	if elapsed > 0 {
+		rate = float64(current) / elapsed
+	}
+
+	suffix := ""
+	if detail != "" {
+		suffix = " · " + detail
+	}
+
+	if total > 0 {
+		pct := float64(current) / float64(total) * 100
+		eta := "—"
+		if rate > 0 && current <= total {
+			remain := time.Duration(float64(total-current)/rate) * time.Second
+			eta = remain.Round(time.Second).String()
+		}
+		log.Printf("  %s %s/%s (%.1f%%) · %s/s · ETA %s%s",
+			r.stage, humanInt(current), humanInt(total), pct, humanRate(rate), eta, suffix)
+		return
+	}
+	log.Printf("  %s %s · %s/s%s", r.stage, humanInt(current), humanRate(rate), suffix)
+}
+
+// humanInt formats n with thousands separators, e.g. 1234567 -> "1,234,567".
+func humanInt(n int64) string {
+	s := fmt.Sprintf("%d", n)
+	neg := false
+	if len(s) > 0 && s[0] == '-' {
+		neg = true
+		s = s[1:]
+	}
+	if len(s) <= 3 {
+		if neg {
+			return "-" + s
+		}
+		return s
+	}
+	// Insert a comma every three digits from the right.
+	lead := len(s) % 3
+	if lead == 0 {
+		lead = 3
+	}
+	out := make([]byte, 0, len(s)+len(s)/3)
+	out = append(out, s[:lead]...)
+	for i := lead; i < len(s); i += 3 {
+		out = append(out, ',')
+		out = append(out, s[i:i+3]...)
+	}
+	if neg {
+		return "-" + string(out)
+	}
+	return string(out)
+}
+
+// humanRate formats an items-per-second rate compactly, e.g. 12345 -> "12.3k".
+func humanRate(perSec float64) string {
+	switch {
+	case perSec >= 1_000_000:
+		return fmt.Sprintf("%.1fM", perSec/1_000_000)
+	case perSec >= 1_000:
+		return fmt.Sprintf("%.1fk", perSec/1_000)
+	default:
+		return fmt.Sprintf("%.0f", perSec)
+	}
+}

--- a/internal/progress/progress_test.go
+++ b/internal/progress/progress_test.go
@@ -1,0 +1,114 @@
+package progress
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHumanInt(t *testing.T) {
+	cases := []struct {
+		in   int64
+		want string
+	}{
+		{0, "0"},
+		{42, "42"},
+		{999, "999"},
+		{1000, "1,000"},
+		{12345, "12,345"},
+		{1234567, "1,234,567"},
+		{-1234, "-1,234"},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, humanInt(c.in), "humanInt(%d)", c.in)
+	}
+}
+
+func TestHumanRate(t *testing.T) {
+	assert.Equal(t, "0", humanRate(0))
+	assert.Equal(t, "999", humanRate(999))
+	assert.Equal(t, "1.0k", humanRate(1000))
+	assert.Equal(t, "12.3k", humanRate(12345))
+	assert.Equal(t, "1.5M", humanRate(1_500_000))
+}
+
+// captureLog redirects the stdlib logger to a buffer for the duration of fn.
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	prevOut := log.Writer()
+	prevFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(prevOut)
+		log.SetFlags(prevFlags)
+	})
+	fn()
+	return buf.String()
+}
+
+func TestNilReporterIsNoOp(t *testing.T) {
+	var r *Reporter
+	out := captureLog(t, func() {
+		r.Stage("x")           // must not panic
+		r.Tick(1, 10, "items") // must not panic
+	})
+	assert.Empty(t, out)
+}
+
+func TestStagePrintsImmediately(t *testing.T) {
+	r := New()
+	out := captureLog(t, func() {
+		r.Stage("phase 1")
+	})
+	assert.Contains(t, out, "phase 1")
+}
+
+func TestTickThrottlesWithinInterval(t *testing.T) {
+	r := New()
+	r.interval = time.Hour // nothing should emit after the Stage baseline
+	out := captureLog(t, func() {
+		r.Stage("phase")
+		for i := range 1000 {
+			r.Tick(int64(i), 1000, "items")
+		}
+	})
+	// Only the Stage line, no Tick lines.
+	assert.Equal(t, 1, strings.Count(out, "\n"))
+	assert.NotContains(t, out, "ETA")
+}
+
+func TestTickEmitsAfterInterval(t *testing.T) {
+	r := New()
+	r.interval = time.Millisecond
+	out := captureLog(t, func() {
+		r.Stage("phase")
+		// Force the baseline into the past so the first Tick is eligible.
+		r.lastNano.Store(time.Now().Add(-time.Second).UnixNano())
+		r.Tick(250, 1000, "items")
+	})
+	require.Contains(t, out, "phase")
+	assert.Contains(t, out, "250/1,000")
+	assert.Contains(t, out, "(25.0%)")
+	assert.Contains(t, out, "ETA")
+	assert.Contains(t, out, "items")
+}
+
+func TestTickUnknownTotalOmitsPctAndETA(t *testing.T) {
+	r := New()
+	r.interval = time.Millisecond
+	out := captureLog(t, func() {
+		r.Stage("phase")
+		r.lastNano.Store(time.Now().Add(-time.Second).UnixNano())
+		r.Tick(500, 0, "")
+	})
+	assert.Contains(t, out, "500")
+	assert.NotContains(t, out, "ETA")
+	assert.NotContains(t, out, "%")
+}

--- a/internal/progress/slots.go
+++ b/internal/progress/slots.go
@@ -1,0 +1,83 @@
+package progress
+
+import "sync/atomic"
+
+// slotStride bounds how often a hot per-slot counter samples the wall clock
+// and touches the shared total: once per 2^12 slots. Phase-0 spec-storage
+// drains run several parallel workers over up to ~1B slots each; a shared
+// atomic incremented on every slot would bounce a cache line across cores
+// billions of times and measurably slow the dominant bench phase. Batching the
+// shared update into per-worker strides keeps the per-slot cost to a single
+// non-atomic increment plus a mask test, and touches the shared atomic only
+// once per stride. Must be a power of two for the mask test in Slot.
+const slotStride = 1 << 12
+
+// Compile-time guard that slotStride is a power of two (the `&(slotStride-1)`
+// mask in Slot means "every Nth call" only then). For a power of two
+// `slotStride & (slotStride-1)` is 0, so this is uint(0); otherwise it is a
+// negative constant that fails to convert to uint — a build error.
+const _ = uint(0 - (slotStride & (slotStride - 1)))
+
+// SlotMeter aggregates a hot, parallel per-slot count into one shared total and
+// emits a throttled count-only heartbeat through a Reporter. Construct one per
+// phase with NewSlotMeter, hand each worker goroutine its own *SlotWorker via
+// Worker, and call Slot once per item. A nil *SlotMeter (built from a nil
+// Reporter) is a no-op, so library/test callers stay silent and pay nothing.
+//
+// The published total is a stride-rounded LOWER BOUND: each worker's final
+// sub-stride remainder (< slotStride) is never flushed, so the heartbeat may
+// undershoot the true processed count by up to workers×(slotStride-1). That is
+// intentional for a count-only line (no percentage/ETA is derived from it) —
+// do not feed this total into a percentage and trust it as exact.
+type SlotMeter struct {
+	r     *Reporter
+	total atomic.Int64
+}
+
+// NewSlotMeter returns a SlotMeter, or nil when r is nil (the no-op fast path
+// for library/test callers that don't wire progress).
+func NewSlotMeter(r *Reporter) *SlotMeter {
+	if r == nil {
+		return nil
+	}
+	return &SlotMeter{r: r}
+}
+
+// SlotMeter is the method form of NewSlotMeter so callers can write
+// cfg.Progress.SlotMeter() without importing this package directly (and
+// without naming the *SlotMeter type). Safe on a nil *Reporter.
+func (r *Reporter) SlotMeter() *SlotMeter {
+	return NewSlotMeter(r)
+}
+
+// Worker returns a goroutine-local counter. Each worker goroutine MUST use its
+// own: SlotWorker holds unsynchronised local state and is not safe to share.
+func (m *SlotMeter) Worker() *SlotWorker {
+	if m == nil {
+		return nil
+	}
+	return &SlotWorker{m: m}
+}
+
+// SlotWorker counts slots for a single goroutine, flushing the running count to
+// the shared SlotMeter (and the wall clock, via Reporter.Tick) only once per
+// slotStride. A nil *SlotWorker is a no-op.
+type SlotWorker struct {
+	m     *SlotMeter
+	local int64
+}
+
+// Slot records one processed slot. The per-call cost is a single non-atomic
+// increment and a mask test; the shared atomic total and the Reporter are
+// touched only once per stride, keeping cross-core contention negligible — so
+// this is cheap enough to call on the hottest per-storage-slot path across
+// parallel workers.
+func (w *SlotWorker) Slot() {
+	if w == nil {
+		return
+	}
+	w.local++
+	if w.local&(slotStride-1) == 0 {
+		w.m.r.Tick(w.m.total.Add(slotStride), 0, "slots")
+	}
+}

--- a/internal/progress/slots_test.go
+++ b/internal/progress/slots_test.go
@@ -1,0 +1,99 @@
+package progress
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNilSlotMeterIsNoOp(t *testing.T) {
+	out := captureLog(t, func() {
+		m := NewSlotMeter(nil) // nil Reporter → nil meter
+		require.Nil(t, m)
+		w := m.Worker() // nil meter → nil worker
+		require.Nil(t, w)
+		for range slotStride * 2 {
+			w.Slot() // must not panic
+		}
+	})
+	assert.Empty(t, out)
+}
+
+func TestSlotMeterBatchesToSharedTotal(t *testing.T) {
+	r := New()
+	r.interval = time.Hour // suppress emission; we only check the total
+	m := NewSlotMeter(r)
+	w := m.Worker()
+
+	// One short of a stride: nothing flushed to the shared total yet.
+	for range slotStride - 1 {
+		w.Slot()
+	}
+	assert.Equal(t, int64(0), m.total.Load(), "shared total must not move before a full stride")
+
+	w.Slot() // crosses the stride boundary
+	assert.Equal(t, int64(slotStride), m.total.Load())
+
+	for range slotStride {
+		w.Slot()
+	}
+	assert.Equal(t, int64(2*slotStride), m.total.Load())
+}
+
+func TestSlotMeterEmitsCountOnly(t *testing.T) {
+	r := New()
+	r.interval = time.Millisecond
+	out := captureLog(t, func() {
+		r.Stage("phase 0")
+		// Push the baseline into the past so the stride flush is eligible to emit.
+		r.lastNano.Store(time.Now().Add(-time.Second).UnixNano())
+		w := m0Worker(r)
+		for range slotStride {
+			w.Slot()
+		}
+	})
+	assert.Contains(t, out, "slots")
+	assert.NotContains(t, out, "ETA") // count-only: no percentage / ETA
+	assert.NotContains(t, out, "%")
+}
+
+// m0Worker is a tiny helper so the test reads at the call site.
+func m0Worker(r *Reporter) *SlotWorker { return NewSlotMeter(r).Worker() }
+
+// TestSlotMeterConcurrent is the -race guard: many workers hammering their own
+// SlotWorkers must funnel into the shared total without data races, and the
+// total must equal the exact number of full strides completed.
+func TestSlotMeterConcurrent(t *testing.T) {
+	r := New()
+	r.interval = time.Hour
+	m := NewSlotMeter(r)
+
+	const workers = 8
+	const perWorker = slotStride * 4
+
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			w := m.Worker()
+			for range perWorker {
+				w.Slot()
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Each worker completes exactly perWorker/slotStride strides; no leftover.
+	want := int64(workers * perWorker)
+	assert.Equal(t, want, m.total.Load())
+}
+
+// guard against an accidentally non-power-of-two stride (the mask test relies
+// on it).
+func TestSlotStrideIsPowerOfTwo(t *testing.T) {
+	assert.Equal(t, 0, slotStride&(slotStride-1), "slotStride must be a power of two")
+}

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum/state-actor/genesis"
 	"github.com/ethereum/state-actor/internal/autofill"
 	"github.com/ethereum/state-actor/internal/clientpolicy"
+	"github.com/ethereum/state-actor/internal/progress"
 	"github.com/ethereum/state-actor/internal/sizecal"
 	"github.com/ethereum/state-actor/internal/spec"
 	"github.com/ethereum/state-actor/internal/specbuild"
@@ -139,6 +140,9 @@ func main() {
 		TargetSize:     parsedTargetSize,
 		GroupDepth:     *groupDepth,
 		Archive:        *archive,
+		// Always-on heartbeat: long runs would otherwise print nothing between
+		// the startup banner and the final summary. Throttled internally.
+		Progress: progress.New(),
 	}
 
 	extraDataBytes := []byte{}


### PR DESCRIPTION
## Problem

During a long `state-actor` run, nothing is printed between the startup banner and the final summary — the tool looks frozen, with no way to tell whether it's making progress. The worst offender is the default **geth MPT path**, which is silent through its entire Phase 2 (the account-trie build, often the longest phase). The binary generator had progress lines but only every 20s, and the other clients had none.

## What this does

Adds a small always-on progress heartbeat. No flag to enable, no flag to silence — it's on whenever you run the CLI.

**New `internal/progress` package** — a tiny `Reporter`:
- `Stage(name)` prints a phase banner (`▸ …`) **immediately**, so every phase boundary gives instant feedback.
- `Tick(current, total, detail)` is called on every loop iteration but **throttled to one line per 15s**; it prints count, %, throughput, and ETA. The throttle check is lock-free (atomic CAS) so it's safe on the hot path.
- A **nil `*Reporter` is a no-op**, so library/test callers stay silent — only `main.go` wires a live one.

**Wiring:**
- `generator.Config` gains a `Progress *progress.Reporter` field; `main.go` always sets `progress.New()`.
- Ticked the generation loops in **all six clients**: geth MPT (the previously-silent default), the binary generator (replaced the old ad-hoc 20s logger), reth, besu, nethermind, erigon, ethrex.

## Sample output (real runs, all six clients)

`▸` lines are phase banners (printed instantly); indented lines are the throttled ticks (one per ~15s).

**geth** (default, native — the previously-silent path), `--target-size=3GB`:
```
▸ geth: phase 1/2 — generating accounts
▸ geth: phase 2/2 — building account trie
  geth: phase 2/2 — building account trie 806,925/3,681,405 (21.9%) · 52.7k/s · ETA 54s · accounts
  geth: phase 2/2 — building account trie 1,343,162/3,681,405 (36.5%) · 43.9k/s · ETA 53s · accounts
  geth: phase 2/2 — building account trie 1,971,944/3,681,405 (53.6%) · 27.7k/s · ETA 1m1s · accounts
  geth: phase 2/2 — building account trie 2,958,195/3,681,405 (80.4%) · 24.8k/s · ETA 29s · accounts
  geth: phase 2/2 — building account trie 3,385,764/3,681,405 (92.0%) · 25.2k/s · ETA 11s · accounts
```

**reth** (both EOA and contract loops tick; contracts are slower via FFI):
```
▸ reth: generating accounts
  reth: generating accounts 1,800,000/2,412,324 (74.6%) · 113.3k/s · ETA 5s · EOAs
  reth: generating accounts 7,000/41,943 (16.7%) · 226/s · ETA 2m34s · contracts
  reth: generating accounts 22,000/41,943 (52.5%) · 474/s · ETA 42s · contracts
  reth: generating accounts 39,000/41,943 (93.0%) · 631/s · ETA 4s · contracts
```

**erigon** (contract tick; the long commitment phase now has a banner):
```
▸ erigon: generating accounts
  erigon: generating accounts 24,650/41,943 (58.8%) · 1.6k/s · ETA 10s · contracts
▸ erigon: building snapshots & commitment
```

**nethermind** (both phase banners + contract tick):
```
▸ nethermind: phase 1/2 — generating accounts
▸ nethermind: phase 1/2 — generating contracts
  nethermind: phase 1/2 — generating contracts 29,125/41,943 (69.4%) · 1.9k/s · ETA 6s · contracts
▸ nethermind: phase 2/2 — building state trie
```

**besu** (`--target-size=12GB` to push phase-1 past the 15s throttle):
```
▸ besu: phase 1/2 — generating accounts
▸ besu: phase 1/2 — generating contracts
  besu: phase 1/2 — generating contracts 126,579/251,658 (50.3%) · 8.4k/s · ETA 14s · contracts
  besu: phase 1/2 — generating contracts 219,169/251,658 (87.1%) · 7.1k/s · ETA 4s · contracts
▸ besu: phase 2/2 — building state trie
```

**ethrex** (`--target-size=12GB`):
```
▸ ethrex: phase 1/2 — generating accounts
▸ ethrex: phase 1/2 — generating contracts
  ethrex: phase 1/2 — generating contracts 97,885/251,658 (38.9%) · 6.5k/s · ETA 23s · contracts
  ethrex: phase 1/2 — generating contracts 173,743/251,658 (69.0%) · 5.8k/s · ETA 13s · contracts
▸ ethrex: phase 2/2 — building state trie
```

### Tick line anatomy (identical format across all clients)
```
  <stage>  <done>/<total> (<pct>) · <rate>/s · ETA <eta> · <detail>
           39,000/41,943   (93.0%)   631/s        4s        contracts
```

## Tests / verification

- New `internal/progress/progress_test.go`: formatting, nil no-op, immediate stage print, throttling, emit-after-interval.
- `go build ./...`, `go vet`, and tests for `internal/progress`, `generator`, `client/geth` all pass; `gofmt` clean.
- **All six clients built and run end-to-end locally** (geth native; reth/besu/nethermind/erigon/ethrex via their cgo Docker images): every run exits 0, and all six produce the **identical** genesis state root `0x80e8e30970ce77d238a57ec3e0212b4db053379d637ee263a29cf4cb2f9f7a21` at seed=42 — so the progress instrumentation is correct and has zero effect on generated state.

## Notes

- besu and ethrex defer their per-contract storage work to the cgo phase-2 (which has no inner Go loop to tick), so at small targets their fast Go-side phase-1 finishes under the 15s throttle and only banners show. At larger targets (12GB above) their phase-1 emits the same tick lines as the others. Their long phase-2 still shows a banner, which removes the "frozen" feeling.