### PR TITLE
feat(manifest): per-run reproducibility manifest + reproduce subcommand

### DIFF
--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -43,6 +43,8 @@ jobs:
       sha_short: ${{ steps.vars.outputs.sha_short }}
       tag_prefix: ${{ steps.vars.outputs.tag_prefix }}
       additional_tags: ${{ steps.vars.outputs.additional_tags }}
+      version: ${{ steps.vars.outputs.version }}
+      revision: ${{ steps.vars.outputs.revision }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -52,6 +54,13 @@ jobs:
         run: |
           SHA_SHORT=$(git rev-parse --short HEAD)
           echo "sha_short=$SHA_SHORT" >> $GITHUB_OUTPUT
+          # Version stamped into the binary via -X main.Version (build-arg
+          # below). Mirrors the Makefile's git-describe so manifests written
+          # by the published images carry a meaningful version.
+          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          # Full commit for the org.opencontainers.image.revision label.
+          echo "revision=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
           if [[ "${{ github.ref }}" == refs/tags/v*.*.* ]]; then
             VERSION_TAG="${GITHUB_REF#refs/tags/}"
             echo "tag_prefix=$VERSION_TAG" >> $GITHUB_OUTPUT
@@ -102,8 +111,12 @@ jobs:
         env:
           PREFIX: ${{ needs.meta.outputs.tag_prefix }}
           SHA: ${{ needs.meta.outputs.sha_short }}
+          VERSION: ${{ needs.meta.outputs.version }}
+          REVISION: ${{ needs.meta.outputs.revision }}
         run: |
           docker build . --file "$DOCKERFILE" \
+            --build-arg "STATE_ACTOR_VERSION=${VERSION}" \
+            --build-arg "STATE_ACTOR_REVISION=${REVISION}" \
             --tag "${GHCR_REPO}:${PREFIX}-amd64" \
             --tag "${GHCR_REPO}:${PREFIX}-${SHA}-amd64" \
             --platform=linux/amd64
@@ -157,8 +170,12 @@ jobs:
         env:
           PREFIX: ${{ needs.meta.outputs.tag_prefix }}
           SHA: ${{ needs.meta.outputs.sha_short }}
+          VERSION: ${{ needs.meta.outputs.version }}
+          REVISION: ${{ needs.meta.outputs.revision }}
         run: |
           docker build . --file "$DOCKERFILE" \
+            --build-arg "STATE_ACTOR_VERSION=${VERSION}" \
+            --build-arg "STATE_ACTOR_REVISION=${REVISION}" \
             --tag "${GHCR_REPO}:${PREFIX}-arm64" \
             --tag "${GHCR_REPO}:${PREFIX}-${SHA}-arm64" \
             --platform=linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN go mod download
 COPY . .
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o state-actor .
+ARG STATE_ACTOR_VERSION=dev
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X main.Version=${STATE_ACTOR_VERSION}" -o state-actor .
 
 # Runtime stage
 FROM alpine:3.19
@@ -22,6 +23,10 @@ LABEL org.opencontainers.image.title="State Actor"
 LABEL org.opencontainers.image.description="High-performance Ethereum state generator"
 LABEL org.opencontainers.image.source="https://github.com/ethereum/state-actor"
 LABEL org.opencontainers.image.licenses="MIT"
+ARG STATE_ACTOR_VERSION=dev
+ARG STATE_ACTOR_REVISION=
+LABEL org.opencontainers.image.version="${STATE_ACTOR_VERSION}"
+LABEL org.opencontainers.image.revision="${STATE_ACTOR_REVISION}"
 
 RUN apk add --no-cache ca-certificates
 

--- a/Dockerfile.besu
+++ b/Dockerfile.besu
@@ -99,10 +99,20 @@ RUN go mod download
 
 COPY . .
 
-RUN go build -tags cgo_besu -ldflags "-s -w" -o /out/state-actor .
+ARG STATE_ACTOR_VERSION=dev
+RUN go build -tags cgo_besu -ldflags "-s -w -X main.Version=${STATE_ACTOR_VERSION}" -o /out/state-actor .
 
 # ---------- Stage 2: minimal runtime image ----------
 FROM debian:bookworm-slim AS runtime
+
+ARG STATE_ACTOR_VERSION=dev
+ARG STATE_ACTOR_REVISION=
+LABEL org.opencontainers.image.title="State Actor (besu)" \
+      org.opencontainers.image.description="Ethereum state generator targeting --client=besu" \
+      org.opencontainers.image.source="https://github.com/ethereum/state-actor" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.version="${STATE_ACTOR_VERSION}" \
+      org.opencontainers.image.revision="${STATE_ACTOR_REVISION}"
 
 # Compression libs (rocksdb runtime links against these). RocksDB's own
 # .so comes from the builder stage. libgflags2.2 is a static transitive

--- a/Dockerfile.erigon
+++ b/Dockerfile.erigon
@@ -103,7 +103,8 @@ RUN go mod tidy -e
 # `-mod=mod` allows the build to fetch any remaining transitive deps
 # tidy could not resolve; in strict readonly mode an unresolved
 # transitive would re-trigger "updates to go.mod needed".
-RUN mkdir -p /out && go build -mod=mod -tags "cgo_erigon cgo_erigon_commitment gofuzz" -ldflags "-s -w" -o /out/state-actor ./
+ARG STATE_ACTOR_VERSION=dev
+RUN mkdir -p /out && go build -mod=mod -tags "cgo_erigon cgo_erigon_commitment gofuzz" -ldflags "-s -w -X main.Version=${STATE_ACTOR_VERSION}" -o /out/state-actor ./
 
 # Also build the erigon binary from /erigon-src (stock upstream, no
 # patches). The daemon launched by scripts/run-bloatnet.sh uses THIS
@@ -135,6 +136,15 @@ FROM erigontech/erigon@sha256:bac6b266367ec59f82576cd8cef047171601fce3f0bbbef36e
 
 # ---------- Stage 3: minimal runtime image ----------
 FROM debian:bookworm-slim AS runtime
+
+ARG STATE_ACTOR_VERSION=dev
+ARG STATE_ACTOR_REVISION=
+LABEL org.opencontainers.image.title="State Actor (erigon)" \
+      org.opencontainers.image.description="Ethereum state generator targeting --client=erigon" \
+      org.opencontainers.image.source="https://github.com/ethereum/state-actor" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.version="${STATE_ACTOR_VERSION}" \
+      org.opencontainers.image.revision="${STATE_ACTOR_REVISION}"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/Dockerfile.ethrex
+++ b/Dockerfile.ethrex
@@ -97,10 +97,20 @@ RUN go mod download
 
 COPY . .
 
-RUN go build -tags cgo_ethrex -ldflags "-s -w" -o /out/state-actor .
+ARG STATE_ACTOR_VERSION=dev
+RUN go build -tags cgo_ethrex -ldflags "-s -w -X main.Version=${STATE_ACTOR_VERSION}" -o /out/state-actor .
 
 # ---------- Stage 2: minimal runtime image ----------
 FROM debian:bookworm-slim AS runtime
+
+ARG STATE_ACTOR_VERSION=dev
+ARG STATE_ACTOR_REVISION=
+LABEL org.opencontainers.image.title="State Actor (ethrex)" \
+      org.opencontainers.image.description="Ethereum state generator targeting --client=ethrex" \
+      org.opencontainers.image.source="https://github.com/ethereum/state-actor" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.version="${STATE_ACTOR_VERSION}" \
+      org.opencontainers.image.revision="${STATE_ACTOR_REVISION}"
 
 # Compression libs (rocksdb runtime links against these). RocksDB's own
 # .so comes from the builder stage. libgflags2.2 is a static transitive

--- a/Dockerfile.geth
+++ b/Dockerfile.geth
@@ -32,7 +32,8 @@ COPY . .
 
 # Pure-Go build — no cgo, no rocksdb, no mdbx. The client/geth path is
 # self-contained on cockroachdb/pebble.
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-s -w" -o /out/state-actor .
+ARG STATE_ACTOR_VERSION=dev
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-s -w -X main.Version=${STATE_ACTOR_VERSION}" -o /out/state-actor .
 
 # ---------- Stage 2: minimal runtime image ----------
 FROM alpine:3.19
@@ -40,6 +41,11 @@ FROM alpine:3.19
 LABEL org.opencontainers.image.title="State Actor (geth)"
 LABEL org.opencontainers.image.description="Ethereum state generator targeting --client=geth (direct cockroachdb/pebble)"
 LABEL org.opencontainers.image.source="https://github.com/ethereum/state-actor"
+LABEL org.opencontainers.image.licenses="MIT"
+ARG STATE_ACTOR_VERSION=dev
+ARG STATE_ACTOR_REVISION=
+LABEL org.opencontainers.image.version="${STATE_ACTOR_VERSION}"
+LABEL org.opencontainers.image.revision="${STATE_ACTOR_REVISION}"
 
 # ca-certificates for HTTPS RPC; curl for the smoke target's RPC probes
 # (validate-big-db-geth.sh runs eth_chainId / eth_getBalance from inside

--- a/Dockerfile.nethermind
+++ b/Dockerfile.nethermind
@@ -81,10 +81,20 @@ RUN go mod download
 
 COPY . .
 
-RUN go build -tags cgo_neth -ldflags "-s -w" -o /out/state-actor .
+ARG STATE_ACTOR_VERSION=dev
+RUN go build -tags cgo_neth -ldflags "-s -w -X main.Version=${STATE_ACTOR_VERSION}" -o /out/state-actor .
 
 # ---------- Stage 2: minimal runtime image ----------
 FROM debian:bookworm-slim AS runtime
+
+ARG STATE_ACTOR_VERSION=dev
+ARG STATE_ACTOR_REVISION=
+LABEL org.opencontainers.image.title="State Actor (nethermind)" \
+      org.opencontainers.image.description="Ethereum state generator targeting --client=nethermind" \
+      org.opencontainers.image.source="https://github.com/ethereum/state-actor" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.version="${STATE_ACTOR_VERSION}" \
+      org.opencontainers.image.revision="${STATE_ACTOR_REVISION}"
 
 # Compression libs (rocksdb runtime links against these). RocksDB's own
 # .so comes from the builder stage.

--- a/Dockerfile.reth
+++ b/Dockerfile.reth
@@ -75,10 +75,20 @@ WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN mkdir -p /out && go build -tags cgo_reth -o /out/state-actor ./
+ARG STATE_ACTOR_VERSION=dev
+RUN mkdir -p /out && go build -tags cgo_reth -ldflags "-X main.Version=${STATE_ACTOR_VERSION}" -o /out/state-actor ./
 
 # ---------- Stage 2: minimal runtime image ----------
 FROM debian:bookworm-slim AS runtime
+
+ARG STATE_ACTOR_VERSION=dev
+ARG STATE_ACTOR_REVISION=
+LABEL org.opencontainers.image.title="State Actor (reth)" \
+      org.opencontainers.image.description="Ethereum state generator targeting --client=reth" \
+      org.opencontainers.image.source="https://github.com/ethereum/state-actor" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.version="${STATE_ACTOR_VERSION}" \
+      org.opencontainers.image.revision="${STATE_ACTOR_REVISION}"
 
 # Compression libs (rocksdb runtime links against these). RocksDB's own
 # .so comes from the builder stage.

--- a/Dockerfile.reth
+++ b/Dockerfile.reth
@@ -76,7 +76,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 ARG STATE_ACTOR_VERSION=dev
-RUN mkdir -p /out && go build -tags cgo_reth -ldflags "-X main.Version=${STATE_ACTOR_VERSION}" -o /out/state-actor ./
+RUN mkdir -p /out && go build -tags cgo_reth -ldflags "-s -w -X main.Version=${STATE_ACTOR_VERSION}" -o /out/state-actor ./
 
 # ---------- Stage 2: minimal runtime image ----------
 FROM debian:bookworm-slim AS runtime

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@
 # Binary name
 BINARY=state-actor
 VERSION?=$(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+REVISION?=$(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
 LDFLAGS=-ldflags "-X main.Version=$(VERSION)"
 
 # Go parameters
@@ -121,7 +122,7 @@ spamoor-install:
 
 ## docker-nethermind: Build the runtime image (state-actor + nethermind smoke)
 docker-nethermind:
-	docker build -f Dockerfile.nethermind -t state-actor-nethermind:latest -t state-actor-nethermind:$(VERSION) .
+	docker build -f Dockerfile.nethermind --build-arg STATE_ACTOR_VERSION=$(VERSION) --build-arg STATE_ACTOR_REVISION=$(REVISION) -t state-actor-nethermind:latest -t state-actor-nethermind:$(VERSION) .
 
 ## image-nethermind: Build the builder stage so we can run cgo_neth go tests inside it.
 ##   Used by test-nethermind-suite. Also reused by CI's per-job docker build.
@@ -175,7 +176,7 @@ smoke-nethermind-spamoor: docker-nethermind
 
 ## docker-besu: Build the runtime image (state-actor + besu smoke)
 docker-besu:
-	docker build -f Dockerfile.besu -t state-actor-besu:latest -t state-actor-besu:$(VERSION) .
+	docker build -f Dockerfile.besu --build-arg STATE_ACTOR_VERSION=$(VERSION) --build-arg STATE_ACTOR_REVISION=$(REVISION) -t state-actor-besu:latest -t state-actor-besu:$(VERSION) .
 
 ## image-besu: Build the builder stage so we can run cgo_besu go tests inside it.
 ##   Used by test-besu-suite. Also reused by CI's per-job docker build.
@@ -241,7 +242,7 @@ smoke-besu-spamoor: docker-besu
 
 ## docker-geth: Build the Geth-capable image (state-actor only; no cgo)
 docker-geth:
-	docker build -f Dockerfile.geth -t state-actor-geth:latest -t state-actor-geth:$(VERSION) .
+	docker build -f Dockerfile.geth --build-arg STATE_ACTOR_VERSION=$(VERSION) --build-arg STATE_ACTOR_REVISION=$(REVISION) -t state-actor-geth:latest -t state-actor-geth:$(VERSION) .
 
 ## smoke-geth: End-to-end smoke for the geth direct-Pebble MPT path.
 ##   Builds the state-actor-geth image, generates a small DB at $(SA_DB_GETH),
@@ -384,6 +385,8 @@ image-erigon:
 ##   which references `state-actor:$client`).
 docker-erigon:
 	docker build -f Dockerfile.erigon \
+	  --build-arg STATE_ACTOR_VERSION=$(VERSION) \
+	  --build-arg STATE_ACTOR_REVISION=$(REVISION) \
 	  -t state-actor-erigon:latest \
 	  -t state-actor-erigon:$(VERSION) \
 	  -t state-actor:erigon .

--- a/client/geth/genesis_json.go
+++ b/client/geth/genesis_json.go
@@ -60,6 +60,14 @@ func writeGenesisJSON(dbPath string, g *genesis.Genesis) (string, error) {
 	return outPath, nil
 }
 
+// DatadirRoot returns the geth datadir root for a given --db chaindata path
+// (<datadir>/geth/chaindata → <datadir>). Exported so callers that drop
+// sidecars at the datadir root (e.g. the run manifest) resolve the same
+// location as the geth-genesis.json sidecar.
+func DatadirRoot(dbPath string) string {
+	return gethDatadir(dbPath)
+}
+
 // gethDatadir derives the geth datadir root from the chaindata path. By
 // convention state-actor's --db ends in <datadir>/geth/chaindata, so the
 // datadir is two levels up. If dbPath does not follow that layout, the sidecar

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -127,6 +127,18 @@ cast balance 0x<a-known-spec-address> --rpc-url ... # → the spec's balance
 cast code    0x<a-known-spec-contract> --rpc-url ... # → the spec's bytecode
 ```
 
+### Reproduce a run from its manifest
+
+Every run drops a `state-actor-manifest.json` at the datadir root (two levels up from `--db` for geth; the `--db` dir itself for the other clients) recording everything needed to reproduce it: the resolved flags — note the **resolved** seed (`--seed=0` expands to a wall-clock seed) and the **resolved** fork (empty `--fork` resolves to the client's max) — the build version + git revision, the run's state root, and, when `--spec` is used, a content-addressed `state-actor-spec-<sha256>.yaml` sidecar written alongside it.
+
+Re-run it into a fresh directory with the `reproduce` subcommand:
+
+```bash
+go run . reproduce --manifest /tmp/sa-geth/state-actor-manifest.json --db /tmp/sa-geth-repro/geth/chaindata
+```
+
+It replays the manifest's resolved flags (reading any spec from the sidecar, not the original path), regenerates into `--db` (which must differ from the original), and verifies the new state root against the recorded one — exiting non-zero on mismatch. This works even for runs created with `--seed=0`, since the manifest captured the concrete seed.
+
 ### Reproduce a CI failure locally
 
 CI loads `examples/full-matrix-spec-feature.yaml` on top of `--seed=42 --target-size=100MB` (mirrored across all five `TestE2ESuite` constants). The auto-fill (mainnet-shaped 20 / 10 / 70 split) emits synthetic state to fill the headroom between the spec's projected cost and `--target-size` — the spec entities are written first, the auto-fill fills the gap. Re-run:

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -137,7 +137,7 @@ Re-run it into a fresh directory with the `reproduce` subcommand:
 go run . reproduce --manifest /tmp/sa-geth/state-actor-manifest.json --db /tmp/sa-geth-repro/geth/chaindata
 ```
 
-It replays the manifest's resolved flags (reading any spec from the sidecar, not the original path), regenerates into `--db` (which must differ from the original), and verifies the new state root against the recorded one — exiting non-zero on mismatch. This works even for runs created with `--seed=0`, since the manifest captured the concrete seed.
+It replays the manifest's resolved flags (reading any spec from the sidecar — whose sha256 is verified first — not the original path), regenerates into `--db` (which must be a **fresh, empty or nonexistent** directory, distinct from the original), and verifies the new state root against the recorded one — exiting non-zero on mismatch. This works even for runs created with `--seed=0`, since the manifest captured the concrete seed. The reproduced datadir gets its own manifest too, with a `reproduced_from` field pointing back at the source manifest.
 
 ### Reproduce a CI failure locally
 

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -26,13 +26,21 @@ const SchemaVersion = 1
 
 // Manifest is the full reproducibility record for one state-actor run.
 type Manifest struct {
-	SchemaVersion int       `json:"schema_version"`
-	StateActor    Build     `json:"state_actor"`
-	GeneratedAt   string    `json:"generated_at"`
-	Command       []string  `json:"command"`
-	Flags         Flags     `json:"flags"`
-	Spec          *SpecFile `json:"spec,omitempty"`
-	Result        *Result   `json:"result,omitempty"`
+	SchemaVersion int    `json:"schema_version"`
+	StateActor    Build  `json:"state_actor"`
+	GeneratedAt   string `json:"generated_at"`
+	// Command is os.Args as the process was invoked. argv[0] is the launcher
+	// path (e.g. a go-run temp binary or ./state-actor), not a canonicalized
+	// program name.
+	Command []string  `json:"command"`
+	Flags   Flags     `json:"flags"`
+	Spec    *SpecFile `json:"spec,omitempty"`
+	Result  *Result   `json:"result,omitempty"`
+	// ReproducedFrom is set when this run was produced by the `reproduce`
+	// subcommand; it holds the manifest path that was replayed. Empty for an
+	// original run. (Command stays the literal reproduce invocation, so this is
+	// what links a reproduced datadir back to its source manifest.)
+	ReproducedFrom string `json:"reproduced_from,omitempty"`
 }
 
 // Build identifies the binary that produced the run. Version comes from the
@@ -46,7 +54,9 @@ type Build struct {
 	Arch        string `json:"arch"`
 	VCSRevision string `json:"vcs_revision,omitempty"`
 	VCSTime     string `json:"vcs_time,omitempty"`
-	VCSModified bool   `json:"vcs_modified,omitempty"`
+	// VCSModified is emitted even when false: for a provenance record, "built
+	// from a clean tree" (false) must be distinguishable from "unknown".
+	VCSModified bool `json:"vcs_modified"`
 }
 
 // Flags is the resolved configuration. Seed and Fork hold the values actually
@@ -86,13 +96,14 @@ type SpecFile struct {
 const SpecFilePrefix = "state-actor-spec-"
 
 // Result records the run's output for verification: a reproduction should
-// land on the same StateRoot.
+// land on the same StateRoot. The counters are always emitted (no omitempty)
+// so a legitimate zero is distinguishable from an omitted field.
 type Result struct {
 	StateRoot        string `json:"state_root"`
 	AccountsCreated  uint64 `json:"accounts_created"`
 	ContractsCreated uint64 `json:"contracts_created"`
-	StorageSlots     uint64 `json:"storage_slots,omitempty"`
-	TotalDBSizeBytes uint64 `json:"total_db_size_bytes,omitempty"`
+	StorageSlots     uint64 `json:"storage_slots"`
+	TotalDBSizeBytes uint64 `json:"total_db_size_bytes"`
 	ElapsedMS        int64  `json:"elapsed_ms"`
 }
 
@@ -122,10 +133,12 @@ func NewBuild(version string) Build {
 
 // resolveVersion picks the version string. An explicit -X main.Version (e.g. a
 // release tag passed via the Docker build-arg) always wins. Otherwise it falls
-// back to the short commit that Go automatically embeds when building from a
-// git checkout — so `go run` and Docker builds without the build-arg still
-// record a meaningful, reproducible version (the .git is in the build context).
-// Only when there is no VCS info at all does it report "dev".
+// back to the short commit that Go automatically embeds for `go build` /
+// `go install` from a git checkout — so Docker builds without the build-arg
+// still record a meaningful, reproducible version (the .git is in the build
+// context and git is installed in the builder images). Note: `go run` does NOT
+// embed VCS info, so an un-stamped `go run` reports "dev"; likewise when there
+// is no VCS info at all.
 func resolveVersion(version, revision string, modified bool) string {
 	if version != "" && version != "dev" {
 		return version
@@ -168,6 +181,24 @@ func WriteSpecSidecar(dir, inputPath string) (*SpecFile, error) {
 	}, nil
 }
 
+// Verify recomputes the sha256 of the sidecar file (OutputFile, located in dir)
+// and checks it against the recorded SHA256. This guards a reproduction against
+// a tampered or corrupted spec sidecar before it is replayed: without it, a
+// changed sidecar would silently alter the reproduced state and surface only as
+// a confusing state-root mismatch.
+func (s *SpecFile) Verify(dir string) error {
+	path := filepath.Join(dir, s.OutputFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("manifest: read spec sidecar %q: %w", path, err)
+	}
+	sum := sha256.Sum256(data)
+	if got := hex.EncodeToString(sum[:]); got != s.SHA256 {
+		return fmt.Errorf("manifest: spec sidecar %q sha256 mismatch: recorded %s, got %s", path, s.SHA256, got)
+	}
+	return nil
+}
+
 // Load reads and parses a manifest JSON file (used by the reproduce path).
 func Load(path string) (*Manifest, error) {
 	data, err := os.ReadFile(path)
@@ -177,6 +208,12 @@ func Load(path string) (*Manifest, error) {
 	var m Manifest
 	if err := json.Unmarshal(data, &m); err != nil {
 		return nil, fmt.Errorf("manifest: parse %q: %w", path, err)
+	}
+	// Refuse a schema this binary cannot safely consume: a newer (breaking)
+	// schema may rename/move fields we'd otherwise silently read as zero, and a
+	// missing/zero version means the file is not a v1 manifest at all.
+	if m.SchemaVersion == 0 || m.SchemaVersion > SchemaVersion {
+		return nil, fmt.Errorf("manifest: unsupported schema_version %d in %q (this binary supports %d)", m.SchemaVersion, path, SchemaVersion)
 	}
 	return &m, nil
 }

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -168,6 +168,19 @@ func WriteSpecSidecar(dir, inputPath string) (*SpecFile, error) {
 	}, nil
 }
 
+// Load reads and parses a manifest JSON file (used by the reproduce path).
+func Load(path string) (*Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("manifest: read %q: %w", path, err)
+	}
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("manifest: parse %q: %w", path, err)
+	}
+	return &m, nil
+}
+
 // Write marshals the manifest and writes it to <dir>/state-actor-manifest.json,
 // returning the path written.
 func (m *Manifest) Write(dir string) (string, error) {

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -1,0 +1,183 @@
+// Package manifest writes a state-actor-manifest.json into a generated
+// datadir capturing everything needed to reproduce the run: the exact
+// command, the resolved flags (note: the *resolved* seed and fork, not the
+// raw inputs — see Flags), any embedded --spec config, the state-actor
+// build, and the run's result. It is a leaf package: it imports only the
+// standard library so any caller can populate and write it.
+package manifest
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/debug"
+)
+
+// FileName is the manifest dropped at the datadir root.
+const FileName = "state-actor-manifest.json"
+
+// SchemaVersion is bumped on any breaking change to the manifest shape so
+// consumers can detect format drift.
+const SchemaVersion = 1
+
+// Manifest is the full reproducibility record for one state-actor run.
+type Manifest struct {
+	SchemaVersion int       `json:"schema_version"`
+	StateActor    Build     `json:"state_actor"`
+	GeneratedAt   string    `json:"generated_at"`
+	Command       []string  `json:"command"`
+	Flags         Flags     `json:"flags"`
+	Spec          *SpecFile `json:"spec,omitempty"`
+	Result        *Result   `json:"result,omitempty"`
+}
+
+// Build identifies the binary that produced the run. Version comes from the
+// -X main.Version ldflag; the VCS fields and GoVersion come from the embedded
+// build info, so a binary built outside the Makefile (e.g. inside a client
+// Docker image) still records its provenance when built from a VCS checkout.
+type Build struct {
+	Version     string `json:"version"`
+	GoVersion   string `json:"go_version"`
+	OS          string `json:"os"`
+	Arch        string `json:"arch"`
+	VCSRevision string `json:"vcs_revision,omitempty"`
+	VCSTime     string `json:"vcs_time,omitempty"`
+	VCSModified bool   `json:"vcs_modified,omitempty"`
+}
+
+// Flags is the resolved configuration. Seed and Fork hold the values actually
+// used, which may differ from the command line: --seed=0 expands to a
+// wall-clock seed, and an empty --fork resolves to the client's maximum fork.
+// ForkInput / SeedInput preserve what the user passed for auditing.
+type Flags struct {
+	Client     string `json:"client"`
+	DB         string `json:"db"`
+	Seed       int64  `json:"seed"`
+	SeedInput  int64  `json:"seed_input"`
+	Fork       string `json:"fork"`
+	ForkInput  string `json:"fork_input"`
+	ChainID    int64  `json:"chain_id"`
+	GasLimit   uint64 `json:"gas_limit"`
+	Timestamp  uint64 `json:"timestamp"`
+	ExtraData  string `json:"extra_data,omitempty"`
+	TargetSize string `json:"target_size,omitempty"`
+	BinaryTrie bool   `json:"binary_trie"`
+	GroupDepth int    `json:"group_depth"`
+	Archive    bool   `json:"archive"`
+	SpecPath   string `json:"spec_path,omitempty"`
+}
+
+// SpecFile references the --spec config used for the run. The raw spec is
+// written verbatim to a content-addressed sidecar (OutputFile) next to the
+// manifest rather than inlined, so the manifest stays readable and the spec is
+// directly reusable: --spec=<OutputFile>. SHA256 names the sidecar and lets a
+// consumer verify it. InputPath records the original --spec path for auditing.
+type SpecFile struct {
+	InputPath  string `json:"input_path"`
+	SHA256     string `json:"sha256"`
+	OutputFile string `json:"output_file"`
+}
+
+// SpecFilePrefix + <sha256> + ".yaml" is the content-addressed sidecar name.
+const SpecFilePrefix = "state-actor-spec-"
+
+// Result records the run's output for verification: a reproduction should
+// land on the same StateRoot.
+type Result struct {
+	StateRoot        string `json:"state_root"`
+	AccountsCreated  uint64 `json:"accounts_created"`
+	ContractsCreated uint64 `json:"contracts_created"`
+	StorageSlots     uint64 `json:"storage_slots,omitempty"`
+	TotalDBSizeBytes uint64 `json:"total_db_size_bytes,omitempty"`
+	ElapsedMS        int64  `json:"elapsed_ms"`
+}
+
+// NewBuild assembles the Build record from the linked-in version and the
+// embedded build info.
+func NewBuild(version string) Build {
+	b := Build{
+		GoVersion: runtime.Version(),
+		OS:        runtime.GOOS,
+		Arch:      runtime.GOARCH,
+	}
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, s := range info.Settings {
+			switch s.Key {
+			case "vcs.revision":
+				b.VCSRevision = s.Value
+			case "vcs.time":
+				b.VCSTime = s.Value
+			case "vcs.modified":
+				b.VCSModified = s.Value == "true"
+			}
+		}
+	}
+	b.Version = resolveVersion(version, b.VCSRevision, b.VCSModified)
+	return b
+}
+
+// resolveVersion picks the version string. An explicit -X main.Version (e.g. a
+// release tag passed via the Docker build-arg) always wins. Otherwise it falls
+// back to the short commit that Go automatically embeds when building from a
+// git checkout — so `go run` and Docker builds without the build-arg still
+// record a meaningful, reproducible version (the .git is in the build context).
+// Only when there is no VCS info at all does it report "dev".
+func resolveVersion(version, revision string, modified bool) string {
+	if version != "" && version != "dev" {
+		return version
+	}
+	if revision != "" {
+		short := revision
+		if len(short) > 12 {
+			short = short[:12]
+		}
+		if modified {
+			short += "-dirty"
+		}
+		return short
+	}
+	return "dev"
+}
+
+// WriteSpecSidecar reads the --spec file at inputPath, writes it verbatim to a
+// content-addressed sidecar (<dir>/state-actor-spec-<sha256>.yaml), and returns
+// a SpecFile referencing it. Returns nil when inputPath is empty (no --spec).
+// The sidecar is byte-identical to the input so its sha matches the filename.
+func WriteSpecSidecar(dir, inputPath string) (*SpecFile, error) {
+	if inputPath == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(inputPath)
+	if err != nil {
+		return nil, fmt.Errorf("manifest: read spec %q: %w", inputPath, err)
+	}
+	sum := sha256.Sum256(data)
+	hexSum := hex.EncodeToString(sum[:])
+	outFile := SpecFilePrefix + hexSum + ".yaml"
+	if err := os.WriteFile(filepath.Join(dir, outFile), data, 0o644); err != nil {
+		return nil, fmt.Errorf("manifest: write spec sidecar: %w", err)
+	}
+	return &SpecFile{
+		InputPath:  inputPath,
+		SHA256:     hexSum,
+		OutputFile: outFile,
+	}, nil
+}
+
+// Write marshals the manifest and writes it to <dir>/state-actor-manifest.json,
+// returning the path written.
+func (m *Manifest) Write(dir string) (string, error) {
+	out, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("manifest: marshal: %w", err)
+	}
+	outPath := filepath.Join(dir, FileName)
+	if err := os.WriteFile(outPath, append(out, '\n'), 0o644); err != nil {
+		return "", fmt.Errorf("manifest: write %q: %w", outPath, err)
+	}
+	return outPath, nil
+}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -78,6 +78,32 @@ func TestWriteSpecSidecarMissingFile(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestWriteThenLoad(t *testing.T) {
+	dir := t.TempDir()
+	m := &Manifest{
+		SchemaVersion: SchemaVersion,
+		StateActor:    NewBuild("v7"),
+		Command:       []string{"state-actor", "--client", "reth"},
+		Flags:         Flags{Client: "reth", Seed: 99, Fork: "prague"},
+		Result:        &Result{StateRoot: "0xdead"},
+	}
+	path, err := m.Write(dir)
+	require.NoError(t, err)
+
+	got, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, "v7", got.StateActor.Version)
+	assert.Equal(t, "reth", got.Flags.Client)
+	assert.Equal(t, int64(99), got.Flags.Seed)
+	assert.Equal(t, "prague", got.Flags.Fork)
+	assert.Equal(t, "0xdead", got.Result.StateRoot)
+}
+
+func TestLoadMissingFile(t *testing.T) {
+	_, err := Load(filepath.Join(t.TempDir(), "nope.json"))
+	assert.Error(t, err)
+}
+
 func TestWriteRoundTrips(t *testing.T) {
 	dir := t.TempDir()
 	m := &Manifest{

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"testing"
 
@@ -143,4 +144,97 @@ func TestWriteRoundTrips(t *testing.T) {
 	assert.Equal(t, "0xabc", got.Result.StateRoot)
 	// Spec omitted → must not appear.
 	assert.NotContains(t, string(data), "\"spec\"")
+}
+
+// TestLoadRejectsUnsupportedSchema pins the schema-compatibility guard in Load:
+// a missing/zero version (not a v1 manifest) and a newer version (potentially
+// breaking) must both be refused rather than silently mis-read.
+func TestLoadRejectsUnsupportedSchema(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, body string) string {
+		p := filepath.Join(dir, name)
+		require.NoError(t, os.WriteFile(p, []byte(body), 0o644))
+		return p
+	}
+
+	// schema_version 0 / missing.
+	_, err := Load(write("zero.json", `{"schema_version":0}`))
+	assert.Error(t, err)
+	_, err = Load(write("missing.json", `{"command":["state-actor"]}`))
+	assert.Error(t, err)
+
+	// schema_version newer than this binary supports.
+	_, err = Load(write("future.json", `{"schema_version":999}`))
+	assert.Error(t, err)
+
+	// Current schema loads fine.
+	p, err := (&Manifest{SchemaVersion: SchemaVersion, StateActor: NewBuild("v1"), Result: &Result{StateRoot: "0x1"}}).Write(dir)
+	require.NoError(t, err)
+	_, err = Load(p)
+	assert.NoError(t, err)
+}
+
+// TestSpecFileVerify covers the content-address check used before a reproduce
+// replays a spec sidecar: the matching file passes, a tampered file and a
+// missing file both error.
+func TestSpecFileVerify(t *testing.T) {
+	srcDir, outDir := t.TempDir(), t.TempDir()
+	inputPath := filepath.Join(srcDir, "spec.yaml")
+	require.NoError(t, os.WriteFile(inputPath, []byte("entities:\n  - kind: eoa\n"), 0o644))
+
+	s, err := WriteSpecSidecar(outDir, inputPath)
+	require.NoError(t, err)
+	require.NotNil(t, s)
+
+	// Matching sidecar verifies.
+	require.NoError(t, s.Verify(outDir))
+
+	// Tampered sidecar fails.
+	require.NoError(t, os.WriteFile(filepath.Join(outDir, s.OutputFile), []byte("tampered\n"), 0o644))
+	assert.Error(t, s.Verify(outDir))
+
+	// Missing sidecar fails.
+	require.NoError(t, os.Remove(filepath.Join(outDir, s.OutputFile)))
+	assert.Error(t, s.Verify(outDir))
+}
+
+// TestManifestFlagsRoundTripAllFields is the drift guard for Flags: every field
+// is set to a distinct non-zero value and must survive Write→Load unchanged.
+// The reflection sweep fails if a newly added Flags field is left unset here,
+// forcing whoever adds it to also confirm reproduce() restores it (otherwise a
+// new state-affecting flag would silently break reproducibility).
+func TestManifestFlagsRoundTripAllFields(t *testing.T) {
+	flags := Flags{
+		Client:     "geth",
+		DB:         "/data/geth/chaindata",
+		Seed:       42,
+		SeedInput:  7,
+		Fork:       "osaka",
+		ForkInput:  "prague",
+		ChainID:    1337,
+		GasLimit:   30_000_000,
+		Timestamp:  1_700_000_000,
+		ExtraData:  "0xdeadbeef",
+		TargetSize: "2GB",
+		BinaryTrie: true,
+		GroupDepth: 8,
+		Archive:    true,
+		SpecPath:   "/in/spec.yaml",
+	}
+	rv := reflect.ValueOf(flags)
+	for i := range rv.NumField() {
+		if rv.Field(i).IsZero() {
+			t.Fatalf("Flags.%s is zero in this fixture — set it, and make sure reproduce() restores it from the manifest",
+				rv.Type().Field(i).Name)
+		}
+	}
+
+	dir := t.TempDir()
+	m := &Manifest{SchemaVersion: SchemaVersion, StateActor: NewBuild("v1"), Flags: flags, Result: &Result{StateRoot: "0x1"}}
+	path, err := m.Write(dir)
+	require.NoError(t, err)
+
+	got, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, flags, got.Flags)
 }

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -1,0 +1,120 @@
+package manifest
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewBuildRecordsRuntime(t *testing.T) {
+	b := NewBuild("v1.2.3")
+	assert.Equal(t, "v1.2.3", b.Version) // explicit version always wins
+	assert.Equal(t, runtime.Version(), b.GoVersion)
+	assert.Equal(t, runtime.GOOS, b.OS)
+	assert.Equal(t, runtime.GOARCH, b.Arch)
+}
+
+func TestResolveVersion(t *testing.T) {
+	cases := []struct {
+		name     string
+		version  string
+		revision string
+		modified bool
+		want     string
+	}{
+		{"explicit tag wins", "v1.2.3", "a2099cf6dc853cea", false, "v1.2.3"},
+		{"explicit wins over dirty vcs", "v1.2.3", "a2099cf6dc853cea", true, "v1.2.3"},
+		{"fallback short sha", "", "abcdef0123456789", false, "abcdef012345"},
+		{"fallback short sha dirty", "dev", "a2099cf6dc853cea", true, "a2099cf6dc85-dirty"},
+		{"no version no vcs", "", "", false, "dev"},
+		{"dev no vcs", "dev", "", false, "dev"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, resolveVersion(c.version, c.revision, c.modified))
+		})
+	}
+}
+
+func TestWriteSpecSidecarEmptyPath(t *testing.T) {
+	s, err := WriteSpecSidecar(t.TempDir(), "")
+	require.NoError(t, err)
+	assert.Nil(t, s)
+}
+
+func TestWriteSpecSidecarWritesContentAddressedFile(t *testing.T) {
+	srcDir := t.TempDir()
+	outDir := t.TempDir()
+	inputPath := filepath.Join(srcDir, "spec.yaml")
+	content := []byte("entities:\n  - kind: eoa\n")
+	require.NoError(t, os.WriteFile(inputPath, content, 0o644))
+
+	s, err := WriteSpecSidecar(outDir, inputPath)
+	require.NoError(t, err)
+	require.NotNil(t, s)
+
+	want := sha256.Sum256(content)
+	wantHex := hex.EncodeToString(want[:])
+	assert.Equal(t, inputPath, s.InputPath)
+	assert.Equal(t, wantHex, s.SHA256)
+	assert.Equal(t, SpecFilePrefix+wantHex+".yaml", s.OutputFile)
+
+	// Sidecar is written verbatim next to the manifest (bare relative name).
+	assert.NotContains(t, s.OutputFile, "/")
+	written, err := os.ReadFile(filepath.Join(outDir, s.OutputFile))
+	require.NoError(t, err)
+	assert.Equal(t, content, written)
+}
+
+func TestWriteSpecSidecarMissingFile(t *testing.T) {
+	_, err := WriteSpecSidecar(t.TempDir(), filepath.Join(t.TempDir(), "nope.yaml"))
+	assert.Error(t, err)
+}
+
+func TestWriteRoundTrips(t *testing.T) {
+	dir := t.TempDir()
+	m := &Manifest{
+		SchemaVersion: SchemaVersion,
+		StateActor:    NewBuild("v9"),
+		GeneratedAt:   "2026-06-25T10:00:00Z",
+		Command:       []string{"state-actor", "--client", "geth"},
+		Flags: Flags{
+			Client:    "geth",
+			DB:        "/tmp/x/geth/chaindata",
+			Seed:      42,
+			SeedInput: 0,
+			Fork:      "osaka",
+			ChainID:   1337,
+			GasLimit:  30_000_000,
+		},
+		Result: &Result{
+			StateRoot:       "0xabc",
+			AccountsCreated: 10,
+			ElapsedMS:       1234,
+		},
+	}
+
+	path, err := m.Write(dir)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(dir, FileName), path)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var got Manifest
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, SchemaVersion, got.SchemaVersion)
+	assert.Equal(t, int64(42), got.Flags.Seed)
+	assert.Equal(t, int64(0), got.Flags.SeedInput)
+	assert.Equal(t, "osaka", got.Flags.Fork)
+	assert.Equal(t, "0xabc", got.Result.StateRoot)
+	// Spec omitted → must not appear.
+	assert.NotContains(t, string(data), "\"spec\"")
+}

--- a/main.go
+++ b/main.go
@@ -69,6 +69,13 @@ var (
 )
 
 func main() {
+	// Subcommands are dispatched on the first positional arg before the global
+	// flags are parsed. `reproduce` regenerates a run from its manifest.
+	if len(os.Args) >= 2 && os.Args[1] == "reproduce" {
+		reproduce(os.Args[2:])
+		return
+	}
+
 	flag.Parse()
 
 	if *listForks {
@@ -91,6 +98,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	generate()
+}
+
+// generate runs the full state-generation pipeline from the resolved global
+// flags, prints the summary, writes the manifest, and returns the run stats.
+// Shared by the default command and the `reproduce` subcommand, which populates
+// the same globals from a manifest before calling it.
+func generate() *generator.Stats {
 	// seedInput preserves the raw --seed for the manifest; *seed below is
 	// resolved to a concrete value (wall-clock when 0) and is what actually
 	// reproduces the run.
@@ -453,6 +468,93 @@ func main() {
 			fmt.Printf("  Contract #%d: %s\n", i+1, addr.Hex())
 		}
 	}
+
+	return stats
+}
+
+// reproduce regenerates a prior run from its state-actor-manifest.json into a
+// fresh --db, then verifies the resulting state root against the manifest
+// (exiting non-zero on mismatch). It populates the same global flags the
+// default command uses, so generation goes through the identical pipeline.
+func reproduce(args []string) {
+	fs := flag.NewFlagSet("reproduce", flag.ExitOnError)
+	manifestPath := fs.String("manifest", "", "Path to the state-actor-manifest.json to reproduce (required)")
+	outDB := fs.String("db", "", "Output database directory for the reproduced run (required; must differ from the original)")
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "Usage: state-actor reproduce --manifest <manifest.json> --db <new-output-dir>")
+		fs.PrintDefaults()
+	}
+	_ = fs.Parse(args)
+
+	if *manifestPath == "" || *outDB == "" {
+		fs.Usage()
+		os.Exit(1)
+	}
+
+	m, err := manifest.Load(*manifestPath)
+	if err != nil {
+		log.Fatalf("reproduce: %v", err)
+	}
+
+	if m.StateActor.Version != Version {
+		log.Printf("warning: manifest was produced by state-actor %q but this binary is %q; reproduction may differ",
+			m.StateActor.Version, Version)
+	}
+
+	// Never clobber the original datadir.
+	if samePath(*outDB, m.Flags.DB) {
+		log.Fatalf("reproduce: --db %q is the manifest's original datadir; choose a different output directory", *outDB)
+	}
+
+	// Populate the generation globals from the manifest's RESOLVED flags. The
+	// concrete seed + fork are what make the run deterministic regardless of
+	// when or where it is reproduced.
+	*client = m.Flags.Client
+	*seed = m.Flags.Seed
+	*fork = m.Flags.Fork
+	*chainID = m.Flags.ChainID
+	*gasLimit = m.Flags.GasLimit
+	*timestamp = m.Flags.Timestamp
+	*extraData = m.Flags.ExtraData
+	*targetSize = m.Flags.TargetSize
+	*binaryTrie = m.Flags.BinaryTrie
+	*groupDepth = m.Flags.GroupDepth
+	*archive = m.Flags.Archive
+	*dbPath = *outDB
+
+	// Reproduce from the content-addressed spec sidecar next to the manifest —
+	// guaranteed present and hash-named, unlike the original input path which
+	// may not exist on this machine.
+	if m.Spec != nil {
+		*specFile = filepath.Join(filepath.Dir(*manifestPath), m.Spec.OutputFile)
+	}
+
+	fmt.Printf("Reproducing run from %s\n", *manifestPath)
+	fmt.Printf("  client=%s seed=%d fork=%s → %s\n\n", *client, *seed, *fork, *dbPath)
+
+	stats := generate()
+
+	// Fail-on-mismatch verification against the recorded state root.
+	if m.Result != nil && m.Result.StateRoot != "" {
+		got := stats.StateRoot.Hex()
+		if got == m.Result.StateRoot {
+			fmt.Printf("\nReproduction: PASS — state root matches %s\n", got)
+			return
+		}
+		fmt.Printf("\nReproduction: MISMATCH\n  expected: %s\n  got:      %s\n", m.Result.StateRoot, got)
+		os.Exit(1)
+	}
+	fmt.Printf("\nReproduction: complete (manifest recorded no state root to verify against)\n")
+}
+
+// samePath reports whether a and b resolve to the same filesystem location.
+func samePath(a, b string) bool {
+	aa, err1 := filepath.Abs(a)
+	bb, err2 := filepath.Abs(b)
+	if err1 != nil || err2 != nil {
+		return filepath.Clean(a) == filepath.Clean(b)
+	}
+	return aa == bb
 }
 
 func formatBytes(b uint64) string {

--- a/main.go
+++ b/main.go
@@ -98,14 +98,24 @@ func main() {
 		os.Exit(1)
 	}
 
-	generate()
+	generate("")
 }
 
 // generate runs the full state-generation pipeline from the resolved global
 // flags, prints the summary, writes the manifest, and returns the run stats.
 // Shared by the default command and the `reproduce` subcommand, which populates
-// the same globals from a manifest before calling it.
-func generate() *generator.Stats {
+// the same globals from a manifest before calling it. reproducedFrom is the
+// source manifest path when invoked via `reproduce` (recorded in the new
+// manifest's reproduced_from), and "" for an original run.
+func generate(reproducedFrom string) *generator.Stats {
+	// Defense-in-depth: main() enforces this for the default command, but
+	// reproduce() calls generate() directly. With neither --spec nor
+	// --target-size there is nothing to emit but the injected system contracts
+	// — a degenerate state that the empty-state guard in Config.Validate does
+	// NOT catch (those contracts populate GenesisAccounts). Fail loudly instead.
+	if *specFile == "" && *targetSize == "" {
+		log.Fatalf("generate: neither --spec nor --target-size is set; nothing to generate")
+	}
 	// seedInput preserves the raw --seed for the manifest; *seed below is
 	// resolved to a concrete value (wall-clock when 0) and is what actually
 	// reproduces the run.
@@ -397,7 +407,11 @@ func generate() *generator.Stats {
 	// run into a non-zero exit.
 	specFileEntry, err := manifest.WriteSpecSidecar(manifestDir, *specFile)
 	if err != nil {
-		log.Printf("warning: manifest spec sidecar failed: %v", err)
+		// Non-fatal (the DB is valid), but a failed sidecar on a --spec run
+		// means reproduce() — which reads the spec from the sidecar, not the
+		// original path — cannot regenerate this run. Warn unmistakably.
+		log.Printf("WARNING: manifest spec sidecar failed: %v\n"+
+			"         this run is NOT reproducible from its manifest (the --spec sidecar is missing)", err)
 	}
 	man := &manifest.Manifest{
 		SchemaVersion: manifest.SchemaVersion,
@@ -429,6 +443,7 @@ func generate() *generator.Stats {
 			StorageSlots:     uint64(stats.StorageSlotsCreated),
 			ElapsedMS:        elapsed.Milliseconds(),
 		},
+		ReproducedFrom: reproducedFrom,
 	}
 	if dbSizeErr == nil {
 		man.Result.TotalDBSizeBytes = dbSize
@@ -482,6 +497,7 @@ func reproduce(args []string) {
 	outDB := fs.String("db", "", "Output database directory for the reproduced run (required; must differ from the original)")
 	fs.Usage = func() {
 		fmt.Fprintln(os.Stderr, "Usage: state-actor reproduce --manifest <manifest.json> --db <new-output-dir>")
+		fmt.Fprintln(os.Stderr, "Flags must follow the 'reproduce' subcommand.")
 		fs.PrintDefaults()
 	}
 	_ = fs.Parse(args)
@@ -496,14 +512,31 @@ func reproduce(args []string) {
 		log.Fatalf("reproduce: %v", err)
 	}
 
-	if m.StateActor.Version != Version {
+	// Compare the manifest's RESOLVED version against this binary's resolved
+	// version — NewBuild applies the same go-build VCS fallback that produced
+	// the recorded value, so an identical binary doesn't spuriously warn (the
+	// raw Version var is "dev" for any un-stamped go build).
+	localVersion := manifest.NewBuild(Version).Version
+	if m.StateActor.Version != localVersion {
 		log.Printf("warning: manifest was produced by state-actor %q but this binary is %q; reproduction may differ",
-			m.StateActor.Version, Version)
+			m.StateActor.Version, localVersion)
+	}
+
+	// A --spec run whose sidecar failed to write (a warning at generation time)
+	// records SpecPath but no Spec entry: it cannot be reproduced. Refuse
+	// clearly rather than regenerating a spec-less (wrong) state → MISMATCH.
+	if m.Spec == nil && m.Flags.SpecPath != "" {
+		log.Fatalf("reproduce: manifest references --spec %q but has no spec sidecar (the original run failed to write it); this manifest is not reproducible", m.Flags.SpecPath)
 	}
 
 	// Never clobber the original datadir.
 	if samePath(*outDB, m.Flags.DB) {
 		log.Fatalf("reproduce: --db %q is the manifest's original datadir; choose a different output directory", *outDB)
+	}
+	// Require a fresh output dir: refuse a pre-existing non-empty directory so a
+	// reproduction can't interleave with or overwrite unrelated client state.
+	if dirExistsNonEmpty(*outDB) {
+		log.Fatalf("reproduce: --db %q must be a fresh (empty or nonexistent) directory", *outDB)
 	}
 
 	// Populate the generation globals from the manifest's RESOLVED flags. The
@@ -524,27 +557,34 @@ func reproduce(args []string) {
 
 	// Reproduce from the content-addressed spec sidecar next to the manifest —
 	// guaranteed present and hash-named, unlike the original input path which
-	// may not exist on this machine.
+	// may not exist on this machine. Verify its sha256 first so a tampered or
+	// corrupted sidecar fails fast instead of silently changing the result.
+	manifestRoot := filepath.Dir(*manifestPath)
 	if m.Spec != nil {
-		*specFile = filepath.Join(filepath.Dir(*manifestPath), m.Spec.OutputFile)
+		if err := m.Spec.Verify(manifestRoot); err != nil {
+			log.Fatalf("reproduce: %v", err)
+		}
+		*specFile = filepath.Join(manifestRoot, m.Spec.OutputFile)
 	}
 
 	fmt.Printf("Reproducing run from %s\n", *manifestPath)
 	fmt.Printf("  client=%s seed=%d fork=%s → %s\n\n", *client, *seed, *fork, *dbPath)
 
-	stats := generate()
+	stats := generate(*manifestPath)
 
-	// Fail-on-mismatch verification against the recorded state root.
-	if m.Result != nil && m.Result.StateRoot != "" {
-		got := stats.StateRoot.Hex()
-		if got == m.Result.StateRoot {
-			fmt.Printf("\nReproduction: PASS — state root matches %s\n", got)
-			return
-		}
-		fmt.Printf("\nReproduction: MISMATCH\n  expected: %s\n  got:      %s\n", m.Result.StateRoot, got)
-		os.Exit(1)
+	// Fail-on-mismatch verification against the recorded state root. A valid
+	// (schema-checked) manifest always records one; its absence means a corrupt
+	// or hand-edited file, which must not silently pass a verification command.
+	if m.Result == nil || m.Result.StateRoot == "" {
+		log.Fatalf("reproduce: manifest recorded no state root to verify against (corrupt manifest?)")
 	}
-	fmt.Printf("\nReproduction: complete (manifest recorded no state root to verify against)\n")
+	got := stats.StateRoot.Hex()
+	if got == m.Result.StateRoot {
+		fmt.Printf("\nReproduction: PASS — state root matches %s\n", got)
+		return
+	}
+	fmt.Printf("\nReproduction: MISMATCH\n  expected: %s\n  got:      %s\n", m.Result.StateRoot, got)
+	os.Exit(1)
 }
 
 // samePath reports whether a and b resolve to the same filesystem location.
@@ -555,6 +595,17 @@ func samePath(a, b string) bool {
 		return filepath.Clean(a) == filepath.Clean(b)
 	}
 	return aa == bb
+}
+
+// dirExistsNonEmpty reports whether path is an existing directory with at least
+// one entry. A nonexistent path, an empty directory, or an unreadable/non-dir
+// path all report false (treated as "not an obstacle" for a fresh reproduce).
+func dirExistsNonEmpty(path string) bool {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return false
+	}
+	return len(entries) > 0
 }
 
 func formatBytes(b uint64) string {

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum/state-actor/genesis"
 	"github.com/ethereum/state-actor/internal/autofill"
 	"github.com/ethereum/state-actor/internal/clientpolicy"
+	"github.com/ethereum/state-actor/internal/manifest"
 	"github.com/ethereum/state-actor/internal/progress"
 	"github.com/ethereum/state-actor/internal/sizecal"
 	"github.com/ethereum/state-actor/internal/spec"
@@ -33,6 +34,11 @@ import (
 	"github.com/ethereum/state-actor/internal/syscontracts"
 	"github.com/ethereum/state-actor/internal/templates"
 )
+
+// Version is the state-actor build version, injected via
+// -ldflags "-X main.Version=..." (see Makefile). Defaults to "dev" for
+// `go run` / un-stamped builds. Recorded in the run manifest.
+var Version = "dev"
 
 var (
 	dbPath     = flag.String("db", "", "Path to the database directory (required)")
@@ -85,6 +91,10 @@ func main() {
 		os.Exit(1)
 	}
 
+	// seedInput preserves the raw --seed for the manifest; *seed below is
+	// resolved to a concrete value (wall-clock when 0) and is what actually
+	// reproduces the run.
+	seedInput := *seed
 	if *seed == 0 {
 		*seed = time.Now().UnixNano()
 	}
@@ -329,6 +339,7 @@ func main() {
 	}
 
 	elapsed := time.Since(start)
+	dbSize, dbSizeErr := dirSize(config.DBPath)
 
 	fmt.Printf("\n=== State Generation Complete ===\n")
 	fmt.Printf("Total Time:        %v\n", elapsed.Round(time.Millisecond))
@@ -346,7 +357,7 @@ func main() {
 	if stats.StemBlobBytes > 0 {
 		fmt.Printf("Stem Blob Bytes:   %s\n", formatBytes(stats.StemBlobBytes))
 	}
-	if dbSize, err := dirSize(config.DBPath); err == nil {
+	if dbSizeErr == nil {
 		fmt.Printf("Total DB Size:     %s\n", formatBytes(dbSize))
 	}
 	if stats.StorageSlotsCreated > 0 {
@@ -356,6 +367,62 @@ func main() {
 
 	if genesisConfig != nil {
 		fmt.Printf("Genesis:           included (ready to use without geth init)\n")
+	}
+
+	// Write the reproducibility manifest to the datadir root. For geth that is
+	// two levels up from --db (<datadir>/geth/chaindata → <datadir>), matching
+	// where geth-genesis.json lands; for the other clients --db IS the datadir,
+	// alongside their chainspec/genesis sidecars.
+	manifestDir := *dbPath
+	if *client == "geth" {
+		manifestDir = geth.DatadirRoot(*dbPath)
+	}
+	// Manifest failures are warnings, not fatal: the DB is already fully
+	// written and valid, so a missing manifest must not turn a successful
+	// run into a non-zero exit.
+	specFileEntry, err := manifest.WriteSpecSidecar(manifestDir, *specFile)
+	if err != nil {
+		log.Printf("warning: manifest spec sidecar failed: %v", err)
+	}
+	man := &manifest.Manifest{
+		SchemaVersion: manifest.SchemaVersion,
+		StateActor:    manifest.NewBuild(Version),
+		GeneratedAt:   start.UTC().Format(time.RFC3339),
+		Command:       os.Args,
+		Flags: manifest.Flags{
+			Client:     *client,
+			DB:         *dbPath,
+			Seed:       *seed,
+			SeedInput:  seedInput,
+			Fork:       chosenFork,
+			ForkInput:  *fork,
+			ChainID:    *chainID,
+			GasLimit:   *gasLimit,
+			Timestamp:  *timestamp,
+			ExtraData:  *extraData,
+			TargetSize: *targetSize,
+			BinaryTrie: *binaryTrie,
+			GroupDepth: *groupDepth,
+			Archive:    *archive,
+			SpecPath:   *specFile,
+		},
+		Spec: specFileEntry,
+		Result: &manifest.Result{
+			StateRoot:        stats.StateRoot.Hex(),
+			AccountsCreated:  uint64(stats.AccountsCreated),
+			ContractsCreated: uint64(stats.ContractsCreated),
+			StorageSlots:     uint64(stats.StorageSlotsCreated),
+			ElapsedMS:        elapsed.Milliseconds(),
+		},
+	}
+	if dbSizeErr == nil {
+		man.Result.TotalDBSizeBytes = dbSize
+	}
+	manifestPath, err := man.Write(manifestDir)
+	if err != nil {
+		log.Printf("warning: manifest write failed: %v", err)
+	} else {
+		fmt.Printf("Manifest:          %s\n", manifestPath)
 	}
 
 	if *benchmark {

--- a/reproduce_test.go
+++ b/reproduce_test.go
@@ -1,0 +1,232 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// buildStateActor compiles the CLI once into a temp dir and returns the path.
+// Mirrors the go-build + exec.Command harness used across main_test.go (geth is
+// the default, no-cgo writer, so this runs in the default CI job).
+func buildStateActor(t *testing.T) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "state-actor")
+	build := exec.Command("go", "build", "-o", bin, ".")
+	build.Dir = "."
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("go build state-actor: %v\n%s", err, out)
+	}
+	return bin
+}
+
+// extractField returns the value after a "Label:   value" row in stdout.
+func extractField(t *testing.T, stdout, label string) string {
+	t.Helper()
+	for _, line := range strings.Split(stdout, "\n") {
+		if strings.HasPrefix(line, label) {
+			return strings.TrimSpace(strings.TrimPrefix(line, label))
+		}
+	}
+	t.Fatalf("could not find %q row in output:\n%s", label, stdout)
+	return ""
+}
+
+// generateGeth runs a small geth generation and returns (manifestPath, stateRoot).
+func generateGeth(t *testing.T, bin, dbDir string, extraArgs ...string) (string, string) {
+	t.Helper()
+	args := append([]string{"--db", dbDir, "--target-size", "2MB", "--seed", "42"}, extraArgs...)
+	out, err := exec.Command(bin, args...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("generate exited: %v\n%s", err, out)
+	}
+	s := string(out)
+	return extractField(t, s, "Manifest:"), extractField(t, s, "State Root:")
+}
+
+// TestReproduceRoundTripMatchesStateRoot is the core contract of the feature: a
+// run reproduced into a fresh --db lands on the recorded state root.
+func TestReproduceRoundTripMatchesStateRoot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping reproduce round-trip e2e in short mode")
+	}
+	bin := buildStateActor(t)
+	manifestPath, origRoot := generateGeth(t, bin, filepath.Join(t.TempDir(), "orig", "chaindata"))
+
+	reproDB := filepath.Join(t.TempDir(), "repro", "chaindata")
+	out, err := exec.Command(bin, "reproduce", "--manifest", manifestPath, "--db", reproDB).CombinedOutput()
+	if err != nil {
+		t.Fatalf("reproduce exited non-zero: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "Reproduction: PASS") {
+		t.Errorf("expected 'Reproduction: PASS' (root %s); got:\n%s", origRoot, out)
+	}
+	// Reproducing with the identical binary must NOT emit the version-mismatch
+	// warning (the manifest stores the resolved version; reproduce compares
+	// against the same resolved value).
+	if strings.Contains(string(out), "reproduction may differ") {
+		t.Errorf("unexpected spurious version-mismatch warning on identical binary:\n%s", out)
+	}
+	// The reproduced datadir gets its own manifest linking back to the source
+	// via reproduced_from (reproDB's parent isn't "geth", so DatadirRoot is
+	// reproDB itself).
+	reproManifest, err := os.ReadFile(filepath.Join(reproDB, "state-actor-manifest.json"))
+	if err != nil {
+		t.Fatalf("read reproduced manifest: %v", err)
+	}
+	if !strings.Contains(string(reproManifest), `"reproduced_from"`) ||
+		!strings.Contains(string(reproManifest), manifestPath) {
+		t.Errorf("reproduced manifest missing reproduced_from=%q:\n%s", manifestPath, reproManifest)
+	}
+}
+
+// TestReproduceWallClockSeedRoundTrip pins the headline property: a --seed=0 run
+// (non-reproducible inputs) reproduces exactly, because the manifest captured the
+// resolved concrete seed.
+func TestReproduceWallClockSeedRoundTrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping --seed=0 reproduce e2e in short mode")
+	}
+	bin := buildStateActor(t)
+	// generateGeth passes --seed 42; override with a trailing --seed 0 (last wins).
+	manifestPath, _ := generateGeth(t, bin, filepath.Join(t.TempDir(), "orig", "chaindata"), "--seed", "0")
+
+	reproDB := filepath.Join(t.TempDir(), "repro", "chaindata")
+	out, err := exec.Command(bin, "reproduce", "--manifest", manifestPath, "--db", reproDB).CombinedOutput()
+	if err != nil {
+		t.Fatalf("reproduce of --seed=0 run exited non-zero: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "Reproduction: PASS") {
+		t.Errorf("expected PASS reproducing a --seed=0 run; got:\n%s", out)
+	}
+}
+
+// TestReproduceMismatchExitsNonZero verifies the safety contract: when the
+// regenerated root differs from the recorded one, reproduce exits non-zero.
+func TestReproduceMismatchExitsNonZero(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping reproduce mismatch e2e in short mode")
+	}
+	bin := buildStateActor(t)
+	manifestPath, origRoot := generateGeth(t, bin, filepath.Join(t.TempDir(), "orig", "chaindata"))
+
+	// Tamper the recorded state root so regeneration cannot match it.
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	bogus := "0x" + strings.Repeat("0", 64)
+	if bogus == origRoot {
+		bogus = "0x" + strings.Repeat("f", 64)
+	}
+	if err := os.WriteFile(manifestPath, []byte(strings.ReplaceAll(string(data), origRoot, bogus)), 0o644); err != nil {
+		t.Fatalf("write tampered manifest: %v", err)
+	}
+
+	reproDB := filepath.Join(t.TempDir(), "repro", "chaindata")
+	cmd := exec.Command(bin, "reproduce", "--manifest", manifestPath, "--db", reproDB)
+	out, _ := cmd.CombinedOutput()
+	if cmd.ProcessState.ExitCode() == 0 {
+		t.Errorf("expected non-zero exit on state-root mismatch; got:\n%s", out)
+	}
+	if !strings.Contains(string(out), "MISMATCH") {
+		t.Errorf("expected 'MISMATCH' in output; got:\n%s", out)
+	}
+}
+
+// TestReproduceRefusesNonEmptyDB pins the fresh-output-dir guard.
+func TestReproduceRefusesNonEmptyDB(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping reproduce fresh-db guard e2e in short mode")
+	}
+	bin := buildStateActor(t)
+	manifestPath, _ := generateGeth(t, bin, filepath.Join(t.TempDir(), "orig", "chaindata"))
+
+	// A pre-existing, non-empty output directory must be refused.
+	busyDB := filepath.Join(t.TempDir(), "busy")
+	if err := os.MkdirAll(busyDB, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(busyDB, "preexisting"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	cmd := exec.Command(bin, "reproduce", "--manifest", manifestPath, "--db", busyDB)
+	out, _ := cmd.CombinedOutput()
+	if cmd.ProcessState.ExitCode() == 0 {
+		t.Errorf("expected non-zero exit for non-empty --db; got:\n%s", out)
+	}
+	if !strings.Contains(string(out), "fresh") {
+		t.Errorf("expected a 'fresh directory' message; got:\n%s", out)
+	}
+}
+
+// TestReproduceRefusesOriginalDatadir verifies reproduce won't clobber the
+// manifest's own source datadir.
+func TestReproduceRefusesOriginalDatadir(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping reproduce original-datadir guard e2e in short mode")
+	}
+	bin := buildStateActor(t)
+	origDB := filepath.Join(t.TempDir(), "orig", "chaindata")
+	manifestPath, _ := generateGeth(t, bin, origDB)
+
+	cmd := exec.Command(bin, "reproduce", "--manifest", manifestPath, "--db", origDB)
+	out, _ := cmd.CombinedOutput()
+	if cmd.ProcessState.ExitCode() == 0 {
+		t.Errorf("expected non-zero exit when reproducing into the original datadir; got:\n%s", out)
+	}
+	if !strings.Contains(string(out), "original datadir") {
+		t.Errorf("expected an 'original datadir' message; got:\n%s", out)
+	}
+}
+
+// TestReproduceRequiresManifestAndDB mirrors the project's CLI-contract tests:
+// missing required flags must exit non-zero.
+func TestReproduceRequiresManifestAndDB(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping reproduce required-flags regression in short mode")
+	}
+	bin := buildStateActor(t)
+	cases := [][]string{
+		{"reproduce"},
+		{"reproduce", "--manifest", "/tmp/m.json"},
+		{"reproduce", "--db", "/tmp/d"},
+		{"reproduce", "--manifest", filepath.Join(t.TempDir(), "nope.json"), "--db", filepath.Join(t.TempDir(), "out")},
+	}
+	for _, args := range cases {
+		cmd := exec.Command(bin, args...)
+		out, _ := cmd.CombinedOutput()
+		if cmd.ProcessState.ExitCode() == 0 {
+			t.Errorf("expected non-zero exit for `reproduce %v`; got:\n%s", args[1:], out)
+		}
+	}
+}
+
+// TestSamePath unit-tests the original-datadir comparison helper.
+func TestSamePath(t *testing.T) {
+	rel := "foo"
+	relAbs, err := filepath.Abs(rel)
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	cases := []struct {
+		name string
+		a, b string
+		want bool
+	}{
+		{"identical", "/x/y", "/x/y", true},
+		{"trailing slash vs none", "/x/y/", "/x/y", true},
+		{"dotdot normalizes", "/x/z/../y", "/x/y", true},
+		{"relative vs absolute", rel, relAbs, true},
+		{"different dirs", "/x/y", "/x/z", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := samePath(c.a, c.b); got != c.want {
+				t.Errorf("samePath(%q, %q) = %v, want %v", c.a, c.b, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Every run now writes a `state-actor-manifest.json` to the output datadir capturing everything needed to reproduce it, plus a `reproduce` subcommand that regenerates a run from that manifest and verifies it.

## What's in the manifest

Written to the datadir root (two levels up from `--db` for geth, alongside `geth-genesis.json`; the `--db` dir itself for the other five clients, beside their chainspec sidecars):

- **`flags`** — resolved config. Critically the **resolved seed** (`--seed=0` expands to wall-clock) and **resolved fork** (empty `--fork` → client max), not just the raw inputs, so the run is reproducible even when the flags alone aren't.
- **`command`** — full `os.Args`.
- **`spec`** — when `--spec` is used, the YAML is written verbatim to a content-addressed `state-actor-spec-<sha256>.yaml` sidecar and referenced by relative filename + sha256 + original input path (not inlined — keeps the manifest readable and the spec directly reusable).
- **`state_actor`** — version, go version, os/arch, and git revision/time/dirty (Go's automatic VCS stamping).
- **`result`** — state root, account/contract/slot counts, db size, elapsed.

Manifest-write failures are warnings, not fatal — a successful generation never exits non-zero just because the manifest couldn't be written.

## `reproduce` subcommand

```bash
state-actor reproduce --manifest <state-actor-manifest.json> --db <new-output-dir>
```

Replays the manifest's resolved flags through the identical generation pipeline into a fresh `--db` (refuses the original datadir), reads any spec from the sidecar next to the manifest, then **verifies the regenerated state root against the recorded one — exiting non-zero on mismatch**. Works even for `--seed=0` runs, since the concrete seed was captured.

## Versioning

- `main.Version` (the `-X main.Version` target was previously a dead no-op) now exists and **falls back to the Go-auto-stamped short commit** when not linked in — so `go run` and plain `docker build` still record a meaningful version.
- Docker images stamp the real `git describe` via a `STATE_ACTOR_VERSION` build-arg, wired through the Makefile and the `deploy-docker` workflow (including a `v*.*.*` tag → `version: v1.2.3`).

## OCI labels

Added `org.opencontainers.image.{title,description,source,licenses,version,revision}` to all 7 Dockerfiles (the 5 cgo clients had none). `version`/`revision` come from build-args (`STATE_ACTOR_VERSION` / new `STATE_ACTOR_REVISION`), wired through the Makefile and deploy workflow.

## Verification

- New `internal/manifest` package with unit tests (version resolution, spec sidecar, load/round-trip); `go build ./...`, `go vet`, `gofmt` clean.
- **Reproduce proven end-to-end**: an original run with `--seed=0` reproduced to the identical state root via the captured resolved seed; spec runs reproduce via the sidecar; same-dir guard and usage verified.
- **All six client Docker images** built and run on this branch: manifest written at the correct datadir location, `version` = git-describe, `vcs_revision` populated, OCI labels present (verified on alpine + debian-cgo variants), and all six produce the identical genesis state root (instrumentation is side-effect-free).

## Docs

Added a "Reproduce a run from its manifest" task to `docs/SKILL.md`.

## Example

Generate a besu DB from `examples/spec-minimal.yaml` via the Docker image:

```bash
mkdir -p /tmp/sa-spec && \
docker run --rm \
  -v /tmp/sa-spec:/data \
  -v "$(pwd)/examples:/specs:ro" \
  ghcr.io/ethereum/state-actor-besu:main \
  --client=besu --db=/data \
  --spec=/specs/spec-minimal.yaml \
  --seed=42 --chain-id=1337
```

The datadir then contains the manifest plus the content-addressed spec sidecar:

```
$ ls /tmp/sa-spec
besu-chainspec.json
database/
DATABASE_METADATA.json
state-actor-manifest.json
state-actor-spec-5309e337ea6c0f88fb86f318c500ed197c1488636216c429ea0051d0824013e4.yaml
```

`state-actor-manifest.json`:

```json
{
  "schema_version": 1,
  "state_actor": {
    "version": "a2099cf-dirty",
    "go_version": "go1.25.11",
    "os": "linux",
    "arch": "arm64",
    "vcs_revision": "a2099cf6dc853cea687a7d2a47172bcdd617d330",
    "vcs_time": "2026-06-25T09:51:55Z",
    "vcs_modified": true
  },
  "generated_at": "2026-06-25T12:51:13Z",
  "command": [
    "/usr/local/bin/state-actor",
    "--client=besu",
    "--db=/data",
    "--spec=/specs/spec-minimal.yaml",
    "--seed=42",
    "--chain-id=1337"
  ],
  "flags": {
    "client": "besu",
    "db": "/data",
    "seed": 42,
    "seed_input": 42,
    "fork": "osaka",
    "fork_input": "",
    "chain_id": 1337,
    "gas_limit": 30000000,
    "timestamp": 0,
    "binary_trie": false,
    "group_depth": 8,
    "archive": false,
    "spec_path": "/specs/spec-minimal.yaml"
  },
  "spec": {
    "input_path": "/specs/spec-minimal.yaml",
    "sha256": "5309e337ea6c0f88fb86f318c500ed197c1488636216c429ea0051d0824013e4",
    "output_file": "state-actor-spec-5309e337ea6c0f88fb86f318c500ed197c1488636216c429ea0051d0824013e4.yaml"
  },
  "result": {
    "state_root": "0x123d9412948ca0f92f8b855420b9f34ee36be5dfaf2b1101baf0f6743e1c1cfd",
    "accounts_created": 1,
    "contracts_created": 5,
    "total_db_size_bytes": 201287,
    "elapsed_ms": 53
  }
}
```

> For a run created with `--seed=0`, `seed_input` would be `0` while `seed` holds the resolved wall-clock value — which is what makes the run reproducible via `reproduce`.


### Reproduce it

Recover the run into a fresh directory and verify it matches:

```bash
rm -rf /tmp/sa-spec-repro && mkdir -p /tmp/sa-spec-repro && \
docker run --rm \
  -v /tmp/sa-spec:/orig:ro \
  -v /tmp/sa-spec-repro:/out \
  ghcr.io/ethereum/state-actor-besu:main \
  reproduce --manifest /orig/state-actor-manifest.json --db /out
```

```
Reproducing run from /orig/state-actor-manifest.json
  client=besu seed=42 fork=osaka → /out
...
Reproduction: PASS — state root matches 0x123d9412948ca0f92f8b855420b9f34ee36be5dfaf2b1101baf0f6743e1c1cfd
```

Notes:
- Mount the original datadir read-only at a **different** container path (`/orig`) and the new output at `/out`. The same-dir guard compares container paths, and the manifest recorded `db=/data`, so the reproduce `--db` must differ (`/out`).
- `/orig` must contain both the manifest and its `state-actor-spec-<sha>.yaml` sidecar — reproduce reads the spec from beside the manifest.
- The reproduce `--db` must be a **fresh** (empty or nonexistent) directory — the command refuses a pre-existing non-empty dir, so clear it first on re-runs.

