### PR TITLE
feat: add templates to support account access benchmark.

### DIFF
--- a/internal/templates/code_pattern.go
+++ b/internal/templates/code_pattern.go
@@ -125,8 +125,8 @@ func BuildUniqueJumpdestRuntimePreAmsterdam(addr common.Address) []byte {
 
 // appendJumpdestFillSeed appends the shared initcode prologue for
 // pre-Amsterdam max-size patterns: fills mem[0:0x8000] with JUMPDESTs
-// via PUSH32 + MCOPY loop. Both unique and max-same patterns build on
-// this prefix; kept centralized to prevent hash drift.
+// via PUSH32 + MCOPY loop. The unique, max-same, and max-diff patterns
+// all build on this prefix; kept centralized to prevent hash drift.
 func appendJumpdestFillSeed(buf []byte) []byte {
 	// PUSH32 (32 × JUMPDEST); PUSH1 0x00; MSTORE.
 	buf = append(buf, 0x7F) // PUSH32
@@ -224,7 +224,8 @@ func buildMaxSameRuntimePreAmsterdam() []byte {
 	return out
 }
 
-// BuildMaxSameInitcodePreAmsterdam returns initcode: STOP + JUMPDEST sea.
+// BuildMaxSameInitcodePreAmsterdam returns initcode that deploys a
+// STOP + JUMPDEST-sea runtime.
 // Vendored to match bench test CREATE2 derivation. Only the hash is used
 // (initcode never executes).
 //

--- a/internal/templates/code_pattern.go
+++ b/internal/templates/code_pattern.go
@@ -3,6 +3,7 @@ package templates
 import (
 	"encoding/binary"
 	"fmt"
+	"slices"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -25,6 +26,12 @@ const (
 	// byte at offset 0x5FFF, then drops off the code (no STOP needed —
 	// the EVM treats end-of-code as a clean exit).
 	CodePatternUniqueJumpdestPreAmsterdam = "unique_jumpdest_pre_amsterdam"
+
+	// CodePatternMaxSamePreAmsterdam — 24576-byte identical runtime
+	// (STOP at 0x00, 24575 JUMPDESTs). Unlike unique patterns, all copies
+	// share one code hash (no embedded address). Used by
+	// AccountMode.EXISTING_CONTRACT_SAME; CodePatternRuntimeSize = 0.
+	CodePatternMaxSamePreAmsterdam = "max_same_pre_amsterdam"
 )
 
 // preAmsterdamMaxCodeSize is the EIP-170 contract-code limit applied
@@ -32,25 +39,26 @@ const (
 // amsterdam pattern variant will live alongside this one when scheduled.
 const preAmsterdamMaxCodeSize = 0x6000 // 24576 bytes.
 
+// single source of truth for recognized pattern names.
+var knownCodePatterns = []string{
+	CodePatternUniqueJumpdestPreAmsterdam,
+	CodePatternMaxSamePreAmsterdam,
+}
+
 // IsKnownCodePattern reports whether the given string is one of the
 // recognized named code patterns. Used at parameter-validate time.
 func IsKnownCodePattern(name string) bool {
-	switch name {
-	case CodePatternUniqueJumpdestPreAmsterdam:
-		return true
-	}
-	return false
+	return slices.Contains(knownCodePatterns, name)
 }
 
-// CodePatternRuntimeSize returns the per-derived-contract runtime size
-// in bytes for a known pattern name; 0 for unknown names. Used to
-// estimate resident memory: pattern runtimes are byte-unique per
-// derived address, so the full count × size set stays reachable (via
-// generator.Config.GenesisCode) for the entire run.
+// CodePatternRuntimeSize returns runtime size for unique patterns,
+// 0 for unknown/shared patterns. Used for resident memory estimation.
 func CodePatternRuntimeSize(name string) uint64 {
 	switch name {
 	case CodePatternUniqueJumpdestPreAmsterdam:
 		return preAmsterdamMaxCodeSize
+	case CodePatternMaxSamePreAmsterdam:
+		return 0
 	}
 	return 0
 }
@@ -107,6 +115,31 @@ func BuildUniqueJumpdestRuntimePreAmsterdam(addr common.Address) []byte {
 	return out
 }
 
+// appendJumpdestFillSeed appends the shared initcode prologue for
+// pre-Amsterdam max-size patterns: fills mem[0:0x8000] with JUMPDESTs
+// via PUSH32 + MCOPY loop. Both unique and max-same patterns build on
+// this prefix; kept centralized to prevent hash drift.
+func appendJumpdestFillSeed(buf []byte) []byte {
+	// PUSH32 (32 × JUMPDEST); PUSH1 0x00; MSTORE.
+	buf = append(buf, 0x7F) // PUSH32
+	for range 32 {
+		buf = append(buf, 0x5B)
+	}
+	buf = append(buf, 0x60, 0x00) // PUSH1 0
+	buf = append(buf, 0x52)       // MSTORE
+
+	// Doubling MCOPY: sizes {32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384}.
+	// Push order: len, src, dst (MCOPY pops with dst on top).
+	for s := uint(5); s < 15; s++ {
+		size := uint64(1) << s
+		buf = append(buf, pushImmediate(size)...) // len
+		buf = append(buf, 0x60, 0x00)             // PUSH1 0 (src)
+		buf = append(buf, pushImmediate(size)...) // dst
+		buf = append(buf, 0x5E)                   // MCOPY
+	}
+	return buf
+}
+
 // BuildUniqueJumpdestInitcodePreAmsterdam returns the initcode that —
 // if run — would deploy the unique-jumpdest runtime above. State-actor
 // never executes this initcode; only its keccak256 hash is used by
@@ -125,26 +158,8 @@ func BuildUniqueJumpdestRuntimePreAmsterdam(addr common.Address) []byte {
 //  5. PUSH2 0x6000; PUSH1 0x00; RETURN — emit the first 0x6000 bytes
 //     of memory as the runtime.
 func BuildUniqueJumpdestInitcodePreAmsterdam() []byte {
-	var buf []byte
-
-	// 1. PUSH32 (32 × JUMPDEST); PUSH1 0x00; MSTORE.
-	buf = append(buf, 0x7F) // PUSH32
-	for range 32 {
-		buf = append(buf, 0x5B)
-	}
-	buf = append(buf, 0x60, 0x00) // PUSH1 0
-	buf = append(buf, 0x52)       // MSTORE
-
-	// 2. Doubling MCOPY: size in {32, 64, 128, 256, 512, 1024, 2048,
-	//    4096, 8192, 16384}. MCOPY pops (dst, src, len) with dst on top,
-	//    so we push len first, then src, then dst.
-	for s := uint(5); s < 15; s++ {
-		size := uint64(1) << s
-		buf = append(buf, pushImmediate(size)...) // len
-		buf = append(buf, 0x60, 0x00)             // PUSH1 0 (src)
-		buf = append(buf, pushImmediate(size)...) // dst
-		buf = append(buf, 0x5E)                   // MCOPY
-	}
+	// Step 1 and 2: seed mem[0:0x8000] with JUMPDEST (shared prologue).
+	buf := appendJumpdestFillSeed(nil)
 
 	// 3. PUSH32 entry; PUSH1 0x00; MSTORE.
 	// entry = PUSH2 0x5FFF; JUMP (4 bytes) + JUMPDEST × 28.
@@ -184,6 +199,46 @@ func BuildUniqueJumpdestInitcodePreAmsterdam() []byte {
 	return buf
 }
 
+// maxSameRuntimePreAmsterdam is the shared runtime for max-same pattern.
+// All derived contracts alias this read-only slice (byte-identical).
+var maxSameRuntimePreAmsterdam = buildMaxSameRuntimePreAmsterdam()
+
+// buildMaxSameRuntimePreAmsterdam returns the 24576-byte runtime: a STOP
+// (0x00) at offset 0 so a call halts immediately, JUMPDEST (0x5B) for
+// every other byte. Matches the deployed code of execution-specs
+// UniqueMaxContractInitcode(diff=False).
+func buildMaxSameRuntimePreAmsterdam() []byte {
+	out := make([]byte, preAmsterdamMaxCodeSize)
+	for i := range out {
+		out[i] = 0x5B // JUMPDEST
+	}
+	out[0] = 0x00 // STOP — a call to the contract halts at byte 0.
+	return out
+}
+
+// BuildMaxSameInitcodePreAmsterdam returns initcode: STOP + JUMPDEST sea.
+// Vendored to match bench test CREATE2 derivation. Only the hash is used
+// (initcode never executes).
+//
+// Steps: fill mem with JUMPDESTs, overwrite mem[0] with STOP, return 0x6000 bytes.
+func BuildMaxSameInitcodePreAmsterdam() []byte {
+	// 1+2. Seed mem[0:0x8000] with JUMPDEST (shared prologue).
+	buf := appendJumpdestFillSeed(nil)
+
+	// 3. MSTORE8(0, 0): MSTORE8 pops (offset, value) with offset on top,
+	// so push value first, then offset.
+	buf = append(buf, 0x60, 0x00) // PUSH1 0 (value)
+	buf = append(buf, 0x60, 0x00) // PUSH1 0 (offset)
+	buf = append(buf, 0x53)       // MSTORE8
+
+	// 4. PUSH2 0x6000; PUSH1 0x00; RETURN.
+	buf = append(buf, 0x61, 0x60, 0x00) // PUSH2 0x6000 (length)
+	buf = append(buf, 0x60, 0x00)       // PUSH1 0 (offset)
+	buf = append(buf, 0xF3)             // RETURN
+
+	return buf
+}
+
 // pushImmediate emits the smallest PUSHN + immediate bytes that pushes
 // `v` onto the EVM stack. Used by the initcode builder to keep the
 // emitted blob compact (32 → PUSH1, 256 → PUSH2, …, up to PUSH8 since
@@ -213,6 +268,8 @@ func codePatternRuntimeFor(name string, addr common.Address) ([]byte, error) {
 	switch name {
 	case CodePatternUniqueJumpdestPreAmsterdam:
 		return BuildUniqueJumpdestRuntimePreAmsterdam(addr), nil
+	case CodePatternMaxSamePreAmsterdam:
+		return maxSameRuntimePreAmsterdam, nil
 	}
 	return nil, fmt.Errorf("unknown code_pattern %q", name)
 }
@@ -226,6 +283,8 @@ func codePatternInitcodeFor(name string) ([]byte, error) {
 	switch name {
 	case CodePatternUniqueJumpdestPreAmsterdam:
 		return BuildUniqueJumpdestInitcodePreAmsterdam(), nil
+	case CodePatternMaxSamePreAmsterdam:
+		return BuildMaxSameInitcodePreAmsterdam(), nil
 	}
 	return nil, fmt.Errorf("unknown code_pattern %q", name)
 }

--- a/internal/templates/code_pattern.go
+++ b/internal/templates/code_pattern.go
@@ -32,6 +32,11 @@ const (
 	// share one code hash (no embedded address). Used by
 	// AccountMode.EXISTING_CONTRACT_SAME; CodePatternRuntimeSize = 0.
 	CodePatternMaxSamePreAmsterdam = "max_same_pre_amsterdam"
+
+	// CodePatternMaxDiffPreAmsterdam — 24576-byte runtime with embedded
+	// address at bytes 0x0C..0x20 (STOP + padding + address + JUMPDESTs).
+	// Byte-unique per contract. Used by AccountMode.EXISTING_CONTRACT_DIFF.
+	CodePatternMaxDiffPreAmsterdam = "max_diff_pre_amsterdam"
 )
 
 // preAmsterdamMaxCodeSize is the EIP-170 contract-code limit applied
@@ -43,6 +48,7 @@ const preAmsterdamMaxCodeSize = 0x6000 // 24576 bytes.
 var knownCodePatterns = []string{
 	CodePatternUniqueJumpdestPreAmsterdam,
 	CodePatternMaxSamePreAmsterdam,
+	CodePatternMaxDiffPreAmsterdam,
 }
 
 // IsKnownCodePattern reports whether the given string is one of the
@@ -56,6 +62,8 @@ func IsKnownCodePattern(name string) bool {
 func CodePatternRuntimeSize(name string) uint64 {
 	switch name {
 	case CodePatternUniqueJumpdestPreAmsterdam:
+		return preAmsterdamMaxCodeSize
+	case CodePatternMaxDiffPreAmsterdam:
 		return preAmsterdamMaxCodeSize
 	case CodePatternMaxSamePreAmsterdam:
 		return 0
@@ -239,6 +247,45 @@ func BuildMaxSameInitcodePreAmsterdam() []byte {
 	return buf
 }
 
+// BuildMaxDiffRuntimePreAmsterdam returns the 24576-byte runtime with
+// embedded address (STOP + padding + address + JUMPDESTs at 0x0C..0x20).
+// Byte-unique per contract. Matches UniqueMaxContractInitcode(diff=True).
+func BuildMaxDiffRuntimePreAmsterdam(addr common.Address) []byte {
+	out := make([]byte, preAmsterdamMaxCodeSize)
+	for i := range out {
+		out[i] = 0x5B // JUMPDEST
+	}
+	// Bytes 0x00..0x0C — STOP at byte 0 plus 11 zero padding bytes
+	// (MSTORE(0, ADDRESS) writes the address right-aligned in 32 bytes).
+	for i := 0; i < 0x0C; i++ {
+		out[i] = 0x00
+	}
+	// Bytes 0x0C..0x20 — the 20-byte address.
+	copy(out[0x0C:0x20], addr[:])
+	// Bytes 0x20..0x6000 stay JUMPDEST from the fill.
+	return out
+}
+
+// BuildMaxDiffInitcodePreAmsterdam returns initcode with embedded ADDRESS.
+// Vendored for CREATE2; only hash used (never executes).
+func BuildMaxDiffInitcodePreAmsterdam() []byte {
+	// 1+2. Seed mem[0:0x8000] with JUMPDEST (shared prologue).
+	buf := appendJumpdestFillSeed(nil)
+
+	// 3. MSTORE(0, ADDRESS): MSTORE pops (offset, value) with offset on
+	// top, so push value (ADDRESS) first, then offset.
+	buf = append(buf, 0x30)       // ADDRESS (value)
+	buf = append(buf, 0x60, 0x00) // PUSH1 0 (offset)
+	buf = append(buf, 0x52)       // MSTORE
+
+	// 4. PUSH2 0x6000; PUSH1 0x00; RETURN.
+	buf = append(buf, 0x61, 0x60, 0x00) // PUSH2 0x6000 (length)
+	buf = append(buf, 0x60, 0x00)       // PUSH1 0 (offset)
+	buf = append(buf, 0xF3)             // RETURN
+
+	return buf
+}
+
 // pushImmediate emits the smallest PUSHN + immediate bytes that pushes
 // `v` onto the EVM stack. Used by the initcode builder to keep the
 // emitted blob compact (32 → PUSH1, 256 → PUSH2, …, up to PUSH8 since
@@ -270,6 +317,8 @@ func codePatternRuntimeFor(name string, addr common.Address) ([]byte, error) {
 		return BuildUniqueJumpdestRuntimePreAmsterdam(addr), nil
 	case CodePatternMaxSamePreAmsterdam:
 		return maxSameRuntimePreAmsterdam, nil
+	case CodePatternMaxDiffPreAmsterdam:
+		return BuildMaxDiffRuntimePreAmsterdam(addr), nil
 	}
 	return nil, fmt.Errorf("unknown code_pattern %q", name)
 }
@@ -285,6 +334,8 @@ func codePatternInitcodeFor(name string) ([]byte, error) {
 		return BuildUniqueJumpdestInitcodePreAmsterdam(), nil
 	case CodePatternMaxSamePreAmsterdam:
 		return BuildMaxSameInitcodePreAmsterdam(), nil
+	case CodePatternMaxDiffPreAmsterdam:
+		return BuildMaxDiffInitcodePreAmsterdam(), nil
 	}
 	return nil, fmt.Errorf("unknown code_pattern %q", name)
 }

--- a/internal/templates/code_pattern_max_diff_test.go
+++ b/internal/templates/code_pattern_max_diff_test.go
@@ -1,0 +1,118 @@
+package templates
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// TestBuildMaxDiffRuntimePreAmsterdamLayout pins the per-address runtime
+// against execution-specs UniqueMaxContractInitcode(diff=True): STOP +
+// 11 zero padding bytes, the 20-byte address at 0x0C..0x20, JUMPDEST sea.
+func TestBuildMaxDiffRuntimePreAmsterdamLayout(t *testing.T) {
+	addr := common.HexToAddress("0x000000000000000000000000000000000000beef")
+	got := BuildMaxDiffRuntimePreAmsterdam(addr)
+
+	if len(got) != 0x6000 {
+		t.Fatalf("length: got %d, want 0x6000 (24576)", len(got))
+	}
+	// Bytes 0x00..0x0C: STOP at 0 plus 11 zero padding bytes.
+	for i := 0; i < 0x0C; i++ {
+		if got[i] != 0x00 {
+			t.Fatalf("byte %d: got 0x%02x, want 0x00", i, got[i])
+		}
+	}
+	// Bytes 0x0C..0x20: embedded address.
+	if !bytes.Equal(got[0x0C:0x20], addr[:]) {
+		t.Errorf("embedded address [0x0C:0x20]: got %x, want %x", got[0x0C:0x20], addr[:])
+	}
+	// Bytes 0x20..0x6000: JUMPDEST filler.
+	for i := 0x20; i < 0x6000; i++ {
+		if got[i] != 0x5B {
+			t.Fatalf("byte %d: got 0x%02x, want 0x5B (JUMPDEST filler)", i, got[i])
+		}
+	}
+}
+
+// TestBuildMaxDiffRuntimeUnique pins that each derived address produces a
+// byte-distinct runtime — they differ only in the embedded-address region.
+func TestBuildMaxDiffRuntimeUnique(t *testing.T) {
+	a := BuildMaxDiffRuntimePreAmsterdam(common.HexToAddress("0x01"))
+	b := BuildMaxDiffRuntimePreAmsterdam(common.HexToAddress("0x02"))
+	if bytes.Equal(a, b) {
+		t.Fatalf("two distinct addresses produced byte-identical runtime")
+	}
+	if !bytes.Equal(a[:0x0C], b[:0x0C]) {
+		t.Errorf("prefix [0:0x0C] should be identical; differ")
+	}
+	if !bytes.Equal(a[0x20:], b[0x20:]) {
+		t.Errorf("suffix [0x20:] should be identical; differ")
+	}
+}
+
+// TestBuildMaxDiffInitcodeMatchesEEST pins the keccak256 of the
+// state-actor-emitted initcode to the value EEST's
+// UniqueMaxContractInitcode(diff=True) produces, so state-actor and
+// execution-specs derive the same CREATE2 addresses for
+// AccountMode.EXISTING_CONTRACT_DIFF.
+//
+// Regenerate from an execution-specs checkout:
+//
+//	from tests.benchmark.helper.account_creator import (
+//	    UniqueMaxContractInitcode)
+//	from eth_utils import keccak
+//	print(keccak(bytes(UniqueMaxContractInitcode(diff=True))).hex())
+func TestBuildMaxDiffInitcodeMatchesEEST(t *testing.T) {
+	const eestInitcodeKeccak = "0xbdaf429840ac400acad3d230653b726a2cdf9201f645976fe353bb45e45bfe63"
+	ic := BuildMaxDiffInitcodePreAmsterdam()
+	got := crypto.Keccak256Hash(ic).Hex()
+	if got != eestInitcodeKeccak {
+		t.Fatalf("initcode keccak diverged from EEST: got %s want %s\n"+
+			"  a mismatch means planted contracts live at addresses\n"+
+			"  EXISTING_CONTRACT_DIFF never queries.",
+			got, eestInitcodeKeccak)
+	}
+}
+
+// TestCreate2DeploysMaxDiffAddressesMatchEEST pins two DERIVED ADDRESSES
+// (canonical Arachnid factory, salts 0 and 1, initcode = max_diff
+// pattern) to literals computed outside go-ethereum (eth_utils keccak):
+//
+//	keccak256(0xff ++ 4e59…956c ++ uint256(salt) ++
+//	          bdaf429840ac400acad3d230653b726a2cdf9201f645976fe353bb45e45bfe63)[12:]
+func TestCreate2DeploysMaxDiffAddressesMatchEEST(t *testing.T) {
+	ent := mkContractEntity("create2_deploys", map[string]any{
+		"code_pattern": CodePatternMaxDiffPreAmsterdam,
+		"salt_count":   2,
+	})
+	out, err := (&create2DeploysTemplate{}).Expand(Context{}, ent)
+	if err != nil {
+		t.Fatalf("Expand: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("count: got %d, want 2", len(out))
+	}
+	want := []common.Address{
+		common.HexToAddress("0xa9cb82ea3c688e8c8153e60c1e340840459f66a6"), // salt 0
+		common.HexToAddress("0x99ea5fb3758b5fa20b4dfbd2971e98e9723f8f1f"), // salt 1
+	}
+	for i := range want {
+		if out[i].Address != want[i] {
+			t.Errorf("salt=%d: got %s, want EEST-derived %s", i, out[i].Address.Hex(), want[i].Hex())
+		}
+		// The derived contract must embed its own address in the runtime.
+		if !bytes.Equal(out[i].Code[0x0C:0x20], out[i].Address[:]) {
+			t.Errorf("salt=%d: runtime does not embed derived address", i)
+		}
+	}
+}
+
+// TestMaxDiffRuntimeSizeCounted pins that max-diff is treated as a
+// byte-unique pattern for residency accounting (unlike max-same).
+func TestMaxDiffRuntimeSizeCounted(t *testing.T) {
+	if got := CodePatternRuntimeSize(CodePatternMaxDiffPreAmsterdam); got != 0x6000 {
+		t.Fatalf("CodePatternRuntimeSize(max_diff) = %d, want 24576 (unique/counted)", got)
+	}
+}

--- a/internal/templates/code_pattern_max_same_test.go
+++ b/internal/templates/code_pattern_max_same_test.go
@@ -1,0 +1,87 @@
+package templates
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func TestBuildMaxSameRuntimePreAmsterdamLayout(t *testing.T) {
+	got := buildMaxSameRuntimePreAmsterdam()
+
+	if len(got) != 0x6000 {
+		t.Fatalf("length: got %d, want 0x6000 (24576)", len(got))
+	}
+	if got[0] != 0x00 {
+		t.Errorf("byte[0]: got 0x%02x, want 0x00 (STOP)", got[0])
+	}
+	for i := 1; i < 0x6000; i++ {
+		if got[i] != 0x5B {
+			t.Fatalf("byte %d: got 0x%02x, want 0x5B (JUMPDEST filler)", i, got[i])
+		}
+	}
+}
+
+func TestBuildMaxSameInitcodeMatchesEEST(t *testing.T) {
+	const eestInitcodeKeccak = "0xe6b00ac4e153de72333bfef8ba8c0241039aa429b54646cf1128e3ca027d7819"
+	ic := BuildMaxSameInitcodePreAmsterdam()
+	got := crypto.Keccak256Hash(ic).Hex()
+	if got != eestInitcodeKeccak {
+		t.Fatalf("initcode keccak diverged from EEST: got %s want %s\n"+
+			"  state-actor and execution-specs must derive the same CREATE2\n"+
+			"  addresses from this initcode; a mismatch means planted\n"+
+			"  contracts live at addresses EXISTING_CONTRACT_SAME never queries.",
+			got, eestInitcodeKeccak)
+	}
+}
+
+func TestCreate2DeploysMaxSameAddressesMatchEEST(t *testing.T) {
+	ent := mkContractEntity("create2_deploys", map[string]any{
+		"code_pattern": CodePatternMaxSamePreAmsterdam,
+		"salt_count":   2,
+	})
+	out, err := (&create2DeploysTemplate{}).Expand(Context{}, ent)
+	if err != nil {
+		t.Fatalf("Expand: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("count: got %d, want 2", len(out))
+	}
+	want := []common.Address{
+		common.HexToAddress("0x457aed6ccdc15f4ee709c7c836168debf8b5fc9d"), // salt 0
+		common.HexToAddress("0xcc42664955411919803aa1d5485ccab6584436aa"), // salt 1
+	}
+	for i := range want {
+		if out[i].Address != want[i] {
+			t.Errorf("salt=%d: got %s, want EEST-derived %s", i, out[i].Address.Hex(), want[i].Hex())
+		}
+		if len(out[i].Code) != 1 && out[i].Code[0] != 0x00 {
+			t.Errorf("salt=%d: runtime byte[0] = 0x%02x, want STOP", i, out[i].Code[0])
+		}
+	}
+}
+
+func TestMaxSameRuntimeSharedAndExempt(t *testing.T) {
+	if got := CodePatternRuntimeSize(CodePatternMaxSamePreAmsterdam); got != 0 {
+		t.Fatalf("CodePatternRuntimeSize(max_same) = %d, want 0 (shared/exempt)", got)
+	}
+
+	ent := mkContractEntity("create2_deploys", map[string]any{
+		"code_pattern": CodePatternMaxSamePreAmsterdam,
+		"salt_count":   3,
+	})
+	out, err := (&create2DeploysTemplate{}).Expand(Context{}, ent)
+	if err != nil {
+		t.Fatalf("Expand: %v", err)
+	}
+	// All three derived contracts must point at the same backing array.
+	if &out[0].Code[0] != &out[1].Code[0] || &out[1].Code[0] != &out[2].Code[0] {
+		t.Errorf("derived runtimes are not aliased: distinct backing arrays")
+	}
+	// And the bytes must be identical (sanity, not just aliased).
+	if !bytes.Equal(out[0].Code, out[1].Code) {
+		t.Errorf("derived runtimes differ in bytes")
+	}
+}

--- a/internal/templates/create2_deploys.go
+++ b/internal/templates/create2_deploys.go
@@ -3,6 +3,7 @@ package templates
 import (
 	"encoding/binary"
 	"fmt"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -98,8 +99,8 @@ func parseCreate2DeploysParams(params map[string]any) (create2DeploysParams, err
 			return pp, fmt.Errorf("create2_deploys: code_pattern must be a string (got %T)", v)
 		}
 		if !IsKnownCodePattern(name) {
-			return pp, fmt.Errorf("create2_deploys: unknown code_pattern %q (known: %q)",
-				name, CodePatternUniqueJumpdestPreAmsterdam)
+			return pp, fmt.Errorf("create2_deploys: unknown code_pattern %q (known: %s)",
+				name, strings.Join(knownCodePatterns, ", "))
 		}
 		if _, has := params["initcode"]; has {
 			return pp, fmt.Errorf("create2_deploys: `initcode` is forbidden when `code_pattern` is set (the pattern owns the initcode)")

--- a/internal/templates/create_preimage_deploys.go
+++ b/internal/templates/create_preimage_deploys.go
@@ -2,6 +2,7 @@ package templates
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -93,8 +94,8 @@ func parseCreatePreimageDeploysParams(params map[string]any) (createPreimageDepl
 			return pp, fmt.Errorf("create_preimage_deploys: code_pattern must be a string (got %T)", v)
 		}
 		if !IsKnownCodePattern(name) {
-			return pp, fmt.Errorf("create_preimage_deploys: unknown code_pattern %q (known: %q)",
-				name, CodePatternUniqueJumpdestPreAmsterdam)
+			return pp, fmt.Errorf("create_preimage_deploys: unknown code_pattern %q (known: %s)",
+				name, strings.Join(knownCodePatterns, ", "))
 		}
 		if _, has := params["runtime"]; has {
 			return pp, fmt.Errorf("create_preimage_deploys: `runtime` is forbidden when `code_pattern` is set (the pattern generates per-address runtime)")

--- a/internal/templates/doc.go
+++ b/internal/templates/doc.go
@@ -21,6 +21,10 @@
 //   - sequential_pkey_eoas.go — kind: contract, template:
 //     sequential_pkey_eoas. N pre-funded EOAs at addresses derived from
 //     sequential private keys; backs the EEST sender-pool layout.
+//   - sequential_pkey_delegations.go — kind: contract, template:
+//     sequential_pkey_delegations. N EIP-7702 delegated EOAs (authority
+//     from sequential pkey, code = 0xef0100||CREATE2 target by index);
+//     backs the EEST yield_distinct_delegate_receiver layout.
 //   - storage_pattern.go  — kind: contract, template: storage_pattern. Plants
 //     slot 0 = final+1 plus slot k = k for k in 1..final; backs the
 //     existing_slots=True path of test_sload_bloated / test_sstore_bloated.

--- a/internal/templates/entity_fields_test.go
+++ b/internal/templates/entity_fields_test.go
@@ -15,15 +15,16 @@ import (
 func TestHonoredEntityFieldsMatrix(t *testing.T) {
 	type row struct{ balance, nonce, code, approxSize bool }
 	want := map[string]row{
-		TemplateNameEOA:                   {true, true, true, true},
-		TemplateNameRaw:                   {true, true, true, true},
-		TemplateNameERC20:                 {true, true, false, true},
-		TemplateNameStoragePattern:        {true, true, false, false},
-		TemplateNameSequentialEOAs:        {false, false, false, false},
-		TemplateNameSequentialPkeyEOAs:    {false, false, false, false},
-		TemplateNameCreate2Factory:        {false, false, false, false},
-		TemplateNameCreate2Deploys:        {false, false, false, false},
-		TemplateNameCreatePreimageDeploys: {false, false, false, false},
+		TemplateNameEOA:                       {true, true, true, true},
+		TemplateNameRaw:                       {true, true, true, true},
+		TemplateNameERC20:                     {true, true, false, true},
+		TemplateNameStoragePattern:            {true, true, false, false},
+		TemplateNameSequentialEOAs:            {false, false, false, false},
+		TemplateNameSequentialPkeyEOAs:        {false, false, false, false},
+		TemplateNameSequentialPkeyDelegations: {false, false, false, false},
+		TemplateNameCreate2Factory:            {false, false, false, false},
+		TemplateNameCreate2Deploys:            {false, false, false, false},
+		TemplateNameCreatePreimageDeploys:     {false, false, false, false},
 	}
 	for _, name := range Names() {
 		tmpl, ok := Lookup(name)

--- a/internal/templates/registry_test.go
+++ b/internal/templates/registry_test.go
@@ -13,6 +13,7 @@ func TestRegistryHasExpectedTemplates(t *testing.T) {
 		"erc20",
 		"raw",
 		"sequential_eoas",
+		"sequential_pkey_delegations",
 		"sequential_pkey_eoas",
 		"storage_pattern",
 	} // sorted
@@ -31,7 +32,7 @@ func TestLookupHit(t *testing.T) {
 	for _, name := range []string{
 		"create2_deploys", "create2_factory", "create_preimage_deploys",
 		"eoa", "erc20", "raw",
-		"sequential_eoas", "sequential_pkey_eoas", "storage_pattern",
+		"sequential_eoas", "sequential_pkey_delegations", "sequential_pkey_eoas", "storage_pattern",
 	} {
 		if _, ok := Lookup(name); !ok {
 			t.Errorf("Lookup(%q) = false, want true", name)

--- a/internal/templates/sequential_pkey_delegations.go
+++ b/internal/templates/sequential_pkey_delegations.go
@@ -18,9 +18,9 @@ func init() {
 	Register(&sequentialPkeyDelegationsTemplate{})
 }
 
-// delegationDesignatorPrefix is the EIP-7702 marker; full code is the
-// 23-byte prefix || 20-byte delegate target.
-var delegationDesignatorPrefix = []byte{0xEF, 0x01, 0x00}
+// delegationDesignatorPrefix is the 3-byte EIP-7702 marker; the full code
+// is the prefix || 20-byte delegate target (23 bytes total).
+const delegationDesignatorPrefix = "\xef\x01\x00"
 
 // sequentialPkeyDelegationsTemplate handles
 // `kind: contract, template: sequential_pkey_delegations`. One entity
@@ -69,7 +69,7 @@ type sequentialPkeyDelegationsParams struct {
 	balance   *uint256.Int   // never nil, never zero; defaults to 1 wei
 	factory   common.Address // target CREATE2 factory; defaults to Arachnid
 	saltStart uint64         // first target salt
-	initHash  []byte         // keccak256 of the target initcode
+	initHash  common.Hash    // keccak256 of the target initcode
 }
 
 // parseSequentialPkeyDelegationsParams is the single validation+parse
@@ -124,7 +124,7 @@ func parseSequentialPkeyDelegationsParams(params map[string]any) (sequentialPkey
 			return pp, fmt.Errorf("sequential_pkey_delegations: %w", err)
 		}
 		if b.IsZero() {
-			return pp, fmt.Errorf("sequential_pkey_delegations: balance must be > 0 (zero-balance accounts are pruned by EIP-161)")
+			return pp, fmt.Errorf("sequential_pkey_delegations: balance must be > 0 (omit balance to use the 1 wei default)")
 		}
 		pp.balance = b
 	}
@@ -135,7 +135,7 @@ func parseSequentialPkeyDelegationsParams(params map[string]any) (sequentialPkey
 	if err != nil {
 		return pp, err
 	}
-	pp.initHash = crypto.Keccak256(initcode)
+	pp.initHash = crypto.Keccak256Hash(initcode)
 
 	pp.factory = CanonicalCREATE2FactoryAddress
 	if v, has := params["factory"]; has {
@@ -220,7 +220,7 @@ func (sequentialPkeyDelegationsTemplate) Expand(ctx Context, e spec.Entity) ([]P
 		// Target #i: CREATE2 address for salt = salt_start + i.
 		var salt [32]byte
 		binary.BigEndian.PutUint64(salt[24:], pp.saltStart+i)
-		target := crypto.CreateAddress2(pp.factory, salt, pp.initHash)
+		target := crypto.CreateAddress2(pp.factory, salt, pp.initHash[:])
 
 		// Code = 0xef0100 || target (23 bytes).
 		code := make([]byte, 0, len(delegationDesignatorPrefix)+common.AddressLength)

--- a/internal/templates/sequential_pkey_delegations.go
+++ b/internal/templates/sequential_pkey_delegations.go
@@ -1,0 +1,244 @@
+package templates
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/holiman/uint256"
+
+	"github.com/ethereum/state-actor/internal/spec"
+)
+
+func init() {
+	Register(&sequentialPkeyDelegationsTemplate{})
+}
+
+// delegationDesignatorPrefix is the EIP-7702 marker; full code is the
+// 23-byte prefix || 20-byte delegate target.
+var delegationDesignatorPrefix = []byte{0xEF, 0x01, 0x00}
+
+// sequentialPkeyDelegationsTemplate handles
+// `kind: contract, template: sequential_pkey_delegations`. One entity
+// expands into `count` EIP-7702-delegated EOAs. Authority #i has private
+// key (start_pkey + i) and code 0xef0100 || target_i, where target_i is
+// the CREATE2 address keccak256(0xff ++ factory ++ salt ++
+// keccak256(initcode))[12:] for salt = salt_start + i. Authority and
+// target are paired by index.
+//
+// Backs execution-specs `yield_distinct_delegate_receiver()`
+// (account_sender_receiver.py): authority EOA(key=DELEGATE_BASE_KEY + i)
+// delegates to EXISTING_CONTRACT_DIFF receiver i. The target derivation
+// mirrors create2_deploys, so pointing this template at the same
+// code_pattern + factory + salt_start as a create2_deploys entity makes
+// every authority delegate to that entity's planted contract.
+//
+// Only the target's initcode hash matters here (the target contract
+// itself is planted by the paired create2_deploys entity); this template
+// emits just the 23-byte delegation markers.
+type sequentialPkeyDelegationsTemplate struct{}
+
+// TemplateNameSequentialPkeyDelegations is the registry key for this template.
+const TemplateNameSequentialPkeyDelegations = "sequential_pkey_delegations"
+
+func (sequentialPkeyDelegationsTemplate) Name() string {
+	return TemplateNameSequentialPkeyDelegations
+}
+func (sequentialPkeyDelegationsTemplate) UserVisible() bool { return true }
+
+// HonoredEntityFields: derived authorities are fully described by the
+// parameters (nonce 1, balance from params, code = delegation marker);
+// entity-level fields would silently not apply, so they are rejected.
+func (sequentialPkeyDelegationsTemplate) HonoredEntityFields() EntityFieldSet {
+	return EntityFieldSet{
+		Balance:              EntityFieldSupport{Alternative: "parameters.balance"},
+		Nonce:                EntityFieldSupport{}, // delegated authorities are always nonce 1
+		Code:                 EntityFieldSupport{}, // code is the derived delegation marker
+		ApproximateSizeBytes: EntityFieldSupport{Alternative: "parameters.count"},
+	}
+}
+
+// sequentialPkeyDelegationsParams is the typed result of the parse boundary.
+type sequentialPkeyDelegationsParams struct {
+	startPkey *big.Int       // 32-byte scalar in [1, secp256k1Order)
+	count     uint64         // in [1, 2^32]
+	balance   *uint256.Int   // never nil, never zero; defaults to 1 wei
+	factory   common.Address // target CREATE2 factory; defaults to Arachnid
+	saltStart uint64         // first target salt
+	initHash  []byte         // keccak256 of the target initcode
+}
+
+// parseSequentialPkeyDelegationsParams is the single validation+parse
+// boundary; ValidateParameters and Expand both call it so a parameter set
+// that validates is the one that expands.
+func parseSequentialPkeyDelegationsParams(params map[string]any) (sequentialPkeyDelegationsParams, error) {
+	var pp sequentialPkeyDelegationsParams
+	if err := RejectUnknownKeys(params, "sequential_pkey_delegations", []string{
+		"start_pkey", "count", "balance", "code_pattern", "initcode", "factory", "salt_start",
+	}); err != nil {
+		return pp, err
+	}
+	for _, required := range []string{"start_pkey", "count"} {
+		if _, ok := params[required]; !ok {
+			return pp, fmt.Errorf("sequential_pkey_delegations: missing required parameter %q", required)
+		}
+	}
+
+	// Authority key base (start_pkey + i), same derivation as sequential_pkey_eoas.
+	pkeyBytes, err := ParseHexBytesParam(params["start_pkey"], "start_pkey")
+	if err != nil {
+		return pp, fmt.Errorf("sequential_pkey_delegations: %w", err)
+	}
+	if len(pkeyBytes) != 32 {
+		return pp, fmt.Errorf("sequential_pkey_delegations: start_pkey must be exactly 32 bytes (got %d)", len(pkeyBytes))
+	}
+	startInt := new(big.Int).SetBytes(pkeyBytes)
+	if startInt.Sign() == 0 {
+		return pp, fmt.Errorf("sequential_pkey_delegations: start_pkey must be a non-zero secp256k1 scalar")
+	}
+	if startInt.Cmp(secp256k1Order) >= 0 {
+		return pp, fmt.Errorf("sequential_pkey_delegations: start_pkey >= secp256k1 curve order")
+	}
+	pp.startPkey = startInt
+
+	count, err := ParseUint64Param(params["count"], "count")
+	if err != nil {
+		return pp, fmt.Errorf("sequential_pkey_delegations: %w", err)
+	}
+	if count == 0 {
+		return pp, fmt.Errorf("sequential_pkey_delegations: count must be >= 1 (count=0 emits nothing; delete the entity instead)")
+	}
+	if count > practicalFanoutLimit {
+		return pp, fmt.Errorf("sequential_pkey_delegations: count=%d exceeds practical limit (2^32)", count)
+	}
+	pp.count = count
+
+	pp.balance = uint256.NewInt(1)
+	if v, has := params["balance"]; has {
+		b, err := ParseUint256Param(v, "balance")
+		if err != nil {
+			return pp, fmt.Errorf("sequential_pkey_delegations: %w", err)
+		}
+		if b.IsZero() {
+			return pp, fmt.Errorf("sequential_pkey_delegations: balance must be > 0 (zero-balance accounts are pruned by EIP-161)")
+		}
+		pp.balance = b
+	}
+
+	// Delegation target initcode: code_pattern XOR initcode (exactly one).
+	// Only its keccak256 is used — to derive the target CREATE2 address.
+	initcode, err := parseDelegationTargetInitcode(params)
+	if err != nil {
+		return pp, err
+	}
+	pp.initHash = crypto.Keccak256(initcode)
+
+	pp.factory = CanonicalCREATE2FactoryAddress
+	if v, has := params["factory"]; has {
+		f, err := ParseAddressParam(v, "factory")
+		if err != nil {
+			return pp, fmt.Errorf("sequential_pkey_delegations: %w", err)
+		}
+		pp.factory = f
+	}
+	if v, has := params["salt_start"]; has {
+		s, err := ParseUint64Param(v, "salt_start")
+		if err != nil {
+			return pp, fmt.Errorf("sequential_pkey_delegations: %w", err)
+		}
+		pp.saltStart = s
+	}
+	return pp, nil
+}
+
+// parseDelegationTargetInitcode resolves the target initcode from either a
+// named code_pattern or a literal initcode (exactly one required).
+func parseDelegationTargetInitcode(params map[string]any) ([]byte, error) {
+	_, hasPattern := params["code_pattern"]
+	_, hasInitcode := params["initcode"]
+	switch {
+	case hasPattern && hasInitcode:
+		return nil, fmt.Errorf("sequential_pkey_delegations: set exactly one of `code_pattern` or `initcode`, not both")
+	case hasPattern:
+		name, ok := params["code_pattern"].(string)
+		if !ok {
+			return nil, fmt.Errorf("sequential_pkey_delegations: code_pattern must be a string (got %T)", params["code_pattern"])
+		}
+		if !IsKnownCodePattern(name) {
+			return nil, fmt.Errorf("sequential_pkey_delegations: unknown code_pattern %q (known: %s)",
+				name, strings.Join(knownCodePatterns, ", "))
+		}
+		return codePatternInitcodeFor(name)
+	case hasInitcode:
+		ic, err := ParseHexBytesParam(params["initcode"], "initcode")
+		if err != nil {
+			return nil, fmt.Errorf("sequential_pkey_delegations: %w", err)
+		}
+		if len(ic) == 0 {
+			return nil, fmt.Errorf("sequential_pkey_delegations: initcode must be non-empty")
+		}
+		return ic, nil
+	default:
+		return nil, fmt.Errorf("sequential_pkey_delegations: missing delegation target — set `code_pattern` or `initcode`")
+	}
+}
+
+func (sequentialPkeyDelegationsTemplate) ValidateParameters(params map[string]any) error {
+	_, err := parseSequentialPkeyDelegationsParams(params)
+	return err
+}
+
+func (sequentialPkeyDelegationsTemplate) Expand(ctx Context, e spec.Entity) ([]PreAllocEntity, error) {
+	pp, err := parseSequentialPkeyDelegationsParams(e.Parameters)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]PreAllocEntity, 0, pp.count)
+	cur := new(big.Int).Set(pp.startPkey)
+	one := big.NewInt(1)
+	seen := make(map[common.Address]struct{}, pp.count)
+	for i := uint64(0); i < pp.count; i++ {
+		if cur.Sign() == 0 || cur.Cmp(secp256k1Order) >= 0 {
+			return nil, fmt.Errorf(
+				"sequential_pkey_delegations: derived pkey #%d falls outside [1, secp256k1_order); pick a smaller count or different start_pkey",
+				i)
+		}
+		priv, err := derivePrivateKey(cur)
+		if err != nil {
+			return nil, fmt.Errorf("sequential_pkey_delegations: derive pkey #%d: %w", i, err)
+		}
+		authority := crypto.PubkeyToAddress(priv.PublicKey)
+		if _, dup := seen[authority]; dup {
+			return nil, fmt.Errorf("sequential_pkey_delegations: duplicate authority %s at pkey #%d", authority.Hex(), i)
+		}
+		seen[authority] = struct{}{}
+
+		// Target #i: CREATE2 address for salt = salt_start + i.
+		var salt [32]byte
+		binary.BigEndian.PutUint64(salt[24:], pp.saltStart+i)
+		target := crypto.CreateAddress2(pp.factory, salt, pp.initHash)
+
+		// Code = 0xef0100 || target (23 bytes).
+		code := make([]byte, 0, len(delegationDesignatorPrefix)+common.AddressLength)
+		code = append(code, delegationDesignatorPrefix...)
+		code = append(code, target[:]...)
+
+		out = append(out, PreAllocEntity{
+			Address: authority,
+			Account: &types.StateAccount{
+				// Delegating via SetCode bumps the authority nonce to 1.
+				Nonce:    1,
+				Balance:  new(uint256.Int).Set(pp.balance),
+				Root:     types.EmptyRootHash,
+				CodeHash: crypto.Keccak256Hash(code).Bytes(),
+			},
+			Code: code,
+		})
+		cur.Add(cur, one)
+	}
+	return out, nil
+}

--- a/internal/templates/sequential_pkey_delegations_test.go
+++ b/internal/templates/sequential_pkey_delegations_test.go
@@ -1,0 +1,112 @@
+package templates
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
+)
+
+// TestSequentialPkeyDelegationsMatchesEELS pins the authority addresses
+// and full EIP-7702 delegation codes against execution-specs
+// `yield_distinct_delegate_receiver()`: authority EOA(key=DELEGATE_BASE_KEY
+// + i) delegates to EXISTING_CONTRACT_DIFF receiver i (max_diff CREATE2).
+//
+// start_pkey = keccak256("gas-repricings-7702-delegate"). Authorities and
+// codes regenerated from an execution-specs checkout via
+// account_sender_receiver.yield_distinct_delegate_receiver +
+// AccountCreator(EXISTING_CONTRACT_DIFF).initcode.
+func TestSequentialPkeyDelegationsMatchesEELS(t *testing.T) {
+	ent := mkContractEntity("sequential_pkey_delegations", map[string]any{
+		"start_pkey":   "0x959a83d905ff1fab43bf72c3e87020e4c77fd4bde0e5eeb48e5edbf74a9ec64e",
+		"code_pattern": CodePatternMaxDiffPreAmsterdam,
+		"count":        2,
+		"balance":      "1000000000000000000",
+	})
+	out, err := (&sequentialPkeyDelegationsTemplate{}).Expand(Context{}, ent)
+	if err != nil {
+		t.Fatalf("Expand: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("count: got %d want 2", len(out))
+	}
+	type want struct {
+		authority string
+		code      string // full 23-byte 0xef0100||target
+	}
+	wants := []want{
+		{"0xc700a71c3ee17f9106ff87e3a27dc52ce9d551eb", "0xef0100a9cb82ea3c688e8c8153e60c1e340840459f66a6"},
+		{"0xf32d6227cde81dde6832accdb5288300f2f1c126", "0xef010099ea5fb3758b5fa20b4dfbd2971e98e9723f8f1f"},
+	}
+	bal := uint256.NewInt(1_000_000_000_000_000_000)
+	for i, w := range wants {
+		if out[i].Address != common.HexToAddress(w.authority) {
+			t.Errorf("i=%d authority: got %s want EELS %s", i, out[i].Address.Hex(), w.authority)
+		}
+		gotCode := "0x" + common.Bytes2Hex(out[i].Code)
+		if !strings.EqualFold(gotCode, w.code) {
+			t.Errorf("i=%d code: got %s want %s", i, gotCode, w.code)
+		}
+		if out[i].Account.Nonce != 1 {
+			t.Errorf("i=%d nonce: got %d want 1", i, out[i].Account.Nonce)
+		}
+		if out[i].Account.Balance.Cmp(bal) != 0 {
+			t.Errorf("i=%d balance: got %s want 1e18", i, out[i].Account.Balance)
+		}
+	}
+}
+
+// TestSequentialPkeyDelegationsLiteralInitcode checks the literal-initcode
+// target mode derives the same address create2_deploys would for that
+// initcode (here the minimal STOP initcode).
+func TestSequentialPkeyDelegationsLiteralInitcode(t *testing.T) {
+	ent := mkContractEntity("sequential_pkey_delegations", map[string]any{
+		"start_pkey": "0x959a83d905ff1fab43bf72c3e87020e4c77fd4bde0e5eeb48e5edbf74a9ec64e",
+		"initcode":   "0x60016000f3", // minimal contract initcode
+		"count":      1,
+	})
+	out, err := (&sequentialPkeyDelegationsTemplate{}).Expand(Context{}, ent)
+	if err != nil {
+		t.Fatalf("Expand: %v", err)
+	}
+	// Target salt 0 for the minimal initcode (matches create2-minimal salt 0).
+	wantTarget := common.HexToAddress("0x794a5Ba51C916E51aD4f45C85e67D9A07e8D0967")
+	gotTarget := common.BytesToAddress(out[0].Code[3:]) // strip 0xef0100
+	if gotTarget != wantTarget {
+		t.Errorf("delegation target: got %s want %s", gotTarget.Hex(), wantTarget.Hex())
+	}
+}
+
+// TestSequentialPkeyDelegationsValidation pins the parameter guards.
+func TestSequentialPkeyDelegationsValidation(t *testing.T) {
+	tmpl := sequentialPkeyDelegationsTemplate{}
+	cases := []struct {
+		name   string
+		params map[string]any
+		errSub string
+	}{
+		{"both target modes", map[string]any{
+			"start_pkey": "0x959a83d905ff1fab43bf72c3e87020e4c77fd4bde0e5eeb48e5edbf74a9ec64e",
+			"count":      1, "code_pattern": CodePatternMaxDiffPreAmsterdam, "initcode": "0x60016000f3",
+		}, "exactly one"},
+		{"no target", map[string]any{
+			"start_pkey": "0x959a83d905ff1fab43bf72c3e87020e4c77fd4bde0e5eeb48e5edbf74a9ec64e", "count": 1,
+		}, "missing delegation target"},
+		{"unknown pattern", map[string]any{
+			"start_pkey": "0x959a83d905ff1fab43bf72c3e87020e4c77fd4bde0e5eeb48e5edbf74a9ec64e",
+			"count":      1, "code_pattern": "bogus",
+		}, "unknown code_pattern"},
+		{"short pkey", map[string]any{
+			"start_pkey": "0x1234", "count": 1, "initcode": "0x60016000f3",
+		}, "32 bytes"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := tmpl.ValidateParameters(c.params)
+			if err == nil || !strings.Contains(err.Error(), c.errSub) {
+				t.Errorf("want error containing %q, got %v", c.errSub, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Adds 2 pre-state generators needed to support execution-specs benchmarks end-to-end:

- `tests/benchmark/stateful/bloatnet/test_account_query.py::test_account_access`
- `tests/benchmark/stateful/bloatnet/test_transaction_types.py::test_ether_transfers_onchain_receivers`

Related PR: https://github.com/ethereum/execution-specs/pull/2947

This includes two new `create2_deploys` code patterns and one new template, each byte-for-byte aligned with the corresponding execution-specs helper, so the CREATE2-derived (and pkey-derived) addresses match what the tests query at runtime.

## What's added

### Two new code patterns (`internal/templates/code_pattern.go`)

| Pattern | Runtime | EELS counterpart | Used by |
|---|---|---|---|
| `max_same_pre_amsterdam` | 24 KB, `STOP` + JUMPDEST **identical** across copies | `UniqueMaxContractInitcode(diff=False)` | `EXISTING_CONTRACT_SAME` / `diff_to_contract_same` |
| `max_diff_pre_amsterdam` | 24 KB, embeds each contract's own address, **byte-unique** | `UniqueMaxContractInitcode(diff=True)` | `EXISTING_CONTRACT_DIFF` / `diff_to_contract_diff` |

### New template `sequential_pkey_delegations` (`internal/templates/sequential_pkey_delegations.go`)

Expands one entity into `count` EIP-7702-delegated EOAs. Authority `#i`:

- **address**: derived from private key `start_pkey + i` (same secp256k1 derivation as `sequential_pkey_eoas`)
- **code**: `0xef0100 || target_i`, where `target_i` is the CREATE2 address for salt `salt_start + i` (same derivation as `create2_deploys`, via `code_pattern` or a literal `initcode`)
- **nonce**: `1` as a 7702 delegation can only exist after processing one SetCode authorization, which bumps the authority nonce.

## EELS alignment

Every derivation is pinned against values computed independently in an
execution-specs checkout (eth_utils keccak, outside go-ethereum):

- `max_same` aligns with `UniqueMaxContractInitcode(diff=False)`.
- `max_diff` aligns with `UniqueMaxContractInitcode(diff=True)`.
- `delegations`: `start_pkey = keccak256("gas-repricings-7702-delegate")`;  authority addresses and full `0xef0100||target` codes (i = 0/1) match `yield_distinct_delegate_receiver()` paired with the `max_diff` receivers.

---

## New Entry Needed

### Minimal Size Contract With Same Bytecode

Entry:

```
# New entry
  - kind: contract
    name: create2-minimal
    template: create2_deploys
    parameters:
      initcode: "0x60016000f3"
      runtime: "0x00"
      salt_count: 150000
```

### Maximum Size Contract With Same Bytecode

Entry:

```
# New entry
  - kind: contract
    name: create2-same
    template: create2_deploys
    parameters:
      code_pattern: max_same_pre_amsterdam
      salt_count: 150000
```

### Maximum Size Contract with Diff Bytecode

Entry:

```
# New entry
  - kind: contract
    name: create2-diff-300m
    template: create2_deploys
    parameters:
      code_pattern: max_diff_pre_amsterdam
      salt_count: 150000
```

### Delegated EOA to Maximum Size Contract:

Entry:

```
# New entry
  - kind: contract
    name: create2-diff-delegations-300m
    template: sequential_pkey_delegations
    parameters:
      start_pkey: "0x959a83d905ff1fab43bf72c3e87020e4c77fd4bde0e5eeb48e5edbf74a9ec64e"
      code_pattern: max_diff_pre_amsterdam
      count: 150000
      balance: "1000000000000000000"
```