### PR TITLE
fix(besu): stream the account-state trie to bound generation memory

### DIFF
--- a/client/besu/genesis_alloc_cgo.go
+++ b/client/besu/genesis_alloc_cgo.go
@@ -45,7 +45,7 @@ func writeGenesisAllocAccounts(
 		return bytes.Compare(entries[i].addrHash[:], entries[j].addrHash[:]) < 0
 	})
 
-	builder := besutrie.New(sink)
+	builder := besutrie.NewStreamingAccountBuilder(sink)
 
 	for _, e := range entries {
 		if err := ctx.Err(); err != nil {
@@ -57,7 +57,7 @@ func writeGenesisAllocAccounts(
 
 		// Per-account storage trie via the streaming builder (O(depth) memory).
 		if len(e.acc.Storage) > 0 {
-			sb := builder.BeginStreamingStorage(e.addrHash)
+			sb := besutrie.NewStreamingStorageBuilder(sink, e.addrHash)
 			// Sort slots by slotHash — the streaming builder requires
 			// keccak-ascending input.
 			type slotKV struct {

--- a/client/besu/state_writer_cgo.go
+++ b/client/besu/state_writer_cgo.go
@@ -43,9 +43,12 @@ func writeStateAndCollectRoot(
 ) (common.Hash, []byte, *generator.Stats, error) {
 	stats := &generator.Stats{}
 
-	// builder is created up-front so Phase 0 can drive per-account
-	// BeginStorage sub-builders before Phase 1 queues account leaves.
-	builder := besutrie.New(sink)
+	// builder streams the account-state trie: it emits trie nodes as the
+	// right-spine collapses (O(trie depth) memory) rather than holding the
+	// entire account MPT resident until Commit (O(accounts) — which OOMs on
+	// large datadirs). Fed in Phase 2 in sorted addrHash order, matching how
+	// geth/reth/neth build their account trie via StackTrie / HashBuilder.
+	builder := besutrie.NewStreamingAccountBuilder(sink)
 
 	// hashToAddr lets Phase 2 read cfg.GenesisAccounts[addr].Root (set
 	// by Phase 0) when encoding spec-entity account leaves.
@@ -163,7 +166,10 @@ func writeStateAndCollectRoot(
 		codeHash := besu.EmptyCodeHash
 		if entity.kind == entityContract {
 			if len(entity.slots) > 0 {
-				sb := builder.BeginStorage(addrHash)
+				// Streaming storage builder: O(depth) like the account trie.
+				// Fed below in sorted-by-slotHash order (slot hashes are unique
+				// within a contract, so insertion is strictly ascending).
+				sb := besutrie.NewStreamingStorageBuilder(sink, addrHash)
 				// Storage trie requires sorted-by-slotHash insertion.
 				type kv struct {
 					slotHash common.Hash

--- a/internal/besu/trie/builder.go
+++ b/internal/besu/trie/builder.go
@@ -84,10 +84,7 @@ func (b *Builder) BeginStorage(addrHash common.Hash) *StorageBuilder {
 // right-spine algorithm. Required for entities with millions of slots
 // where the non-streaming StorageBuilder OOMs.
 func (b *Builder) BeginStreamingStorage(addrHash common.Hash) *StreamingStorageBuilder {
-	return &StreamingStorageBuilder{
-		addrHash: addrHash,
-		sink:     b.sink,
-	}
+	return NewStreamingStorageBuilder(b.sink, addrHash)
 }
 
 // Commit finalizes the account-state trie and emits all non-inline nodes via

--- a/internal/besu/trie/streaming_account_builder.go
+++ b/internal/besu/trie/streaming_account_builder.go
@@ -1,0 +1,55 @@
+package trie
+
+import "github.com/ethereum/go-ethereum/common"
+
+// StreamingAccountBuilder builds the Bonsai account-state trie in O(trie depth)
+// memory, the account-trie counterpart to StreamingStorageBuilder. It is a thin
+// wrapper over the shared streamingBuilder engine with an account emitter
+// (un-prefixed node keys via PutAccountStateTrieNode).
+//
+// It replaces the non-streaming Builder for bulk generation: Builder keeps the
+// entire account MPT resident until Commit (O(accounts) memory), which OOMs on
+// large datadirs; this builder emits nodes as the right-spine collapses, so peak
+// memory is O(depth) regardless of account count — matching how geth/reth/neth
+// build their account trie via StackTrie / HashBuilder.
+//
+// Input contract: AddAccount/AddLeaf calls MUST arrive in strictly ascending
+// keccak256(address) (addrHash) order; the Phase 2 sorted-Pebble iteration
+// provides this.
+type StreamingAccountBuilder struct {
+	c streamingBuilder
+}
+
+// NewStreamingAccountBuilder constructs a streaming account-state trie builder
+// that emits trie nodes through the caller-supplied sink.
+func NewStreamingAccountBuilder(sink NodeSink) *StreamingAccountBuilder {
+	return &StreamingAccountBuilder{c: streamingBuilder{sink: sink, em: accountTrieEmitter{}}}
+}
+
+// AddAccount inserts (addrHash → accountRLP) into the account-state trie.
+// addrHash must be keccak256(address); accountRLP is the flat account RLP.
+// addrHash MUST be strictly greater than the previous call's; out-of-order input
+// returns ErrSlotsOutOfOrder.
+func (ab *StreamingAccountBuilder) AddAccount(addrHash common.Hash, accountRLP []byte) error {
+	return ab.c.addLeaf(addrHash, accountRLP)
+}
+
+// AddLeaf is an alias for AddAccount so *StreamingAccountBuilder satisfies
+// streamingtrie.HashBuilder.
+func (ab *StreamingAccountBuilder) AddLeaf(keyHash common.Hash, valueRLP []byte) error {
+	return ab.c.addLeaf(keyHash, valueRLP)
+}
+
+// Commit finalises the account trie and returns (rootHash, rootRLP). The caller
+// passes rootRLP to NodeSink.SaveWorldState. An empty trie returns
+// (EmptyTrieNodeHash, [0x80]) with zero sink calls.
+func (ab *StreamingAccountBuilder) Commit() (common.Hash, []byte, error) {
+	return ab.c.finalize()
+}
+
+// Root finalises the account trie and returns just the root hash. Implements
+// the streamingtrie.HashBuilder contract (alongside AddLeaf).
+func (ab *StreamingAccountBuilder) Root() (common.Hash, error) {
+	h, _, err := ab.c.finalize()
+	return h, err
+}

--- a/internal/besu/trie/streaming_account_builder_test.go
+++ b/internal/besu/trie/streaming_account_builder_test.go
@@ -1,0 +1,141 @@
+package trie
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/holiman/uint256"
+
+	"github.com/ethereum/state-actor/internal/besu"
+	besurlp "github.com/ethereum/state-actor/internal/besu/rlp"
+)
+
+type acctEntry struct {
+	hash common.Hash
+	rlp  []byte
+}
+
+// makeSortedAccounts builds n distinct accounts sorted by addrHash ascending —
+// the order the Phase 2 sorted-Pebble iteration feeds the builder.
+func makeSortedAccounts(t *testing.T, n int) []acctEntry {
+	t.Helper()
+	out := make([]acctEntry, 0, n)
+	for i := 0; i < n; i++ {
+		h := crypto.Keccak256Hash([]byte{byte(i), byte(i >> 8), byte(i >> 16), 0xac})
+		rlp, err := besurlp.EncodeAccount(uint64(i+1), uint256.NewInt(uint64(i)*7+1), besu.EmptyTrieNodeHash, besu.EmptyCodeHash)
+		if err != nil {
+			t.Fatalf("EncodeAccount: %v", err)
+		}
+		out = append(out, acctEntry{hash: h, rlp: rlp})
+	}
+	sort.Slice(out, func(i, j int) bool { return bytes.Compare(out[i].hash[:], out[j].hash[:]) < 0 })
+	// Drop any (astronomically unlikely) duplicate hashes — the streaming
+	// builder requires strictly ascending keys.
+	dedup := out[:0]
+	var last common.Hash
+	for i, a := range out {
+		if i > 0 && a.hash == last {
+			continue
+		}
+		dedup = append(dedup, a)
+		last = a.hash
+	}
+	return dedup
+}
+
+// TestStreamingAccountBuilder_MatchesInMemoryBuilder is the correctness gate for
+// the OOM fix: the streaming account builder must produce a byte-identical trie
+// — same root hash, same root RLP, and the same set of emitted nodes — as the
+// non-streaming in-memory Builder, for the same sorted account set.
+func TestStreamingAccountBuilder_MatchesInMemoryBuilder(t *testing.T) {
+	for _, n := range []int{0, 1, 2, 17, 256, 5000} {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			accts := makeSortedAccounts(t, n)
+
+			// Reference: non-streaming in-memory Builder.
+			refSink := &recordingSink{}
+			ref := New(refSink)
+			for _, a := range accts {
+				if err := ref.AddAccount(a.hash, a.rlp); err != nil {
+					t.Fatalf("ref AddAccount: %v", err)
+				}
+			}
+			refHash, refRLP, err := ref.Commit()
+			if err != nil {
+				t.Fatalf("ref Commit: %v", err)
+			}
+
+			// Under test: streaming builder.
+			strSink := &recordingSink{}
+			str := NewStreamingAccountBuilder(strSink)
+			for _, a := range accts {
+				if err := str.AddAccount(a.hash, a.rlp); err != nil {
+					t.Fatalf("streaming AddAccount: %v", err)
+				}
+			}
+			strHash, strRLP, err := str.Commit()
+			if err != nil {
+				t.Fatalf("streaming Commit: %v", err)
+			}
+
+			if refHash != strHash {
+				t.Errorf("root hash mismatch: ref %x, streaming %x", refHash, strHash)
+			}
+			if !bytes.Equal(refRLP, strRLP) {
+				t.Errorf("root RLP mismatch: ref %x, streaming %x", refRLP, strRLP)
+			}
+			assertSameStateNodes(t, refSink.stateNodes, strSink.stateNodes)
+		})
+	}
+}
+
+// TestStreamingAccountBuilder_RejectsOutOfOrder pins the strict-ascending input
+// contract.
+func TestStreamingAccountBuilder_RejectsOutOfOrder(t *testing.T) {
+	b := NewStreamingAccountBuilder(&recordingSink{})
+	hi := crypto.Keccak256Hash([]byte{0x02})
+	lo := crypto.Keccak256Hash([]byte{0x01})
+	if hi.Big().Cmp(lo.Big()) < 0 {
+		hi, lo = lo, hi // ensure hi > lo
+	}
+	if err := b.AddAccount(hi, []byte{0x11}); err != nil {
+		t.Fatalf("first AddAccount: %v", err)
+	}
+	if err := b.AddAccount(lo, []byte{0x22}); err == nil {
+		t.Fatalf("expected ErrSlotsOutOfOrder for descending addrHash, got nil")
+	}
+}
+
+// assertSameStateNodes checks the two builders emitted the same set of account
+// trie nodes (keyed by location). Emission ORDER may differ (in-memory commits
+// post-order at the end; streaming emits as the spine collapses), so compare as
+// a set.
+func assertSameStateNodes(t *testing.T, ref, got []sinkRecord) {
+	t.Helper()
+	if len(ref) != len(got) {
+		t.Errorf("emitted node count: ref %d, streaming %d", len(ref), len(got))
+	}
+	index := func(rs []sinkRecord) map[string]sinkRecord {
+		m := make(map[string]sinkRecord, len(rs))
+		for _, r := range rs {
+			m[string(r.location)] = r
+		}
+		return m
+	}
+	refByLoc := index(ref)
+	for _, g := range got {
+		r, ok := refByLoc[string(g.location)]
+		if !ok {
+			t.Errorf("streaming emitted node at location %x absent in ref", g.location)
+			continue
+		}
+		if r.hash != g.hash || !bytes.Equal(r.rlp, g.rlp) {
+			t.Errorf("node mismatch at location %x:\n  ref:       hash %x rlp %x\n  streaming: hash %x rlp %x",
+				g.location, r.hash, r.rlp, g.hash, g.rlp)
+		}
+	}
+}

--- a/internal/besu/trie/streaming_storage_builder.go
+++ b/internal/besu/trie/streaming_storage_builder.go
@@ -10,150 +10,127 @@ import (
 	"github.com/ethereum/state-actor/internal/besu"
 )
 
-// ErrSlotsOutOfOrder is returned by StreamingStorageBuilder.AddSlot when
-// the new slotHash is less than or equal to the previous slotHash. The
-// streaming algorithm assumes strictly ascending input.
-var ErrSlotsOutOfOrder = errors.New("besu/trie: AddSlot called out of keccak-ascending order")
+// ErrSlotsOutOfOrder is returned when a streaming builder receives a key that
+// is less than or equal to the previous key. The streaming algorithm assumes
+// strictly ascending keccak-key input (slots for storage, addrHashes for the
+// account trie).
+var ErrSlotsOutOfOrder = errors.New("besu/trie: streaming leaf added out of keccak-ascending order")
 
-// StreamingStorageBuilder builds the per-account Bonsai storage trie in
-// O(trie depth) memory by processing keccak-sorted slot inserts through a
-// right-spine, mirroring the reth HashBuilder / geth StackTrie algorithm.
+// streamingBuilder is the shared right-spine engine for both the account-state
+// trie and the per-account storage tries. It builds a Bonsai MPT in O(trie
+// depth) memory by processing keccak-sorted leaf inserts through a right-spine,
+// mirroring the reth HashBuilder / geth StackTrie algorithm. The only
+// account-vs-storage difference is the node-emit target, supplied via em:
+//   - accountTrieEmitter → PutAccountStateTrieNode(location, …)
+//   - storageTrieEmitter → PutAccountStorageTrieNode(addrHash, location, …)
+//
 // Bonsai-specific:
 //   - DB key is the raw-nibble location (1 byte/nibble), assembled
 //     incrementally from current[0:lenFrom] (leaves/extensions) or
 //     current[0:length] (branches).
 //   - Roots whose RLP < 32 bytes are emitted explicitly at RootLocation
-//     (matches StorageBuilder.Commit's small-root case).
+//     (matches the non-streaming builders' small-root case).
 //   - Nodes whose hash equals besu.EmptyTrieNodeHash are not emitted.
-//
-// Input contract: AddSlot calls MUST arrive in strictly ascending
-// keccak256(slotKey) order; streamingtrie.IterateRoot provides this.
-type StreamingStorageBuilder struct {
-	addrHash common.Hash
-	sink     NodeSink
+type streamingBuilder struct {
+	sink NodeSink
+	em   emitter
 
-	// prevPath is the keyPath(prevSlotHash) — 65 bytes, terminator 0x10
-	// at index 64. nil until the first AddSlot.
+	// prevPath is the keyPath(prevKeyHash) — 65 bytes, terminator 0x10 at
+	// index 64. nil until the first leaf.
 	prevPath  []byte
 	prevValue []byte
 
 	// stack holds the right-spine of finalized child references in
-	// ascending-depth order. Each entry is either inline RLP (len < 32)
-	// or a 33-byte hash reference (0xa0 || keccak(rlp)).
+	// ascending-depth order. Each entry is either inline RLP (len < 32) or a
+	// 33-byte hash reference (0xa0 || keccak(rlp)).
 	stack [][]byte
-	// stateMasks[d] is the slot-occupancy bitset for the branch whose
-	// location is prevPath[:d]. Bit i set iff slot i has a finalized
-	// child somewhere on the stack.
+	// stateMasks[d] is the slot-occupancy bitset for the branch whose location
+	// is prevPath[:d]. Bit i set iff slot i has a finalized child on the stack.
 	stateMasks []uint16
 
 	leafCount int
+
+	// rootRLP captures the full RLP of the root node (the one emitted at the
+	// empty RootLocation). Needed by the account caller for SaveWorldState; the
+	// storage caller ignores it.
+	rootRLP []byte
 }
 
-// NewStreamingStorageBuilder constructs a streaming builder that emits
-// trie nodes through the caller-supplied sink. Use this when parallel
-// workers each need their own builder pointing at their own per-worker
-// node sink — `Builder.BeginStreamingStorage` is fine for the single-
-// goroutine path, but its returned builder writes through the parent
-// Builder's shared sink and is unsafe under concurrent use.
-//
-// addrHash must be the keccak256(address) the storage trie belongs to;
-// it's used as the prefix on every emitted trie-node write.
-func NewStreamingStorageBuilder(sink NodeSink, addrHash common.Hash) *StreamingStorageBuilder {
-	return &StreamingStorageBuilder{
-		addrHash: addrHash,
-		sink:     sink,
-	}
-}
-
-// AddSlot inserts (slotHash → valueRLP) into the streaming Bonsai
-// storage trie. slotHash MUST be strictly greater than the previous
-// call's slotHash; out-of-order input returns ErrSlotsOutOfOrder.
-func (sb *StreamingStorageBuilder) AddSlot(slotHash common.Hash, valueRLP []byte) error {
-	newPath := keyPath(slotHash[:])
-	if sb.prevPath != nil {
-		if cmp := bytes.Compare(newPath, sb.prevPath); cmp <= 0 {
+// addLeaf inserts (keyHash → valueRLP). keyHash MUST be strictly greater than
+// the previous call's keyHash; out-of-order input returns ErrSlotsOutOfOrder.
+func (c *streamingBuilder) addLeaf(keyHash common.Hash, valueRLP []byte) error {
+	newPath := keyPath(keyHash[:])
+	if c.prevPath != nil {
+		if cmp := bytes.Compare(newPath, c.prevPath); cmp <= 0 {
 			return ErrSlotsOutOfOrder
 		}
-		if err := sb.update(newPath); err != nil {
+		if err := c.update(newPath); err != nil {
 			return err
 		}
 	}
-	sb.leafCount++
-	sb.prevPath = newPath
-	// streamingtrie may reuse the valueRLP buffer between iterations —
-	// copy so we can hold it until the next AddSlot or Commit.
-	sb.prevValue = append([]byte(nil), valueRLP...)
+	c.leafCount++
+	c.prevPath = newPath
+	// The caller may reuse the valueRLP buffer between iterations — copy so we
+	// can hold it until the next addLeaf or finalize.
+	c.prevValue = append([]byte(nil), valueRLP...)
 	return nil
 }
 
-// AddLeaf is an alias for AddSlot — both append one (keccak-key, RLP value)
-// leaf to the trie. The alias lets *StreamingStorageBuilder satisfy
-// streamingtrie.HashBuilder without an adapter.
-func (sb *StreamingStorageBuilder) AddLeaf(keyHash common.Hash, valueRLP []byte) error {
-	return sb.AddSlot(keyHash, valueRLP)
-}
-
-// Root finalises the streaming build and returns the storage trie root.
-// Implements the streamingtrie.HashBuilder contract (alongside AddLeaf).
-func (sb *StreamingStorageBuilder) Root() (common.Hash, error) {
-	return sb.Commit()
-}
-
-// Commit finalises the streaming build and returns the storage trie root.
-// Empty trie returns EmptyTrieNodeHash with zero sink calls. Small-root
-// case (root RLP < 32 bytes) emits the root at RootLocation, matching
-// the non-streaming StorageBuilder at builder.go:131-140.
-func (sb *StreamingStorageBuilder) Commit() (common.Hash, error) {
-	if sb.leafCount == 0 {
-		return besu.EmptyTrieNodeHash, nil
+// finalize collapses the spine and returns (rootHash, rootRLP). Empty trie
+// returns EmptyTrieNodeHash with the canonical empty-RLP [0x80] and zero sink
+// calls. Small-root case (root RLP < 32 bytes) emits the root at RootLocation,
+// matching the non-streaming builders.
+func (c *streamingBuilder) finalize() (common.Hash, []byte, error) {
+	if c.leafCount == 0 {
+		return besu.EmptyTrieNodeHash, []byte{0x80}, nil
 	}
-	if sb.prevPath != nil {
-		if err := sb.update(nil); err != nil {
-			return common.Hash{}, err
+	if c.prevPath != nil {
+		if err := c.update(nil); err != nil {
+			return common.Hash{}, nil, err
 		}
-		sb.prevPath = nil
-		sb.prevValue = nil
+		c.prevPath = nil
+		c.prevValue = nil
 	}
-	if len(sb.stack) == 0 {
-		// Defensive — leafCount > 0 implies stack is non-empty after
-		// update(nil). Treat as empty if somehow drained.
-		return besu.EmptyTrieNodeHash, nil
+	if len(c.stack) == 0 {
+		// Defensive — leafCount > 0 implies stack is non-empty after update(nil).
+		return besu.EmptyTrieNodeHash, []byte{0x80}, nil
 	}
-	rootRef := sb.stack[len(sb.stack)-1]
+	rootRef := c.stack[len(c.stack)-1]
 	if len(rootRef) == 33 && rootRef[0] == 0xa0 {
 		var h common.Hash
 		copy(h[:], rootRef[1:])
-		return h, nil
+		// Hashed root: its full RLP was captured by maybeEmit at RootLocation.
+		return h, c.rootRLP, nil
 	}
 	// Root RLP is inline (< 32 B). Emit at RootLocation explicitly.
 	rootRLP := rootRef
 	rootHash := NodeHash(rootRLP)
 	if rootHash != besu.EmptyTrieNodeHash {
-		if err := sb.sink.PutAccountStorageTrieNode(sb.addrHash, RootLocation, rootHash, rootRLP); err != nil {
-			return common.Hash{}, err
+		if err := c.em.emit(c.sink, RootLocation, rootHash, rootRLP); err != nil {
+			return common.Hash{}, nil, err
 		}
 	}
-	return rootHash, nil
+	return rootHash, rootRLP, nil
 }
 
-// update processes the deferred previous leaf against the new succeeding
-// key. If succeeding is nil, performs full finalisation (collapses the
-// spine down to a single root reference).
+// update processes the deferred previous leaf against the new succeeding key.
+// If succeeding is nil, performs full finalisation (collapses the spine down to
+// a single root reference).
 //
 // Mirrors reth's HashBuilder.update at internal/reth/hash_builder.go:223-303
-// with three Bonsai adjustments: (1) location bytes built incrementally
-// for every emit, (2) emit fires for leaves and extensions in addition
-// to branches (reth only emits branch metadata for incremental
-// re-execution), (3) HP-encoding via Bonsai's CompactEncode.
-func (sb *StreamingStorageBuilder) update(succeeding []byte) error {
+// with three Bonsai adjustments: (1) location bytes built incrementally for
+// every emit, (2) emit fires for leaves and extensions in addition to branches
+// (reth only emits branch metadata for incremental re-execution), (3) HP-encoding
+// via Bonsai's CompactEncode.
+func (c *streamingBuilder) update(succeeding []byte) error {
 	buildExtensions := false
-	current := sb.prevPath
+	current := c.prevPath
 
 	for {
-		precedingExists := len(sb.stateMasks) > 0
+		precedingExists := len(c.stateMasks) > 0
 		precedingLen := 0
 		if precedingExists {
-			precedingLen = len(sb.stateMasks) - 1
+			precedingLen = len(c.stateMasks) - 1
 		}
 
 		cpl := commonPrefixLen(succeeding, current)
@@ -163,10 +140,10 @@ func (sb *StreamingStorageBuilder) update(succeeding []byte) error {
 		}
 
 		extraDigit := current[length]
-		for len(sb.stateMasks) <= length {
-			sb.stateMasks = append(sb.stateMasks, 0)
+		for len(c.stateMasks) <= length {
+			c.stateMasks = append(c.stateMasks, 0)
 		}
-		sb.stateMasks[length] |= uint16(1) << extraDigit
+		c.stateMasks[length] |= uint16(1) << extraDigit
 
 		lenFrom := length
 		if len(succeeding) > 0 || precedingExists {
@@ -175,23 +152,23 @@ func (sb *StreamingStorageBuilder) update(succeeding []byte) error {
 		shortNodeKey := current[lenFrom:]
 
 		if !buildExtensions {
-			leafRLP := encodeLeafRLP(shortNodeKey, sb.prevValue)
+			leafRLP := encodeLeafRLP(shortNodeKey, c.prevValue)
 			leafLocation := append([]byte(nil), current[:lenFrom]...)
-			if err := sb.maybeEmit(leafLocation, leafRLP); err != nil {
+			if err := c.maybeEmit(leafLocation, leafRLP); err != nil {
 				return err
 			}
-			sb.stack = append(sb.stack, refOfRLP(leafRLP))
+			c.stack = append(c.stack, refOfRLP(leafRLP))
 		}
 
 		if buildExtensions && len(shortNodeKey) > 0 {
-			top := sb.stack[len(sb.stack)-1]
-			sb.stack = sb.stack[:len(sb.stack)-1]
+			top := c.stack[len(c.stack)-1]
+			c.stack = c.stack[:len(c.stack)-1]
 			extRLP := encodeExtensionRLP(shortNodeKey, top)
 			extLocation := append([]byte(nil), current[:lenFrom]...)
-			if err := sb.maybeEmit(extLocation, extRLP); err != nil {
+			if err := c.maybeEmit(extLocation, extRLP); err != nil {
 				return err
 			}
-			sb.stack = append(sb.stack, refOfRLP(extRLP))
+			c.stack = append(c.stack, refOfRLP(extRLP))
 		}
 
 		if precedingLen <= cpl && len(succeeding) > 0 {
@@ -199,14 +176,14 @@ func (sb *StreamingStorageBuilder) update(succeeding []byte) error {
 		}
 
 		if len(succeeding) > 0 || precedingExists {
-			if err := sb.sealBranchAt(current, length); err != nil {
+			if err := c.sealBranchAt(current, length); err != nil {
 				return err
 			}
 		}
 
-		sb.stateMasks = sb.stateMasks[:length]
-		for len(sb.stateMasks) > 0 && sb.stateMasks[len(sb.stateMasks)-1] == 0 {
-			sb.stateMasks = sb.stateMasks[:len(sb.stateMasks)-1]
+		c.stateMasks = c.stateMasks[:length]
+		for len(c.stateMasks) > 0 && c.stateMasks[len(c.stateMasks)-1] == 0 {
+			c.stateMasks = c.stateMasks[:len(c.stateMasks)-1]
 		}
 
 		if precedingLen == 0 {
@@ -218,28 +195,30 @@ func (sb *StreamingStorageBuilder) update(succeeding []byte) error {
 }
 
 // sealBranchAt pops popcount(stateMasks[length]) children from the stack,
-// encodes them as a 17-RLP-item branch node, emits at location
-// current[:length], and pushes the branch's ref back onto the stack.
-func (sb *StreamingStorageBuilder) sealBranchAt(current []byte, length int) error {
-	stateMask := sb.stateMasks[length]
+// encodes them as a 17-RLP-item branch node, emits at location current[:length],
+// and pushes the branch's ref back onto the stack.
+func (c *streamingBuilder) sealBranchAt(current []byte, length int) error {
+	stateMask := c.stateMasks[length]
 	childCount := popcount16(stateMask)
-	firstChild := len(sb.stack) - childCount
-	children := sb.stack[firstChild:]
+	firstChild := len(c.stack) - childCount
+	children := c.stack[firstChild:]
 
 	branchRLP := encodeBranchRLP(stateMask, children)
 	branchLocation := append([]byte(nil), current[:length]...)
-	if err := sb.maybeEmit(branchLocation, branchRLP); err != nil {
+	if err := c.maybeEmit(branchLocation, branchRLP); err != nil {
 		return err
 	}
 
-	sb.stack = sb.stack[:firstChild]
-	sb.stack = append(sb.stack, refOfRLP(branchRLP))
+	c.stack = c.stack[:firstChild]
+	c.stack = append(c.stack, refOfRLP(branchRLP))
 	return nil
 }
 
-// maybeEmit fires PutAccountStorageTrieNode for non-inline nodes whose
-// hash is not EmptyTrieNodeHash. Mirrors builder.go:323-333 (maybeEmit).
-func (sb *StreamingStorageBuilder) maybeEmit(location, rlp []byte) error {
+// maybeEmit fires em.emit for non-inline nodes whose hash is not
+// EmptyTrieNodeHash. Mirrors builder.go's maybeEmit. The root node — the only
+// one emitted at the empty RootLocation — has its full RLP captured so the
+// caller can recover it after finalize.
+func (c *streamingBuilder) maybeEmit(location, rlp []byte) error {
 	if !IsReferencedByHash(rlp) {
 		return nil
 	}
@@ -247,7 +226,59 @@ func (sb *StreamingStorageBuilder) maybeEmit(location, rlp []byte) error {
 	if hash == besu.EmptyTrieNodeHash {
 		return nil
 	}
-	return sb.sink.PutAccountStorageTrieNode(sb.addrHash, location, hash, rlp)
+	if len(location) == 0 {
+		c.rootRLP = append([]byte(nil), rlp...)
+	}
+	return c.em.emit(c.sink, location, hash, rlp)
+}
+
+// StreamingStorageBuilder builds the per-account Bonsai storage trie in O(trie
+// depth) memory. It is a thin wrapper over the shared streamingBuilder engine
+// with a storage emitter (addrHash-prefixed node keys).
+//
+// Input contract: AddSlot/AddLeaf calls MUST arrive in strictly ascending
+// keccak256(slotKey) order; streamingtrie.IterateRoot provides this.
+type StreamingStorageBuilder struct {
+	c streamingBuilder
+}
+
+// NewStreamingStorageBuilder constructs a streaming storage builder that emits
+// trie nodes through the caller-supplied sink. Use this when parallel workers
+// each need their own builder pointing at their own per-worker node sink —
+// `Builder.BeginStreamingStorage` is fine for the single-goroutine path, but its
+// returned builder writes through the parent Builder's shared sink and is unsafe
+// under concurrent use.
+//
+// addrHash must be the keccak256(address) the storage trie belongs to; it's used
+// as the prefix on every emitted trie-node write.
+func NewStreamingStorageBuilder(sink NodeSink, addrHash common.Hash) *StreamingStorageBuilder {
+	return &StreamingStorageBuilder{c: streamingBuilder{sink: sink, em: storageTrieEmitter{addrHash: addrHash}}}
+}
+
+// AddSlot inserts (slotHash → valueRLP) into the streaming storage trie.
+// slotHash MUST be strictly greater than the previous call's; out-of-order
+// input returns ErrSlotsOutOfOrder.
+func (sb *StreamingStorageBuilder) AddSlot(slotHash common.Hash, valueRLP []byte) error {
+	return sb.c.addLeaf(slotHash, valueRLP)
+}
+
+// AddLeaf is an alias for AddSlot — both append one (keccak-key, RLP value)
+// leaf. The alias lets *StreamingStorageBuilder satisfy streamingtrie.HashBuilder.
+func (sb *StreamingStorageBuilder) AddLeaf(keyHash common.Hash, valueRLP []byte) error {
+	return sb.c.addLeaf(keyHash, valueRLP)
+}
+
+// Commit finalises the build and returns the storage trie root. Empty trie
+// returns EmptyTrieNodeHash with zero sink calls.
+func (sb *StreamingStorageBuilder) Commit() (common.Hash, error) {
+	h, _, err := sb.c.finalize()
+	return h, err
+}
+
+// Root finalises the build and returns the storage trie root. Implements the
+// streamingtrie.HashBuilder contract (alongside AddLeaf).
+func (sb *StreamingStorageBuilder) Root() (common.Hash, error) {
+	return sb.Commit()
 }
 
 // encodeLeafRLP encodes a leaf node as RLP [CompactEncode(path, true), value].
@@ -267,10 +298,9 @@ func encodeLeafRLP(path, value []byte) []byte {
 }
 
 // encodeExtensionRLP encodes an extension node as RLP
-// [CompactEncode(path, false), childRef]. childRef is the byte sequence
-// a parent uses to reference the child (inline RLP for small children,
-// 0xa0 || keccak for hashed). Matches extensionNode.EncodedBytes at
-// node.go:119-136.
+// [CompactEncode(path, false), childRef]. childRef is the byte sequence a parent
+// uses to reference the child (inline RLP for small children, 0xa0 || keccak for
+// hashed). Matches extensionNode.EncodedBytes at node.go:119-136.
 func encodeExtensionRLP(path, childRef []byte) []byte {
 	hp := CompactEncode(path, false)
 	rlp, err := gethrlp.EncodeToBytes([]gethrlp.RawValue{
@@ -283,11 +313,10 @@ func encodeExtensionRLP(path, childRef []byte) []byte {
 	return rlp
 }
 
-// encodeBranchRLP encodes a 17-item branch RLP. stateMask indicates which
-// slots are occupied (bit i = slot i has a child); occupied slots are
-// taken from children in ascending order. Empty slots and the 17th
-// value slot encode as 0x80 (RLP null). Matches branchNode.EncodedBytes
-// at node.go:177-197.
+// encodeBranchRLP encodes a 17-item branch RLP. stateMask indicates which slots
+// are occupied (bit i = slot i has a child); occupied slots are taken from
+// children in ascending order. Empty slots and the 17th value slot encode as
+// 0x80 (RLP null). Matches branchNode.EncodedBytes at node.go:177-197.
 func encodeBranchRLP(stateMask uint16, children [][]byte) []byte {
 	items := make([]gethrlp.RawValue, 17)
 	childIdx := 0
@@ -307,8 +336,8 @@ func encodeBranchRLP(stateMask uint16, children [][]byte) []byte {
 	return rlp
 }
 
-// refOfRLP returns the byte sequence a parent uses to reference a child
-// node, matching EncodedBytesRef at hash.go:31-43.
+// refOfRLP returns the byte sequence a parent uses to reference a child node,
+// matching EncodedBytesRef at hash.go:31-43.
 func refOfRLP(rlp []byte) []byte {
 	if !IsReferencedByHash(rlp) {
 		out := make([]byte, len(rlp))

--- a/internal/streamsort/streamsort.go
+++ b/internal/streamsort/streamsort.go
@@ -146,12 +146,19 @@ func NewWithOptions(workDir string, opts Options) (*Store, error) {
 		MemTableStopWritesThreshold: 2,
 		L0CompactionThreshold:       math.MaxInt32,
 		L0StopWritesThreshold:       math.MaxInt32,
-		MaxConcurrentCompactions:    func() int { return runtime.NumCPU() },
-		BytesPerSync:                0,
-		WALBytesPerSync:             0,
-		NoSyncOnClose:               true,
-		FormatMajorVersion:          pebble.FormatNewest,
-		Cache:                       cache,
+		// Cap compaction concurrency at 8. runtime.NumCPU() on a high-core box
+		// spawns one compactor goroutine per core, each with transient
+		// per-compaction buffers — GiBs of extra RAM during flush/compact that
+		// scales with core count (this is why reducing --cores eased the Besu
+		// generation OOM). 8 keeps compaction off the write path without the
+		// per-core blow-up. Mirrors the cap on geth's production Pebble
+		// (client/geth/writer.go).
+		MaxConcurrentCompactions: func() int { return min(runtime.NumCPU(), 8) },
+		BytesPerSync:             0,
+		WALBytesPerSync:          0,
+		NoSyncOnClose:            true,
+		FormatMajorVersion:       pebble.FormatNewest,
+		Cache:                    cache,
 		Levels: []pebble.LevelOptions{
 			{Compression: sstable.NoCompression},
 		},


### PR DESCRIPTION
## Problem

Generating a large Besu datadir OOM-kills `state-actor` in phase 2 ("besu: phase 2/2 — building state trie … accounts"). On a 58 GB VM it died at ~116M/246M accounts.

**Root cause:** Besu builds the **account-state trie entirely in memory**. `internal/besu/trie/builder.go`'s `Builder.AddAccount` accumulates the whole MPT in `root` (functional, path-copying inserts — every branch descent allocates a fresh 16-child node) and only emits nodes at `Commit()`. That is **O(accounts)** RAM. geth / reth / nethermind all stream their account trie via `StackTrie` / `HashBuilder` (O(depth)). Besu already streamed **storage** (#111) but the account trie was never migrated.

The "per-CPU Pebble write buffers" theory from the report is a real but **secondary** contributor — `streamsort` capped compaction concurrency at raw `NumCPU` (commit 3).

## Fix

1. **Stream the account trie.** Generalize the existing streaming right-spine into a shared `streamingBuilder` core that emits via the existing `emitter` interface; `StreamingStorageBuilder` becomes a thin storage-emitter wrapper (behaviour unchanged) and a new `StreamingAccountBuilder` is the account-emitter wrapper. The in-memory `Builder` is retained as the test oracle.
2. **Wire phase 2** (`client/besu/state_writer_cgo.go`, `genesis_alloc_cgo.go`) to `NewStreamingAccountBuilder`; per-contract storage now uses `NewStreamingStorageBuilder` too. Both O(depth).
3. **Cap `streamsort` compaction concurrency** at `min(NumCPU, 8)` (was raw `runtime.NumCPU()` — one compactor goroutine per core with transient per-compaction buffers; the per-core RAM that made reducing `--cores` help). Mirrors geth's production Pebble cap. Output-identical.

## Validation

- **Native unit test** (`internal/besu/trie`): streaming builder == in-memory `Builder` (identical root hash, root RLP, and emitted node set) for 0–5000 accounts; out-of-order input rejected.
- **cgo (Docker):** `go build -tags cgo_besu` clean; **golden state root unchanged**, reproducibility holds, and the differential oracle matches **Besu's pinned values** → cross-client state-root invariance preserved.
- **100 GB memory gate** (bench host, container `--memory=58g` replicating the original failing VM, `--target-size=100GB` → **122.7M accounts / 536.8M storage slots / 140 GB datadir**): **completed `exit 0`, peak RSS 6.93 GiB** (vs the old builder's OOM at ~116M accounts under the same 58 GiB), 2h1m wall, `OOMKilled=false`. The streaming builder cleared the exact point where the old code died.

Fixes the Besu generation OOM.
