### PR TITLE
fix(besu): review follow-up to #107 — comment accuracy, fail-loud finalize, tests

### DIFF
--- a/client/besu/state_writer_cgo.go
+++ b/client/besu/state_writer_cgo.go
@@ -34,7 +34,10 @@ const maxPhase0Workers = 8
 // sorted, builds per-account storage tries, writes flat state and
 // code, and feeds the outer account trie.
 //
-// Memory bound: O(max storage slots in any single contract).
+// Both the account-state trie and each per-account storage trie are built
+// streaming (O(trie depth)), so account/contract count does not drive peak RAM.
+// Memory bound: O(max storage slots in any single contract) — the per-contract
+// slot map + sort buffer materialized in Phase 2.
 func writeStateAndCollectRoot(
 	ctx context.Context,
 	cfg generator.Config,

--- a/internal/besu/trie/builder.go
+++ b/internal/besu/trie/builder.go
@@ -36,13 +36,14 @@ type NodeSink interface {
 	SaveWorldState(blockHash common.Hash, rootHash common.Hash, rootRLP []byte) error
 }
 
-// Builder is a streaming Bonsai-trie builder for the account-state trie.
-// It is insert-only and assumes inputs arrive in keccak-sorted addrHash
-// order (this is what the Phase 2 pipeline guarantees by iterating a
-// sorted Pebble database).
+// Builder is the in-memory (non-streaming) Bonsai account-state trie builder.
+// It maintains the entire account MPT resident (functional inserts) and emits
+// non-inline nodes via the NodeSink only at Commit time (post-order traversal),
+// so its memory is O(accounts). Production bulk generation uses
+// StreamingAccountBuilder (O(trie depth), in streaming_account_builder.go);
+// Builder is retained as the byte-identical reference oracle in tests.
 //
-// The builder maintains an in-memory MPT and emits non-inline nodes via the
-// NodeSink at Commit time (post-order traversal).
+// It is insert-only and assumes inputs arrive in keccak-sorted addrHash order.
 type Builder struct {
 	sink  NodeSink
 	root  Node
@@ -78,11 +79,11 @@ func (b *Builder) BeginStorage(addrHash common.Hash) *StorageBuilder {
 	}
 }
 
-// BeginStreamingStorage returns a StreamingStorageBuilder for the
-// per-account storage trie. Like BeginStorage, but builds in O(depth)
-// memory by consuming AddSlot calls in keccak-ascending order via a
-// right-spine algorithm. Required for entities with millions of slots
-// where the non-streaming StorageBuilder OOMs.
+// BeginStreamingStorage returns a StreamingStorageBuilder bound to this
+// Builder's sink. Retained for the in-memory Builder API and tests — production
+// code constructs NewStreamingStorageBuilder directly. Builds in O(trie depth)
+// memory by consuming AddSlot calls in keccak-ascending order via a right-spine
+// algorithm.
 func (b *Builder) BeginStreamingStorage(addrHash common.Hash) *StreamingStorageBuilder {
 	return NewStreamingStorageBuilder(b.sink, addrHash)
 }

--- a/internal/besu/trie/streaming_account_builder_test.go
+++ b/internal/besu/trie/streaming_account_builder_test.go
@@ -2,6 +2,7 @@ package trie
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"sort"
 	"testing"
@@ -47,6 +48,48 @@ func makeSortedAccounts(t *testing.T, n int) []acctEntry {
 	return dedup
 }
 
+// assertAccountEquivalence builds the same sorted account set with the in-memory
+// Builder (the trusted oracle) and the streaming builder, asserting a
+// byte-identical trie: same root hash, same root RLP, and the same set of
+// emitted nodes.
+func assertAccountEquivalence(t *testing.T, accts []acctEntry) {
+	t.Helper()
+
+	// Reference: non-streaming in-memory Builder.
+	refSink := &recordingSink{}
+	ref := New(refSink)
+	for _, a := range accts {
+		if err := ref.AddAccount(a.hash, a.rlp); err != nil {
+			t.Fatalf("ref AddAccount: %v", err)
+		}
+	}
+	refHash, refRLP, err := ref.Commit()
+	if err != nil {
+		t.Fatalf("ref Commit: %v", err)
+	}
+
+	// Under test: streaming builder.
+	strSink := &recordingSink{}
+	str := NewStreamingAccountBuilder(strSink)
+	for _, a := range accts {
+		if err := str.AddAccount(a.hash, a.rlp); err != nil {
+			t.Fatalf("streaming AddAccount: %v", err)
+		}
+	}
+	strHash, strRLP, err := str.Commit()
+	if err != nil {
+		t.Fatalf("streaming Commit: %v", err)
+	}
+
+	if refHash != strHash {
+		t.Errorf("root hash mismatch: ref %x, streaming %x", refHash, strHash)
+	}
+	if !bytes.Equal(refRLP, strRLP) {
+		t.Errorf("root RLP mismatch: ref %x, streaming %x", refRLP, strRLP)
+	}
+	assertSameStateNodes(t, refSink.stateNodes, strSink.stateNodes)
+}
+
 // TestStreamingAccountBuilder_MatchesInMemoryBuilder is the correctness gate for
 // the OOM fix: the streaming account builder must produce a byte-identical trie
 // — same root hash, same root RLP, and the same set of emitted nodes — as the
@@ -54,43 +97,61 @@ func makeSortedAccounts(t *testing.T, n int) []acctEntry {
 func TestStreamingAccountBuilder_MatchesInMemoryBuilder(t *testing.T) {
 	for _, n := range []int{0, 1, 2, 17, 256, 5000} {
 		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
-			accts := makeSortedAccounts(t, n)
-
-			// Reference: non-streaming in-memory Builder.
-			refSink := &recordingSink{}
-			ref := New(refSink)
-			for _, a := range accts {
-				if err := ref.AddAccount(a.hash, a.rlp); err != nil {
-					t.Fatalf("ref AddAccount: %v", err)
-				}
-			}
-			refHash, refRLP, err := ref.Commit()
-			if err != nil {
-				t.Fatalf("ref Commit: %v", err)
-			}
-
-			// Under test: streaming builder.
-			strSink := &recordingSink{}
-			str := NewStreamingAccountBuilder(strSink)
-			for _, a := range accts {
-				if err := str.AddAccount(a.hash, a.rlp); err != nil {
-					t.Fatalf("streaming AddAccount: %v", err)
-				}
-			}
-			strHash, strRLP, err := str.Commit()
-			if err != nil {
-				t.Fatalf("streaming Commit: %v", err)
-			}
-
-			if refHash != strHash {
-				t.Errorf("root hash mismatch: ref %x, streaming %x", refHash, strHash)
-			}
-			if !bytes.Equal(refRLP, strRLP) {
-				t.Errorf("root RLP mismatch: ref %x, streaming %x", refRLP, strRLP)
-			}
-			assertSameStateNodes(t, refSink.stateNodes, strSink.stateNodes)
+			assertAccountEquivalence(t, makeSortedAccounts(t, n))
 		})
 	}
+}
+
+// TestStreamingAccountBuilder_ContractLeaves feeds contract-shaped account
+// leaves (non-empty storageRoot + codeHash). makeSortedAccounts only produces
+// EOA-shaped leaves (empty storage/code); the builder treats the leaf value as
+// opaque bytes, so this pins that contract leaves stream identically to the
+// oracle without relying on the Docker E2E suite.
+func TestStreamingAccountBuilder_ContractLeaves(t *testing.T) {
+	const n = 512
+	accts := make([]acctEntry, 0, n)
+	for i := 0; i < n; i++ {
+		h := crypto.Keccak256Hash([]byte{byte(i), byte(i >> 8), 0xc0, 0x17})
+		storageRoot, codeHash := besu.EmptyTrieNodeHash, besu.EmptyCodeHash
+		if i%3 == 0 {
+			// Distinct non-empty roots/hashes — opaque to the builder, need not
+			// be real trie roots.
+			storageRoot = crypto.Keccak256Hash([]byte{byte(i), 0x5a})
+			codeHash = crypto.Keccak256Hash([]byte{byte(i), 0xc0})
+		}
+		rlp, err := besurlp.EncodeAccount(uint64(i+1), uint256.NewInt(uint64(i)+1), storageRoot, codeHash)
+		if err != nil {
+			t.Fatalf("EncodeAccount: %v", err)
+		}
+		accts = append(accts, acctEntry{hash: h, rlp: rlp})
+	}
+	sort.Slice(accts, func(i, j int) bool { return bytes.Compare(accts[i].hash[:], accts[j].hash[:]) < 0 })
+	assertAccountEquivalence(t, accts)
+}
+
+// TestStreamingAccountBuilder_RootExtension pins the one root shape the random-
+// key equivalence test never produces: a root that is an EXTENSION node. All
+// keys share a long leading prefix (30 identical bytes, distinct 2-byte suffix),
+// so the trie root is an extension over the shared prefix. This exercises the
+// streaming builder's root-RLP capture for an extension root.
+func TestStreamingAccountBuilder_RootExtension(t *testing.T) {
+	const n = 64
+	accts := make([]acctEntry, 0, n)
+	for i := 0; i < n; i++ {
+		var h common.Hash
+		for k := 0; k < 30; k++ {
+			h[k] = 0xAB // shared 30-byte (60-nibble) prefix → extension root
+		}
+		h[30] = byte(i >> 8)
+		h[31] = byte(i)
+		rlp, err := besurlp.EncodeAccount(uint64(i+1), uint256.NewInt(uint64(i)+1), besu.EmptyTrieNodeHash, besu.EmptyCodeHash)
+		if err != nil {
+			t.Fatalf("EncodeAccount: %v", err)
+		}
+		accts = append(accts, acctEntry{hash: h, rlp: rlp})
+	}
+	sort.Slice(accts, func(i, j int) bool { return bytes.Compare(accts[i].hash[:], accts[j].hash[:]) < 0 })
+	assertAccountEquivalence(t, accts)
 }
 
 // TestStreamingAccountBuilder_RejectsOutOfOrder pins the strict-ascending input
@@ -105,8 +166,8 @@ func TestStreamingAccountBuilder_RejectsOutOfOrder(t *testing.T) {
 	if err := b.AddAccount(hi, []byte{0x11}); err != nil {
 		t.Fatalf("first AddAccount: %v", err)
 	}
-	if err := b.AddAccount(lo, []byte{0x22}); err == nil {
-		t.Fatalf("expected ErrSlotsOutOfOrder for descending addrHash, got nil")
+	if err := b.AddAccount(lo, []byte{0x22}); !errors.Is(err, ErrSlotsOutOfOrder) {
+		t.Fatalf("expected ErrSlotsOutOfOrder for descending addrHash, got %v", err)
 	}
 }
 

--- a/internal/besu/trie/streaming_storage_builder.go
+++ b/internal/besu/trie/streaming_storage_builder.go
@@ -3,6 +3,7 @@ package trie
 import (
 	"bytes"
 	"errors"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	gethrlp "github.com/ethereum/go-ethereum/rlp"
@@ -92,8 +93,11 @@ func (c *streamingBuilder) finalize() (common.Hash, []byte, error) {
 		c.prevValue = nil
 	}
 	if len(c.stack) == 0 {
-		// Defensive — leafCount > 0 implies stack is non-empty after update(nil).
-		return besu.EmptyTrieNodeHash, []byte{0x80}, nil
+		// leafCount > 0 implies a non-empty stack after update(nil); an empty
+		// stack here means the spine-collapse invariant is broken. Fail loudly
+		// rather than return a valid-looking empty root — a silent wrong root
+		// would surface only as a cross-client state-root divergence later.
+		return common.Hash{}, nil, fmt.Errorf("besu/trie: finalize: empty stack with leafCount=%d (builder invariant violated)", c.leafCount)
 	}
 	rootRef := c.stack[len(c.stack)-1]
 	if len(rootRef) == 33 && rootRef[0] == 0xa0 {
@@ -243,11 +247,10 @@ type StreamingStorageBuilder struct {
 }
 
 // NewStreamingStorageBuilder constructs a streaming storage builder that emits
-// trie nodes through the caller-supplied sink. Use this when parallel workers
-// each need their own builder pointing at their own per-worker node sink —
-// `Builder.BeginStreamingStorage` is fine for the single-goroutine path, but its
-// returned builder writes through the parent Builder's shared sink and is unsafe
-// under concurrent use.
+// trie nodes through the caller-supplied sink. This is the production
+// constructor — each phase-0/phase-2 worker builds its own per-worker sink and
+// builder. (Builder.BeginStreamingStorage wraps this for the in-memory Builder
+// API and tests.)
 //
 // addrHash must be the keccak256(address) the storage trie belongs to; it's used
 // as the prefix on every emitted trie-node write.

--- a/internal/streamsort/streamsort.go
+++ b/internal/streamsort/streamsort.go
@@ -149,10 +149,11 @@ func NewWithOptions(workDir string, opts Options) (*Store, error) {
 		// Cap compaction concurrency at 8. runtime.NumCPU() on a high-core box
 		// spawns one compactor goroutine per core, each with transient
 		// per-compaction buffers — GiBs of extra RAM during flush/compact that
-		// scales with core count (this is why reducing --cores eased the Besu
-		// generation OOM). 8 keeps compaction off the write path without the
-		// per-core blow-up. Mirrors the cap on geth's production Pebble
-		// (client/geth/writer.go).
+		// scales with core count. This is a secondary memory contributor,
+		// consistent with reducing --cores easing the Besu generation OOM,
+		// though the dominant cause there was the non-streaming account trie.
+		// 8 keeps compaction off the write path without the per-core blow-up.
+		// Mirrors the cap on geth's production Pebble (client/geth/writer.go:116-124).
 		MaxConcurrentCompactions: func() int { return min(runtime.NumCPU(), 8) },
 		BytesPerSync:             0,
 		WALBytesPerSync:          0,


### PR DESCRIPTION
Follow-up polish to #107 (merged), from a fact-checked multi-agent review of that PR.
**No behavior change — the besu golden state root is unchanged** (verified on this branch
via the besu cgo `TestBesuGoldenStateRoot` / `TestDifferentialOracle` / `TestBesuReproducibility`
tests, plus the native streaming-vs-in-memory equivalence test).

## Comment accuracy / rot (exposed by #107's refactor)
- **streamsort**: soften the compaction-cap comment's causal claim — the dominant OOM cause
  #107 fixed was the non-streaming account trie (CPU-independent), so the compaction cap is at
  most a secondary contributor; cite geth's exact mirror (`client/geth/writer.go:116-124`).
- **builder.go**: the in-memory `Builder` is the test oracle now, not "streaming" — reword its
  doc and `BeginStreamingStorage` (test/oracle-only; production uses the standalone constructor).
- **streaming_storage_builder.go**: `NewStreamingStorageBuilder` is the production constructor;
  drop the stale "fine for the single-goroutine path" note.
- **state_writer_cgo.go**: clarify that both the account and per-account storage tries now stream.

## Defensive
- `streamingBuilder.finalize`: the (unreachable) empty-stack branch now returns an error instead
  of a valid-looking empty root — a silent wrong root would otherwise surface only as a
  cross-client state-root divergence. No happy-path change.

## Tests
- Extract `assertAccountEquivalence`; add a **contract-shaped-leaf** case (non-empty
  storageRoot/codeHash — the matrix otherwise only used EOA leaves) and a **root-extension**
  case (shared-prefix keys — the one root shape random keccak keys never produce, pinning the
  streaming root-RLP capture for it).
- `RejectsOutOfOrder` now asserts `errors.Is(err, ErrSlotsOutOfOrder)`.

## Deferred (noted in review; not in this PR)
- Pre-existing `decodeEntity` OOB-panic hardening (separate concern).
- Minor hygiene/micro-opt: a finalize `done`-guard, the `captureRoot` storage allocation gate,
  a `var _ streamingtrie.HashBuilder` assertion, and richer `ErrSlotsOutOfOrder` context.
