### PR TITLE
ci(docker): on-demand PR image builds + close-time cleanup

### DIFF
--- a/.github/workflows/cleanup-pr-images.yaml
+++ b/.github/workflows/cleanup-pr-images.yaml
@@ -1,0 +1,97 @@
+# Cleanup - PR Docker images
+#
+# Deletes the `pr-<n>` GHCR tags that `deploy-docker.yaml`'s workflow_dispatch
+# publishes, once the PR is closed. Without this, every PR build leaves seven
+# images × (multi-arch manifest + sha manifest + 2 per-arch tags) behind
+# forever.
+#
+# Runs on `pull_request_target` because a `pull_request` run from a fork gets a
+# read-only GITHUB_TOKEN and cannot delete package versions — and most PRs here
+# come from forks. That trigger is safe *here* specifically because this
+# workflow never checks out or executes PR code: it only calls the packages
+# API with tag names derived from the PR number. Do not add a checkout of
+# `head.sha` to this file.
+
+name: Cleanup - PR Docker images
+
+on:
+  pull_request_target:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'PR number whose pr-<n> images should be deleted.'
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.pr || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Delete pr-${{ inputs.pr || github.event.pull_request.number }} image tags
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Delete PR package versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          PR: ${{ inputs.pr || github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$PR" =~ ^[0-9]+$ ]]; then
+            echo "::error::pr must be a number, got '$PR'"
+            exit 1
+          fi
+          # Exported for the jq filter below. Matching is exact-or-`pr-<n>-`
+          # prefixed so that closing PR #1 cannot match PR #112's tags.
+          export PR_TAG="pr-${PR}"
+
+          PACKAGES=(
+            state-actor
+            state-actor-besu
+            state-actor-nethermind
+            state-actor-reth
+            state-actor-geth
+            state-actor-ethrex
+            state-actor-erigon
+          )
+
+          deleted=0
+          for pkg in "${PACKAGES[@]}"; do
+            # A package only exists once something has been pushed to it; a
+            # never-built client 404s, which is not an error here.
+            if ! versions=$(gh api --paginate \
+              "/orgs/${OWNER}/packages/container/${pkg}/versions" 2>/dev/null); then
+              echo "· ${pkg}: no such package, skipping"
+              continue
+            fi
+
+            # Only delete a version when EVERY tag on it belongs to this PR.
+            # Versions are content-addressed, so if a PR head happens to build
+            # byte-identical to main, one version carries both `pr-<n>` and
+            # `main` — deleting it would take `main` down with it. Untagged
+            # versions are left alone: they are the per-arch children of
+            # manifests and cannot be attributed to a PR by tag.
+            ids=$(jq -r '
+              .[]
+              | . as $v
+              | (($v.metadata.container.tags) // []) as $tags
+              | select(($tags | length) > 0)
+              | select($tags | any(. == env.PR_TAG or startswith(env.PR_TAG + "-")))
+              | select($tags | all(. == env.PR_TAG or startswith(env.PR_TAG + "-")))
+              | $v.id
+            ' <<<"$versions")
+
+            for id in $ids; do
+              echo "· ${pkg}: deleting version ${id}"
+              gh api -X DELETE \
+                "/orgs/${OWNER}/packages/container/${pkg}/versions/${id}"
+              deleted=$((deleted + 1))
+            done
+          done
+
+          echo "Deleted ${deleted} package version(s) for ${PR_TAG}."

--- a/.github/workflows/cleanup-pr-images.yaml
+++ b/.github/workflows/cleanup-pr-images.yaml
@@ -60,14 +60,26 @@ jobs:
             state-actor-erigon
           )
 
+          err=$(mktemp)
+          trap 'rm -f "$err"' EXIT
+
           deleted=0
           for pkg in "${PACKAGES[@]}"; do
-            # A package only exists once something has been pushed to it; a
-            # never-built client 404s, which is not an error here.
-            if ! versions=$(gh api --paginate \
-              "/orgs/${OWNER}/packages/container/${pkg}/versions" 2>/dev/null); then
-              echo "· ${pkg}: no such package, skipping"
+            # A package only exists once something has been pushed to it, so a
+            # never-built client 404s and that is not an error. Anything else
+            # is: treating a 403 or a 5xx as "no such package" would report
+            # success while deleting nothing, and the tags would leak forever
+            # with nobody watching — this job only ever runs at PR close.
+            if versions=$(gh api --paginate \
+              "/orgs/${OWNER}/packages/container/${pkg}/versions" 2>"$err"); then
+              :
+            elif grep -q 'HTTP 404' "$err"; then
+              echo "· ${pkg}: never published, skipping"
               continue
+            else
+              echo "::error::${pkg}: could not list package versions"
+              cat "$err" >&2
+              exit 1
             fi
 
             # Only delete a version when EVERY tag on it belongs to this PR.

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -19,12 +19,26 @@
 # Tag strategy (per image):
 #   push to main      → main, main-latest, main-<sha>
 #   tag v*.*.*        → <version>, latest, <version>-<sha>
+#   workflow_dispatch → pr-<n>, pr-<n>-<sha>
 # Per-arch build tags (…-amd64 / …-arm64) are implementation detail; consumers
 # pull the multi-arch manifests above.
+#
+# PR builds are manual (`workflow_dispatch`) by design, not label- or
+# `pull_request`-triggered. A `pull_request` run from a fork gets a read-only
+# GITHUB_TOKEN and cannot push to GHCR at all, and most contributions here
+# arrive from forks. The alternative — `pull_request_target` — hands a
+# packages:write token to a workflow building a fork-authored Dockerfile on
+# every label event. Dispatch keeps the same code-execution exposure (a
+# maintainer is still building fork code) but makes it a deliberate,
+# per-commit act rather than something an event config can misfire.
+# `pr` is a PR number, and a fork PR's head is fetchable from this repo under
+# refs/pull/*, so fork PRs work without a fork remote.
 #
 # The matrix is the only thing that differs from benchmarkoor (which had one
 # file per image): the per-client Dockerfiles would otherwise mean that many
 # near-identical workflow files, so the per-image fan-out lives in a matrix.
+# `meta` computes that matrix, so a dispatch naming one client builds one
+# image rather than all seven.
 
 name: Deploy - Docker
 
@@ -34,24 +48,81 @@ on:
       - main
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'PR number to build (e.g. 112). Builds that PR''s head commit and pushes pr-<n> tags.'
+        required: true
+        type: string
+      images:
+        description: 'Images to build: "all", or a comma-separated subset of base,besu,nethermind,reth,geth,ethrex,erigon.'
+        required: false
+        default: all
+        type: string
+
+# Supersede an in-flight build of the same PR when it gets re-dispatched.
+# Pushes to main and version tags are never cancelled — a release build that
+# loses a race would leave half-published manifests behind.
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.pr && format('pr-{0}', inputs.pr) || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' }}
 
 jobs:
   meta:
-    name: Compute tags and build info
+    name: Compute tags, matrix and build info
     runs-on: ubuntu-latest
     outputs:
+      checkout_ref: ${{ steps.resolve.outputs.checkout_ref }}
       sha_short: ${{ steps.vars.outputs.sha_short }}
       tag_prefix: ${{ steps.vars.outputs.tag_prefix }}
       additional_tags: ${{ steps.vars.outputs.additional_tags }}
       version: ${{ steps.vars.outputs.version }}
       revision: ${{ steps.vars.outputs.revision }}
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      suffixes: ${{ steps.matrix.outputs.suffixes }}
     steps:
+      # Resolve the PR head to a concrete sha ONCE, here, and hand it to every
+      # downstream job. If the contributor force-pushes mid-run, the later jobs
+      # still build the commit this job stamped rather than silently splitting
+      # the multi-arch manifest across two different commits.
+      - name: Resolve commit to build
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ inputs.pr }}
+        run: |
+          set -euo pipefail
+          # Empty for push events, which leaves every checkout below on its
+          # default ref. Deliberate: actions/checkout turns a 40-char `ref`
+          # into a bare `git fetch origin <sha>`, which brings no tag refs, and
+          # `git describe --tags` in the next step would silently degrade a
+          # release's version stamp from v1.2.3 to a bare sha.
+          if [[ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ]]; then
+            echo "checkout_ref=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ ! "$PR" =~ ^[0-9]+$ ]]; then
+            echo "::error::pr input must be a number, got '$PR'"
+            exit 1
+          fi
+          HEAD_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}" --jq .head.sha)
+          echo "Building PR #${PR} at ${HEAD_SHA}"
+          # A sha, not refs/pull/<n>/head: fork heads live in this repo under
+          # refs/pull/*, so the sha is fetchable, and pinning it here stops a
+          # mid-run force-push from splitting the multi-arch manifest across
+          # two commits. PR builds therefore stamp VERSION as a bare sha.
+          echo "checkout_ref=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ steps.resolve.outputs.checkout_ref }}
           fetch-depth: 0
 
       - id: vars
+        env:
+          PR: ${{ inputs.pr }}
         run: |
+          set -euo pipefail
           SHA_SHORT=$(git rev-parse --short HEAD)
           echo "sha_short=$SHA_SHORT" >> $GITHUB_OUTPUT
           # Version stamped into the binary via -X main.Version (build-arg
@@ -61,7 +132,13 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           # Full commit for the org.opencontainers.image.revision label.
           echo "revision=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-          if [[ "${{ github.ref }}" == refs/tags/v*.*.* ]]; then
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            # No moving-"latest" analogue for PRs: pr-<n> already is the
+            # moving pointer, and pr-<n>-<sha> the pinned one. Nothing a
+            # dispatch produces may collide with main/latest/<version>.
+            echo "tag_prefix=pr-${PR}" >> $GITHUB_OUTPUT
+            echo "additional_tags=[\"pr-${PR}\"]" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.ref }}" == refs/tags/v*.*.* ]]; then
             VERSION_TAG="${GITHUB_REF#refs/tags/}"
             echo "tag_prefix=$VERSION_TAG" >> $GITHUB_OUTPUT
             echo "additional_tags=[\"$VERSION_TAG\",\"latest\"]" >> $GITHUB_OUTPUT
@@ -69,6 +146,42 @@ jobs:
             echo "tag_prefix=main" >> $GITHUB_OUTPUT
             echo "additional_tags=[\"main\",\"main-latest\"]" >> $GITHUB_OUTPUT
           fi
+
+      # Single source of truth for the image list — the build and manifest
+      # jobs all fan out from these two outputs.
+      - id: matrix
+        env:
+          IMAGES: ${{ inputs.images }}
+        run: |
+          set -euo pipefail
+          ALL='[
+            {"name":"base",       "suffix":"",           "dockerfile":"Dockerfile"},
+            {"name":"besu",       "suffix":"-besu",      "dockerfile":"Dockerfile.besu"},
+            {"name":"nethermind", "suffix":"-nethermind","dockerfile":"Dockerfile.nethermind"},
+            {"name":"reth",       "suffix":"-reth",      "dockerfile":"Dockerfile.reth"},
+            {"name":"geth",       "suffix":"-geth",      "dockerfile":"Dockerfile.geth"},
+            {"name":"ethrex",     "suffix":"-ethrex",    "dockerfile":"Dockerfile.ethrex"},
+            {"name":"erigon",     "suffix":"-erigon",    "dockerfile":"Dockerfile.erigon"}
+          ]'
+          if [[ "$GITHUB_EVENT_NAME" != "workflow_dispatch" || -z "${IMAGES:-}" || "$IMAGES" == "all" ]]; then
+            SELECTED="$ALL"
+          else
+            # Reject unknown names loudly. A typo'd client would otherwise
+            # silently narrow the matrix and "succeed" having built nothing.
+            KNOWN=$(jq -r '.[].name' <<<"$ALL")
+            for want in ${IMAGES//,/ }; do
+              if ! grep -qx -- "$want" <<<"$KNOWN"; then
+                echo "::error::unknown image '$want'; valid: $(tr '\n' ' ' <<<"$KNOWN")"
+                exit 1
+              fi
+            done
+            SELECTED=$(jq -c --arg csv "$IMAGES" \
+              '($csv | split(",") | map(gsub("^\\s+|\\s+$";""))) as $want
+               | map(select(.name as $n | $want | index($n)))' <<<"$ALL")
+          fi
+          echo "Building: $(jq -r '[.[].name] | join(", ")' <<<"$SELECTED")"
+          echo "matrix=$(jq -c '.' <<<"$SELECTED")" >> "$GITHUB_OUTPUT"
+          echo "suffixes=$(jq -c '[.[].suffix]' <<<"$SELECTED")" >> "$GITHUB_OUTPUT"
 
   build_amd64:
     name: Build amd64 image (${{ matrix.dockerfile }})
@@ -81,20 +194,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - { suffix: '',            dockerfile: Dockerfile }
-          - { suffix: '-besu',       dockerfile: Dockerfile.besu }
-          - { suffix: '-nethermind', dockerfile: Dockerfile.nethermind }
-          - { suffix: '-reth',       dockerfile: Dockerfile.reth }
-          - { suffix: '-geth',       dockerfile: Dockerfile.geth }
-          - { suffix: '-ethrex',     dockerfile: Dockerfile.ethrex }
-          - { suffix: '-erigon',     dockerfile: Dockerfile.erigon }
+        include: ${{ fromJSON(needs.meta.outputs.matrix) }}
     env:
       GHCR_REPO: ghcr.io/${{ github.repository }}${{ matrix.suffix }}
       DOCKERFILE: ${{ matrix.dockerfile }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ needs.meta.outputs.checkout_ref }}
           fetch-depth: 0
 
       - name: Set up Docker Buildx
@@ -140,20 +247,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - { suffix: '',            dockerfile: Dockerfile }
-          - { suffix: '-besu',       dockerfile: Dockerfile.besu }
-          - { suffix: '-nethermind', dockerfile: Dockerfile.nethermind }
-          - { suffix: '-reth',       dockerfile: Dockerfile.reth }
-          - { suffix: '-geth',       dockerfile: Dockerfile.geth }
-          - { suffix: '-ethrex',     dockerfile: Dockerfile.ethrex }
-          - { suffix: '-erigon',     dockerfile: Dockerfile.erigon }
+        include: ${{ fromJSON(needs.meta.outputs.matrix) }}
     env:
       GHCR_REPO: ghcr.io/${{ github.repository }}${{ matrix.suffix }}
       DOCKERFILE: ${{ matrix.dockerfile }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ needs.meta.outputs.checkout_ref }}
           fetch-depth: 0
 
       - name: Set up Docker Buildx
@@ -197,7 +298,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        suffix: ['', '-besu', '-nethermind', '-reth', '-geth', '-ethrex', '-erigon']
+        suffix: ${{ fromJSON(needs.meta.outputs.suffixes) }}
     env:
       GHCR_REPO: ghcr.io/${{ github.repository }}${{ matrix.suffix }}
     steps:
@@ -230,7 +331,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        suffix: ['', '-besu', '-nethermind', '-reth', '-geth', '-ethrex', '-erigon']
+        suffix: ${{ fromJSON(needs.meta.outputs.suffixes) }}
         tag: ${{ fromJSON(needs.meta.outputs.additional_tags) }}
     env:
       GHCR_REPO: ghcr.io/${{ github.repository }}${{ matrix.suffix }}

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -60,11 +60,18 @@ on:
         default: all
         type: string
 
-# Supersede an in-flight build of the same PR when it gets re-dispatched.
+# Supersede an in-flight build only when the same PR is re-dispatched for the
+# same images — re-dispatching means "redo it", so cancelling the old run is
+# the point. The images are part of the key so that dispatching `besu` and then
+# `nethermind` for one PR runs both instead of the second silently cancelling
+# the first's ~15 min cgo build. Two dispatches with *overlapping* sets can
+# then race to push one tag, which is benign: both build the same PR head, so
+# they publish the same content.
+#
 # Pushes to main and version tags are never cancelled — a release build that
 # loses a race would leave half-published manifests behind.
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.pr && format('pr-{0}', inputs.pr) || github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.pr && format('pr-{0}-{1}', inputs.pr, inputs.images) || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' }}
 
 jobs:
@@ -166,18 +173,30 @@ jobs:
           if [[ "$GITHUB_EVENT_NAME" != "workflow_dispatch" || -z "${IMAGES:-}" || "$IMAGES" == "all" ]]; then
             SELECTED="$ALL"
           else
-            # Reject unknown names loudly. A typo'd client would otherwise
-            # silently narrow the matrix and "succeed" having built nothing.
-            KNOWN=$(jq -r '.[].name' <<<"$ALL")
-            for want in ${IMAGES//,/ }; do
-              if ! grep -qx -- "$want" <<<"$KNOWN"; then
-                echo "::error::unknown image '$want'; valid: $(tr '\n' ' ' <<<"$KNOWN")"
-                exit 1
-              fi
-            done
-            SELECTED=$(jq -c --arg csv "$IMAGES" \
-              '($csv | split(",") | map(gsub("^\\s+|\\s+$";""))) as $want
-               | map(select(.name as $n | $want | index($n)))' <<<"$ALL")
+            # Split and match in ONE jq pass, and reject whatever it could not
+            # match. Validating in bash and selecting in jq lets the two
+            # disagree: bash word-splits "nethermind besu" into two valid names
+            # and passes it, while split(",") sees one unknown name and selects
+            # nothing — a typo would then "succeed" having built nothing, the
+            # opposite of what the check is for.
+            PARSED=$(jq -c --arg csv "$IMAGES" '
+              ($csv | split(",") | map(gsub("^\\s+|\\s+$";"")) | map(select(length > 0)) | unique) as $want
+              | { selected: map(select(.name as $n | $want | index($n))),
+                  unknown:  ($want - map(.name)) }
+            ' <<<"$ALL")
+            UNKNOWN=$(jq -r '.unknown | join(", ")' <<<"$PARSED")
+            if [[ -n "$UNKNOWN" ]]; then
+              echo "::error::unknown image(s): ${UNKNOWN}; valid: $(jq -r 'map(.name) | join(", ")' <<<"$ALL")"
+              exit 1
+            fi
+            SELECTED=$(jq -c '.selected' <<<"$PARSED")
+          fi
+          # Backstop for every path above: an empty matrix expands to zero
+          # build jobs, the manifest jobs skip on `needs`, and the run reports
+          # success having published nothing.
+          if [[ "$(jq 'length' <<<"$SELECTED")" -eq 0 ]]; then
+            echo "::error::no images selected from '${IMAGES:-}'"
+            exit 1
           fi
           echo "Building: $(jq -r '[.[].name] | join(", ")' <<<"$SELECTED")"
           echo "matrix=$(jq -c '.' <<<"$SELECTED")" >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -80,6 +80,18 @@ docker build -f Dockerfile.geth       -t state-actor-geth:dev .        # pure Go
 
 Then run your locally-built tag in place of the `ghcr.io/...:main` image in any recipe below, e.g. `docker run --rm -v /tmp/sa-reth:/data state-actor-reth:dev --client=reth --db=/data --target-size=1GB`. The cgo images build RocksDB from source, so the first build is slow (~15 min); subsequent builds reuse the layer cache. The same Dockerfiles are what CI publishes via `.github/workflows/deploy-docker.yaml`.
 
+### Images for an open pull request
+
+To try a PR's images without building them, a maintainer can publish them from the **Deploy - Docker** workflow's *Run workflow* button, passing the PR number and either `all` or a comma-separated subset (`nethermind`, `besu,reth`, …). This is manual rather than automatic: most PRs come from forks, and a fork's `pull_request` run gets a read-only token that cannot push to GHCR.
+
+That publishes two tags per selected image — `pr-<n>`, which follows the PR as it is re-dispatched, and `pr-<n>-<sha>`, pinned to one commit:
+
+```bash
+docker pull ghcr.io/ethereum/state-actor-nethermind:pr-112
+```
+
+Both are deleted automatically when the PR closes.
+
 ## Usage
 
 Every client runs the same way: mount an output directory at `/data` and run its `ghcr.io/ethereum/state-actor-<client>:main` image. Substitute `geth` / `reth` / `besu` / `nethermind` / `ethrex` / `erigon` for the client and the matching image.


### PR DESCRIPTION
## Why

`deploy-docker.yaml` only ran on `main` and `v*` tags, so trying out a PR's client image meant building it yourself (~15 min for the cgo ones). This adds a `workflow_dispatch` that publishes any PR's images on request, plus cleanup when the PR closes.

Motivating case: #112 (nethermind).

## Usage

**Actions → Deploy - Docker → Run workflow**, with `pr: 112` and `images: nethermind` (or `all`, or `besu,reth`):

```bash
docker pull ghcr.io/ethereum/state-actor-nethermind:pr-112          # moves as the PR is re-dispatched
docker pull ghcr.io/ethereum/state-actor-nethermind:pr-112-717e963  # pinned to one commit
```

Both are deleted when the PR closes.

## Why dispatch and not a PR label

A label trigger can't work for the case that motivated it. #112 is a fork PR, and a fork's `pull_request` run gets a **read-only** `GITHUB_TOKEN` that cannot push to GHCR — the label would gate a build that then fails at the push. `pull_request_target` has the token but hands `packages:write` to a workflow building a fork-authored Dockerfile on every label event.

`workflow_dispatch` takes a PR *number*, so fork PRs work via `refs/pull/*`. The code-execution exposure is unchanged (a maintainer is still building fork code) but it becomes a deliberate, per-commit act rather than something an event config can misfire. This reasoning is in the workflow header so it doesn't get "helpfully" converted back to a label trigger.

## Tags

Mirrors the existing scheme rather than inventing one — `pr-<n>` is the moving pointer (as `main` is), `pr-<n>-<sha>` the pinned one (as `main-<sha>` is). No `pr-<n>-latest`: `main-latest` only exists to parallel `latest`, and there's no versioned counterpart. Nothing a dispatch produces can collide with `main` / `latest` / `<version>`.

## Notable

**`meta` now computes the image matrix**, replacing four hardcoded copies of the client list. A dispatch naming one client builds one image, not seven.

**`checkout_ref` is deliberately empty for push events.** I originally pinned every checkout to a resolved sha and caught the regression before shipping: `actions/checkout` converts a 40-char `ref` into a bare `git fetch origin <sha>`, which brings no tag refs, so `git describe --tags` degrades from `v9.9.9-1-g057d7c7` to `057d7c7` — silently downgrading the version stamped into every **release** image. Verified against a scratch repo. Push/tag behavior is now preserved byte-for-byte; only dispatch pins a sha, which additionally stops a mid-run force-push from splitting the multi-arch manifest across two commits. PR images stamp `VERSION` as a bare sha.

**Cleanup only deletes a version when _every_ tag on it belongs to the PR.** Versions are content-addressed, so a PR head that builds byte-identical to `main` carries both `pr-112` and `main` — deleting it would take `main` down too. It uses `pull_request_target` for the same read-only-token reason, which is safe here only because it never checks out PR code (noted in the file).

## Testing

No CI covers workflow YAML, so I extracted the shell steps from the YAML and ran them:

- **Matrix**: `nethermind` → 1 image; `nethermind, besu` → 2 (whitespace tolerated); `all` and push → all 7; typo `nethermnid` → fails loud rather than silently building nothing.
- **Tags**: dispatch → `pr-112` / `["pr-112"]`; `refs/heads/main` → `main` / `["main","main-latest"]`; `refs/tags/v1.2.3` → `v1.2.3` / `["v1.2.3","latest"]` — the latter two identical to pre-change output.
- **Cleanup**, end-to-end against a stubbed `gh` with fixture versions: deletes the three `pr-112` versions; keeps `pr-1` and `pr-1120` (prefix-collision guard), `main`, `latest`/`v1.2.3`, untagged manifest children, and the `main`+`pr-112` co-tagged version. Missing packages skip gracefully.
- **Injection**: `pr: "112; rm -rf /"` rejected by the numeric guard.
- `actionlint` clean on the new file; `deploy-docker.yaml` goes 8 → 10 shellcheck infos, the 2 new being unquoted `$GITHUB_OUTPUT` matching the file's existing style.

The one thing I can't test locally is the dispatch actually pushing to GHCR — worth a trial run on #112 after merge.