### PR TITLE
chore(ci): move all actions to Node 24 runtimes and pin by SHA

### DIFF
--- a/.github/actions/cgo-suite/action.yml
+++ b/.github/actions/cgo-suite/action.yml
@@ -45,15 +45,15 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: docker/setup-buildx-action@v3
-    - uses: actions/setup-go@v5
+    - uses: docker/setup-buildx-action@v4
+    - uses: actions/setup-go@v7
       with:
         go-version-file: go.mod
         cache: true
 
     - name: Cache spamoor binary
       id: spamoor-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: /usr/local/bin/spamoor
         key: spamoor-${{ inputs.spamoor-ref }}-${{ runner.os }}
@@ -62,7 +62,7 @@ runs:
       shell: bash
       run: make spamoor-install SPAMOOR_COMMIT=${{ inputs.spamoor-ref }}
 
-    - uses: docker/build-push-action@v5
+    - uses: docker/build-push-action@v7
       with:
         context: .
         file: ${{ inputs.dockerfile }}
@@ -108,7 +108,7 @@ runs:
           go test -tags "$TEST_TAGS" "$TEST_PKG" "${run_filter[@]}" -v -timeout 45m
         docker volume rm -f "$VOL" >/dev/null 2>&1 || true
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       if: always()
       with:
         name: ${{ inputs.client }}-result

--- a/.github/actions/cgo-suite/action.yml
+++ b/.github/actions/cgo-suite/action.yml
@@ -45,15 +45,15 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: docker/setup-buildx-action@v4
-    - uses: actions/setup-go@v7
+    - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+    - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version-file: go.mod
         cache: true
 
     - name: Cache spamoor binary
       id: spamoor-cache
-      uses: actions/cache@v6
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: /usr/local/bin/spamoor
         key: spamoor-${{ inputs.spamoor-ref }}-${{ runner.os }}
@@ -62,7 +62,7 @@ runs:
       shell: bash
       run: make spamoor-install SPAMOOR_COMMIT=${{ inputs.spamoor-ref }}
 
-    - uses: docker/build-push-action@v7
+    - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
         context: .
         file: ${{ inputs.dockerfile }}
@@ -108,7 +108,7 @@ runs:
           go test -tags "$TEST_TAGS" "$TEST_PKG" "${run_filter[@]}" -v -timeout 45m
         docker volume rm -f "$VOL" >/dev/null 2>&1 || true
 
-    - uses: actions/upload-artifact@v7
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
         name: ${{ inputs.client }}-result

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,13 @@
 # would re-build RocksDB from scratch (~15 min, almost the entire job
 # timeout). Inlining the `docker run` step skips Make's prereq and uses
 # the just-loaded image directly. Local dev still uses `make` normally.
+#
+# Action versions are pinned by SHA for reproducibility, same as
+# deploy-docker.yaml; the trailing comment is the human-readable tag. A
+# floating `@v7` re-points whenever upstream moves the major tag, so a
+# green run says nothing about what the next one will execute. Bump the
+# SHA and the comment together — the composite action at
+# .github/actions/cgo-suite/ pins its own steps the same way.
 
 name: CI
 
@@ -63,7 +70,7 @@ concurrency:
 env:
   # Pinned spamoor commit (NOT a branch — ethpandaops/spamoor's default
   # branch is `master`, not `main`, so bare branch names are fragile).
-  # Bump when picking up upstream improvements. The `actions/cache@v6`
+  # Bump when picking up upstream improvements. The `actions/cache`
   # key derives from this; a bump invalidates cache and rebuilds
   # (~2 min). Each suite job installs spamoor via the same key, so
   # warm cache shares across jobs.
@@ -75,8 +82,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true
@@ -165,7 +172,7 @@ jobs:
             test-pkg: ./client/erigon/
             test-run-filter: 'TestErigonGoldenStateRoot|TestE2ESuite|TestPatchGenesisHeaderStateRoot'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/cgo-suite
         with:
           client: ${{ matrix.client }}
@@ -183,8 +190,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true
@@ -194,7 +201,7 @@ jobs:
       # no engine-API mock needed.
       - name: Cache spamoor binary
         id: spamoor-cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /usr/local/bin/spamoor
           key: spamoor-${{ env.SPAMOOR_REF }}-${{ runner.os }}
@@ -210,7 +217,7 @@ jobs:
           REQUIRE_SPAMOOR=1 \
             go test -tags oracle -run TestE2ESuite -v -timeout 30m ./client/geth/...
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: geth-result
@@ -243,7 +250,7 @@ jobs:
       # image build — five extra multi-MB artifacts this job would fetch
       # and then ignore. The checks below glob `*-result.json`, so they
       # stayed correct either way; this just stops paying for the rest.
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: _artifacts
           pattern: '*-result'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ concurrency:
 env:
   # Pinned spamoor commit (NOT a branch — ethpandaops/spamoor's default
   # branch is `master`, not `main`, so bare branch names are fragile).
-  # Bump when picking up upstream improvements. The `actions/cache@v4`
+  # Bump when picking up upstream improvements. The `actions/cache@v6`
   # key derives from this; a bump invalidates cache and rebuilds
   # (~2 min). Each suite job installs spamoor via the same key, so
   # warm cache shares across jobs.
@@ -75,8 +75,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
@@ -165,7 +165,7 @@ jobs:
             test-pkg: ./client/erigon/
             test-run-filter: 'TestErigonGoldenStateRoot|TestE2ESuite|TestPatchGenesisHeaderStateRoot'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/cgo-suite
         with:
           client: ${{ matrix.client }}
@@ -183,8 +183,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
@@ -194,7 +194,7 @@ jobs:
       # no engine-API mock needed.
       - name: Cache spamoor binary
         id: spamoor-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: /usr/local/bin/spamoor
           key: spamoor-${{ env.SPAMOOR_REF }}-${{ runner.os }}
@@ -210,7 +210,7 @@ jobs:
           REQUIRE_SPAMOOR=1 \
             go test -tags oracle -run TestE2ESuite -v -timeout 30m ./client/geth/...
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: geth-result
@@ -237,9 +237,16 @@ jobs:
     if: always() && !cancelled()
     timeout-minutes: 5
     steps:
-      - uses: actions/download-artifact@v4
+      # `pattern` scopes this to the six *-result artifacts the suite jobs
+      # upload. Without it the step downloads EVERY artifact in the run,
+      # and docker/build-push-action >= v6 exports a build record per
+      # image build — five extra multi-MB artifacts this job would fetch
+      # and then ignore. The checks below glob `*-result.json`, so they
+      # stayed correct either way; this just stops paying for the rest.
+      - uses: actions/download-artifact@v8
         with:
           path: _artifacts
+          pattern: '*-result'
           merge-multiple: true
       - name: Compare genesis state-roots across all 6 clients
         run: |

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -120,7 +120,7 @@ jobs:
           # two commits. PR builds therefore stamp VERSION as a bare sha.
           echo "checkout_ref=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.resolve.outputs.checkout_ref }}
           fetch-depth: 0
@@ -218,7 +218,7 @@ jobs:
       GHCR_REPO: ghcr.io/${{ github.repository }}${{ matrix.suffix }}
       DOCKERFILE: ${{ matrix.dockerfile }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.meta.outputs.checkout_ref }}
           fetch-depth: 0
@@ -271,7 +271,7 @@ jobs:
       GHCR_REPO: ghcr.io/${{ github.repository }}${{ matrix.suffix }}
       DOCKERFILE: ${{ matrix.dockerfile }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.meta.outputs.checkout_ref }}
           fetch-depth: 0

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -224,10 +224,10 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -277,10 +277,10 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -322,10 +322,10 @@ jobs:
       GHCR_REPO: ghcr.io/${{ github.repository }}${{ matrix.suffix }}
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -356,10 +356,10 @@ jobs:
       GHCR_REPO: ghcr.io/${{ github.repository }}${{ matrix.suffix }}
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
Every CI and deploy run currently emits GitHub's Node 20 deprecation
warning. Node 20 actions are already being force-run on Node 24, and the
runtime is being removed — so this is a deadline, not a cosmetic warning.

Moves every action onto a release that declares `node24` itself, and
brings `ci.yml` onto the SHA-pinning convention `deploy-docker.yaml`
already used.

## What was warning

Taken from the annotations of a real run (`29877684158`) rather than
inferred from the files — which is how the last three surfaced. They live
in `.github/actions/cgo-suite/action.yml`, and GitHub attributes a
composite action's steps to the calling job:

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | v4 | v7.0.1 |
| `actions/setup-go` | v5 | v7.0.0 |
| `actions/cache` | v4 | v6.1.0 |
| `actions/upload-artifact` | v4 | v7.0.1 |
| `actions/download-artifact` | v4 | v8.0.1 |
| `docker/build-push-action` | v5 | v7.3.0 |
| `docker/setup-buildx-action` | v3 | v4.2.0 |
| `docker/login-action` | v3.3.0 | v4.4.0 |

`deploy-docker.yaml`'s `actions/checkout` also goes v6.0.2 → v7.0.1 so
there is one checkout pin repo-wide; v6 was already node24 and not
warning.

## Notes for review

**`upload-artifact@v5` and `download-artifact@v6` would not have fixed
this.** Both advertise Node 24 support in their release notes but still
default to node20 — hence v7/v8. Every target was confirmed by reading
`runs.using` in its own `action.yml` at the pinned SHA, not by trusting
the tag.

**Breaking changes across the crossed majors were checked individually
and miss us:**

- `checkout@v7` refuses fork-PR checkout, but the guard is event-gated —
  it returns early unless the event is `pull_request_target` or
  `workflow_run` (`src/unsafe-pr-checkout-helper.ts`). `ci.yml` uses
  `pull_request`; `deploy-docker.yaml` uses `push` +
  `workflow_dispatch`. The latter deliberately builds fork PR heads and
  is unaffected, so `allow-unsafe-pr-checkout` is not needed.
- `checkout@v7` still classifies a 40-char `ref` as a commit
  (`src/input-helper.ts`). `deploy-docker.yaml` depends on this: it is
  why PR builds stamp VERSION as a bare sha, and why push events pass an
  empty ref so `git describe --tags` keeps working.
- `download-artifact@v5`'s path change applies only to downloads by
  `artifact-ids`. We download by pattern.
- `setup-go@v6`'s toolchain rework has nothing to select — `go.mod` pins
  `go 1.25.7` with no `toolchain` directive.
- `download-artifact@v8` now errors rather than warns on a digest
  mismatch. That is the behaviour we want.
- Every input this repo passes still exists at the new majors.

**One real side effect, handled.** `build-push-action >= v6` exports a
build record as a workflow artifact per image build, and
`cross-client-genesis-root` downloaded *every* artifact in the run. Its
checks glob `*-result.json` so they stayed correct, but it would fetch
five multi-MB build records only to ignore them. Scoped that download
with `pattern: '*-result'`, which also makes the aggregator's contract
explicit. The alternative was `DOCKER_BUILD_SUMMARY: false`; summaries
were kept since they help debug the long RocksDB builds.

## SHA pinning

`ci.yml` and the composite tracked floating major tags. A floating `@v7`
re-points whenever upstream moves the major tag, so a green run says
nothing about what the next one executes. Both now pin by SHA with the
tag as a trailing comment, matching `deploy-docker.yaml`, and the
convention is recorded in `ci.yml`'s header.

Pinning is a freeze, not a bump: each floating major resolved to exactly
the patch pinned here, so behaviour is unchanged. All nine pins were
re-verified after writing by re-resolving each tag through its annotated
tag object back to a commit SHA.

## Verification

- `actionlint` on both workflows: no new findings (deploy-docker had 10
  pre-existing shellcheck infos, ci.yml 1 — identical counts before and
  after).
- Both workflows and the composite parse as valid YAML.
- No `node20` action remains anywhere under `.github/`.

Note that CI on `main` was already failing before this branch (run
`29877630672`), so a red run here is not necessarily attributable to
these changes.
