### PR TITLE
fix(ethrex): bound peak RSS so large --target-size runs stop OOM-killing (closes #116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,19 @@
   p2p enabled — its synchronizer must register the post-merge head as in-sync, otherwise
   Besu answers `SYNCING`.
 
+### Added
+- **`--client=ethrex` reports its memory split every 30s.** New
+  `internal/memstat` samples process RSS against the Go runtime's own total —
+  their difference being the cgo memory no `GOMEMLIMIT` can govern — plus
+  host-wide `MemAvailable`/`Dirty`/`Writeback`, which distinguish "this process
+  exhausted memory" from "unreclaimable page cache did". Alongside it the
+  ethrex writer logs RocksDB's own accounting (`cur-size-all-mem-tables`,
+  `estimate-table-readers-mem`, block-cache usage, L0 file count), so the
+  budget constants can be checked against ground truth instead of trusted.
+  A SIGKILL cannot log anything, so the last line before a kill is the only
+  record — this exists because two 350 GB runs died leaving nothing but an
+  exit code to reason from.
+
 ### Fixed
 - **`--client=ethrex` no longer OOM-kills on large `--target-size` runs.** A
   350 GB fill was SIGKILLed ~38% into Phase 2 on a 62 GiB host because nothing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,43 +35,36 @@
   their difference being the cgo memory no `GOMEMLIMIT` can govern — plus
   host-wide `MemAvailable`/`Dirty`/`Writeback`, which distinguish "this process
   exhausted memory" from "unreclaimable page cache did". Alongside it the
-  ethrex writer logs RocksDB's own accounting (`cur-size-all-mem-tables`,
-  `estimate-table-readers-mem`, block-cache usage, L0 file count), so the
-  budget constants can be checked against ground truth instead of trusted.
-  A SIGKILL cannot log anything, so the last line before a kill is the only
-  record — this exists because two 350 GB runs died leaving nothing but an
-  exit code to reason from.
+  ethrex writer logs RocksDB's own accounting (memtables, table readers,
+  block-cache usage, L0 file count), and `Close()` logs per-CF compaction
+  duration and memory — the phases a SIGKILL would otherwise leave unrecorded.
 
 ### Fixed
-- **`MALLOC_ARENA_MAX=2` in `Dockerfile.ethrex`, and the ethrex memory budget
-  recalibrated against a kernel OOM report.** The kill was confirmed genuine —
-  `state-actor` held **51.3 GiB of anonymous RSS** — but not for the reason
-  first assumed. The kernel showed only 15 MB of page cache and 16 GiB in
-  transparent huge pages, while RocksDB's own properties accounted for under
-  10 GiB (`estimate-table-readers-mem` held 388 KB). The unaccounted remainder
-  was glibc arena fragmentation, which grows with allocation churn and so with
-  bytes written. Capping arenas, dropping the write-only block cache 4 GiB →
-  512 MiB, and reserving for fragmentation explicitly cut peak RSS **9.4 → 7.3
-  GiB** and off-heap **8.1 → 5.4 GiB** on an identical 40 GB fill, with a
-  byte-identical state root.
-
-- **`--client=ethrex` no longer OOM-kills on large `--target-size` runs.** A
-  350 GB fill was SIGKILLed ~38% into Phase 2 on a 62 GiB host because nothing
-  bounded three compounding memory terms. Now: RocksDB's index and bloom-filter
-  blocks are routed through the existing 4 GiB shared block cache
-  (`cache_index_and_filter_blocks`) instead of RocksDB's default of pre-loading
-  them into per-SST table readers, where they sat outside every budget and grew
-  with each SST written; `db_write_buffer_size` caps total memtable memory,
-  which the per-CF write buffers (mirrored from ethrex, and not summed by
-  RocksDB) would otherwise allow to reach 12 GiB across the four big state CFs;
-  and the new `internal/memlimit` package derives a `GOMEMLIMIT` from the host's
-  real ceiling (cgroup v2, cgroup v1, then `/proc/meminfo`) minus the writer's
-  declared off-heap reserve, so `GOGC=100` can no longer double a bytecode-heavy
-  live heap unchecked. An explicit `GOMEMLIMIT` still wins, and a limit too
-  small to help is declined and logged rather than applied — one below the live
-  heap trades an OOM kill for an unbounded GC stall. **These are process-runtime
-  knobs only: the produced datadir is byte-identical, which
-  `TestEthrexGoldenStateRoot` and `TestGenesisDumpGolden` pin.**
+- **`--client=ethrex` no longer OOM-kills on large `--target-size` runs
+  (closes #116).** A 350 GB fill died at 51.3 GiB anon RSS on a 62 GiB host
+  (kernel-confirmed OOM; 16 GiB of it transparent huge pages). Fixed on two
+  fronts. **Allocator**: the runtime image now runs RocksDB on jemalloc via
+  `LD_PRELOAD` — RocksDB-on-glibc is the documented pathological pairing
+  behind unbounded allocator retention, and jemalloc is what ethrex itself
+  ships as its default global allocator (`MALLOC_ARENA_MAX=2` stays as the
+  fallback for a failed preload). **Structure**, aligning the writer with the
+  besu/nethermind/geth/erigon disciplines: Phase-2 workers capped at 8 (was
+  uncapped `NumCPU()`); state-CF memtables 256 MiB × 4 (was 512 MiB × 6 with
+  min-merge) under a 4 GiB `db_write_buffer_size` backstop; index and
+  bloom-filter blocks routed through the shared block cache (512 MiB — as a
+  4 GiB bystander they sat in per-SST table readers outside every budget)
+  with `max_open_files` bounded; `Close()`-time CompactRange serialized
+  (concurrent manual compactions of never-compacted L0 stacked readahead at
+  the run's peak); Phase-1 sort spill moved from `/tmp` to the datadir
+  volume. The new `internal/memlimit` derives a `GOMEMLIMIT` from the host's
+  real ceiling (cgroup v2 → cgroup v1 → `/proc/meminfo`) minus the writer's
+  declared off-heap reserve; an explicit `GOMEMLIMIT` wins, and a limit too
+  small to help is declined and logged — one below the live heap trades an
+  OOM kill for an unbounded GC stall. These are process-runtime knobs only:
+  the produced database is **logically identical** — same KV content, same
+  state root, pinned by `TestEthrexGoldenStateRoot` and
+  `TestGenesisDumpGolden` (physical SST packing legitimately varies with
+  flush cadence).
 
 - **`erc20` template now honors `approximate_size_bytes`.** Previously
   the universal entity-level sizing knob was silently ignored on the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,18 @@
   exit code to reason from.
 
 ### Fixed
+- **`MALLOC_ARENA_MAX=2` in `Dockerfile.ethrex`, and the ethrex memory budget
+  recalibrated against a kernel OOM report.** The kill was confirmed genuine —
+  `state-actor` held **51.3 GiB of anonymous RSS** — but not for the reason
+  first assumed. The kernel showed only 15 MB of page cache and 16 GiB in
+  transparent huge pages, while RocksDB's own properties accounted for under
+  10 GiB (`estimate-table-readers-mem` held 388 KB). The unaccounted remainder
+  was glibc arena fragmentation, which grows with allocation churn and so with
+  bytes written. Capping arenas, dropping the write-only block cache 4 GiB →
+  512 MiB, and reserving for fragmentation explicitly cut peak RSS **9.4 → 7.3
+  GiB** and off-heap **8.1 → 5.4 GiB** on an identical 40 GB fill, with a
+  byte-identical state root.
+
 - **`--client=ethrex` no longer OOM-kills on large `--target-size` runs.** A
   350 GB fill was SIGKILLed ~38% into Phase 2 on a 62 GiB host because nothing
   bounded three compounding memory terms. Now: RocksDB's index and bloom-filter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,11 @@
   real ceiling (cgroup v2 → cgroup v1 → `/proc/meminfo`) minus the writer's
   declared off-heap reserve; an explicit `GOMEMLIMIT` wins, and a limit too
   small to help is declined and logged — one below the live heap trades an
-  OOM kill for an unbounded GC stall. These are process-runtime knobs only:
+  OOM kill for an unbounded GC stall. The reserve is measured, not guessed:
+  a 40 GB same-seed A/B put the jemalloc off-heap plateau at ~4.4 GiB
+  (flat; the glibc baseline climbed to 6.2 GiB on identical work), so the
+  reserve is 8 GiB — budgeted caps plus a 1.5 GiB allocator slack — and the
+  heap takes half the post-reserve remainder. These are process-runtime knobs only:
   the produced database is **logically identical** — same KV content, same
   state root, pinned by `TestEthrexGoldenStateRoot` and
   `TestGenesisDumpGolden` (physical SST packing legitimately varies with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,24 @@
   Besu answers `SYNCING`.
 
 ### Fixed
+- **`--client=ethrex` no longer OOM-kills on large `--target-size` runs.** A
+  350 GB fill was SIGKILLed ~38% into Phase 2 on a 62 GiB host because nothing
+  bounded three compounding memory terms. Now: RocksDB's index and bloom-filter
+  blocks are routed through the existing 4 GiB shared block cache
+  (`cache_index_and_filter_blocks`) instead of RocksDB's default of pre-loading
+  them into per-SST table readers, where they sat outside every budget and grew
+  with each SST written; `db_write_buffer_size` caps total memtable memory,
+  which the per-CF write buffers (mirrored from ethrex, and not summed by
+  RocksDB) would otherwise allow to reach 12 GiB across the four big state CFs;
+  and the new `internal/memlimit` package derives a `GOMEMLIMIT` from the host's
+  real ceiling (cgroup v2, cgroup v1, then `/proc/meminfo`) minus the writer's
+  declared off-heap reserve, so `GOGC=100` can no longer double a bytecode-heavy
+  live heap unchecked. An explicit `GOMEMLIMIT` still wins, and a limit too
+  small to help is declined and logged rather than applied — one below the live
+  heap trades an OOM kill for an unbounded GC stall. **These are process-runtime
+  knobs only: the produced datadir is byte-identical, which
+  `TestEthrexGoldenStateRoot` and `TestGenesisDumpGolden` pin.**
+
 - **`erc20` template now honors `approximate_size_bytes`.** Previously
   the universal entity-level sizing knob was silently ignored on the
   `erc20` template (only `raw` and `eoa` consumed it), even though

--- a/Dockerfile.ethrex
+++ b/Dockerfile.ethrex
@@ -115,8 +115,11 @@ LABEL org.opencontainers.image.title="State Actor (ethrex)" \
 # Compression libs (rocksdb runtime links against these). RocksDB's own
 # .so comes from the builder stage. libgflags2.2 is a static transitive
 # dep of librocksdb.so — without it runtime symbol resolution fails.
+# libjemalloc2 is the allocator RocksDB runs on here — see the LD_PRELOAD
+# note below.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
+    libjemalloc2 \
     libsnappy1v5 \
     liblz4-1 \
     libzstd1 \
@@ -131,21 +134,31 @@ RUN ldconfig
 
 COPY --from=builder /out/state-actor /usr/local/bin/state-actor
 
-# glibc allocates up to 8 arenas per core (128 on a 16-core builder) and never
-# returns a freed chunk from one arena to another. RocksDB's flush threads
-# churn large buffers from many threads at once, so the per-arena free lists
-# retain memory that never comes back to the OS — fragmentation that grows with
-# allocation churn, and therefore with bytes written.
+# Run the C side (RocksDB via grocksdb) on jemalloc, not glibc malloc.
 #
-# This was measured, not assumed. A 350 GB fill was OOM-killed with 51.3 GiB of
-# anonymous RSS, of which RocksDB's own properties accounted for well under
-# 10 GiB (estimate-table-readers-mem held 388 KB; memtables and block cache sat
-# inside their caps). The unaccounted remainder tracked bytes written, which is
-# the signature of arena fragmentation rather than of any RocksDB budget.
+# RocksDB on glibc is a documented pathological pairing: glibc keeps up to 8
+# malloc arenas per core (128 on a 16-core host) and never returns a freed
+# chunk from one arena to another, so RocksDB's flush threads — churning
+# large buffers from many threads at once — leave per-arena free lists that
+# ratchet upward for the life of the process, amplified by transparent huge
+# pages backing the arenas. Measured, not assumed: a 350 GB fill was
+# OOM-killed at 51.3 GiB anon RSS (16 GiB of it THP) while RocksDB's own
+# properties accounted for well under 10 GiB.
 #
-# Capping arenas trades a little allocator contention for bounded RSS — the
-# right trade for a batch writer whose failure mode is the OOM killer. It must
-# be set in the environment: glibc reads it once, before main.
+# jemalloc is also what this RocksDB configuration was tuned against
+# upstream: ethrex ships jemalloc as its default global allocator
+# (tikv-jemallocator), as does reth — the options this writer mirrors from
+# ethrex have never run on glibc there.
+#
+# The bare SONAME lets ld.so resolve the multiarch path on amd64 and arm64
+# alike. Go's runtime allocator is unaffected (it mmaps directly); only cgo
+# allocations route through jemalloc.
+ENV LD_PRELOAD=libjemalloc.so.2
+
+# Fallback bound if the preload ever fails (ld.so prints a warning to stderr
+# and continues on glibc malloc): cap glibc at 2 arenas so per-arena
+# free-list retention stays bounded. Inert under jemalloc, which ignores
+# glibc-specific knobs. Must be an env var: glibc reads it once, before main.
 ENV MALLOC_ARENA_MAX=2
 
 ENTRYPOINT ["/usr/local/bin/state-actor"]

--- a/Dockerfile.ethrex
+++ b/Dockerfile.ethrex
@@ -131,4 +131,21 @@ RUN ldconfig
 
 COPY --from=builder /out/state-actor /usr/local/bin/state-actor
 
+# glibc allocates up to 8 arenas per core (128 on a 16-core builder) and never
+# returns a freed chunk from one arena to another. RocksDB's flush threads
+# churn large buffers from many threads at once, so the per-arena free lists
+# retain memory that never comes back to the OS — fragmentation that grows with
+# allocation churn, and therefore with bytes written.
+#
+# This was measured, not assumed. A 350 GB fill was OOM-killed with 51.3 GiB of
+# anonymous RSS, of which RocksDB's own properties accounted for well under
+# 10 GiB (estimate-table-readers-mem held 388 KB; memtables and block cache sat
+# inside their caps). The unaccounted remainder tracked bytes written, which is
+# the signature of arena fragmentation rather than of any RocksDB budget.
+#
+# Capping arenas trades a little allocator contention for bounded RSS — the
+# right trade for a batch writer whose failure mode is the OOM killer. It must
+# be set in the environment: glibc reads it once, before main.
+ENV MALLOC_ARENA_MAX=2
+
 ENTRYPOINT ["/usr/local/bin/state-actor"]

--- a/client/besu/dbs_cgo.go
+++ b/client/besu/dbs_cgo.go
@@ -110,8 +110,14 @@ func openBesuDB(datadir string) (*besuDB, error) {
 		t.SetBlockSize(32 << 10) // 32 KB
 		t.SetFormatVersion(5)
 		t.SetFilterPolicy(bf)
-		// SetPartitionFilters not exposed by grocksdb — accept default.
-		// SetCacheIndexAndFilterBlocks not exposed by grocksdb — accept default.
+		// SetPartitionFilters and SetCacheIndexAndFilterBlocks ARE exposed by
+		// grocksdb v1.10.x (earlier comments here claimed otherwise). Both
+		// stay at RocksDB defaults deliberately: the bulk path is write-only
+		// and Besu re-tunes table options at first open. NOTE the default
+		// means index/filter blocks live in per-SST table readers, outside
+		// any cache bound, growing with SST count — the term the ethrex
+		// writer now routes through its shared cache; porting that here is a
+		// tracked follow-up.
 		return t
 	}
 

--- a/client/ethrex/dbs_cgo.go
+++ b/client/ethrex/dbs_cgo.go
@@ -4,10 +4,11 @@ package ethrex
 
 import (
 	"fmt"
+	"log"
 	"math"
 	"os"
 	"runtime"
-	"sync"
+	"time"
 
 	"github.com/linxGnu/grocksdb"
 
@@ -338,13 +339,23 @@ func openEthrexDB(dbPath string) (*ethrexDB, error) {
 func (d *ethrexDB) Close() {
 	if d.db != nil {
 		emptyRange := grocksdb.Range{Start: nil, Limit: nil}
-		// exclusive=false lets these per-CF manual compactions overlap instead
-		// of serializing on RocksDB's exclusive-manual-compaction lock; the
-		// shared CompactRangeOptions is read-only during compaction so it is
-		// safe to use from all goroutines.
-		cro := grocksdb.NewCompactRangeOptions()
-		cro.SetExclusiveManualCompaction(false)
-		var wg sync.WaitGroup
+		// Serial, mirroring the besu and nethermind writers. The 12-goroutine
+		// fan-out this replaces bought little — max_background_jobs
+		// (bulkBackgroundJobs) already floored real parallelism at 8 — and
+		// cost memory at the worst moment: with L0 never compacted during
+		// the import, the L0→base merge takes EVERY L0 file of a CF as
+		// input at ~2 MiB compaction readahead each (~2800 files across the
+		// state CFs at 700 GB), so compacting the four state CFs
+		// concurrently stacked ~4× that readahead on top of end-of-run
+		// state. Serial caps the term at the largest single CF. State CFs
+		// go first: they dominate, and an interrupt part-way leaves the
+		// cheap CFs uncompacted rather than the expensive ones.
+		//
+		// The per-CF log lines are the only record of this phase: the 30s
+		// sampler is stopped BEFORE Close (it reads DB properties, and
+		// grocksdb does not guard against a closed handle), so without them
+		// Close-time compaction memory would be invisible — the same
+		// blindness that let #116's import-phase terms go unmeasured.
 		for _, idx := range []int{
 			cfIdxAccountTrieNodes,
 			cfIdxStorageTrieNodes,
@@ -360,15 +371,14 @@ func (d *ethrexDB) Close() {
 			cfIdxCanonicalBlockHashes,
 		} {
 			if idx < len(d.cfs) && d.cfs[idx] != nil {
-				wg.Add(1)
-				go func(cf *grocksdb.ColumnFamilyHandle) {
-					defer wg.Done()
-					d.db.CompactRangeCFOpt(cf, emptyRange, cro)
-				}(d.cfs[idx])
+				start := time.Now()
+				d.db.CompactRangeCF(d.cfs[idx], emptyRange)
+				log.Printf("  ethrex: compacted %s in %s · mem %s · %s",
+					ethrexinternal.Tables[idx],
+					time.Since(start).Round(time.Second),
+					memstat.Read(), d.memoryReport())
 			}
 		}
-		wg.Wait()
-		cro.Destroy()
 	}
 
 	for _, h := range d.cfs {

--- a/client/ethrex/dbs_cgo.go
+++ b/client/ethrex/dbs_cgo.go
@@ -221,6 +221,12 @@ func openEthrexDB(dbPath string) (*ethrexDB, error) {
 		// memory-placement option only: it changes nothing about the bytes
 		// written, and nothing is read during bulk import, so eviction costs
 		// nothing here. See ethrexBlockCacheBytes for why it is load-bearing.
+		//
+		// Do NOT "complete the pairing" with
+		// SetPinL0FilterAndIndexBlocksInCache: with L0 uncompacted for the
+		// whole import (~2800 files at 700 GB), pinning would push several
+		// GiB past the cache's capacity — pinned usage may legally exceed an
+		// LRU's size, defeating the bound this cache exists to provide.
 		bbto.SetCacheIndexAndFilterBlocks(true)
 
 		switch i {

--- a/client/ethrex/dbs_cgo.go
+++ b/client/ethrex/dbs_cgo.go
@@ -19,18 +19,23 @@ import (
 // during bulk import.
 const bulkBackgroundJobs = 8
 
-// ethrexBlockCacheBytes is the shared LRU block cache, mirroring ethrex's
-// crates/storage/backend/rocksdb.rs (4 GiB, shared across all CFs).
+// ethrexBlockCacheBytes is the shared LRU block cache across all CFs.
 //
-// Paired with cache_index_and_filter_blocks (set per-CF below), this is also
-// the ceiling for index and bloom-filter blocks. That pairing is the point:
-// RocksDB's default pre-loads them into each table reader instead, outside
-// every budget and unevictable for as long as the SST stays open. At the
-// scale this writer targets — billions of keys across the four big state CFs,
-// with 10-bit filters and 131-byte storage_flatkeyvalue keys — that is several
-// GiB of RAM that grows monotonically with every SST written, and it is one
-// of the terms that OOM-killed a 350 GB ethrex run mid-import.
-const ethrexBlockCacheBytes = 4 * 1024 * 1024 * 1024
+// ethrex's own crates/storage/backend/rocksdb.rs uses 4 GiB. This writer uses
+// far less BY DESIGN: a block cache only accelerates reads, and generation is
+// write-only until Close()'s CompactRange. Cache size is a process-runtime
+// knob — it does not change a single byte of the produced DB — so mirroring
+// ethrex here would buy representativeness that does not exist while costing
+// RAM that demonstrably does.
+//
+// Paired with cache_index_and_filter_blocks (set per-CF below) it is also the
+// ceiling for index and bloom-filter blocks. RocksDB's default pre-loads those
+// into each table reader instead, outside every budget. Measurement says the
+// pairing works and the sizing is safe: over a 79 GB fill,
+// estimate-table-readers-mem stayed at 388 KB while cache usage climbed to
+// 1.5 GiB — so index/filter memory is bounded here, and capping the cache
+// merely evicts blocks nothing is reading.
+const ethrexBlockCacheBytes = 512 * 1024 * 1024
 
 // ethrexDBWriteBufferBytes caps TOTAL memtable memory across all CFs.
 //
@@ -61,13 +66,30 @@ const ethrexMaxOpenFiles = 32768
 // compaction/iterator scratch.
 const ethrexAuxOffHeapBytes = 2 * 1024 * 1024 * 1024
 
+// ethrexFragmentationReserveBytes covers allocator memory that no component
+// reports and no cap governs: glibc arena free lists and the transparent huge
+// pages backing them.
+//
+// This term exists because omitting it got a run killed. A 350 GB fill died
+// with 51.3 GiB of anonymous RSS while RocksDB's own properties accounted for
+// under 10 GiB and the kernel showed only 15 MB of page cache — so roughly
+// half the process was allocator overhead invisible to every budget here. The
+// kernel's own numbers put 16 GiB of that in transparent huge pages.
+//
+// MALLOC_ARENA_MAX=2 in Dockerfile.ethrex attacks the cause and should shrink
+// this considerably; the reserve stays conservative until the memory samples
+// from a full-scale run say otherwise. Reserving too much only makes the Go
+// heap tighter, which costs GC cycles. Reserving too little costs the run.
+const ethrexFragmentationReserveBytes = 12 * 1024 * 1024 * 1024
+
 // ethrexOffHeapReserveBytes is the total RAM this writer commits OUTSIDE the
 // Go heap. runImpl subtracts it from the host's memory ceiling before deriving
 // GOMEMLIMIT, so the Go runtime budgets against what is actually left rather
-// than against memory RocksDB and Pebble have already claimed.
+// than against memory RocksDB, Pebble, and the C allocator have already taken.
 const ethrexOffHeapReserveBytes = ethrexBlockCacheBytes +
 	ethrexDBWriteBufferBytes +
-	ethrexAuxOffHeapBytes
+	ethrexAuxOffHeapBytes +
+	ethrexFragmentationReserveBytes
 
 // ethrexCompressibleCF reports whether a CF uses LZ4 in the real ethrex client.
 // Mirrors `compressible_tables` in ethrex rocksdb.rs: only block-metadata CFs

--- a/client/ethrex/dbs_cgo.go
+++ b/client/ethrex/dbs_cgo.go
@@ -70,21 +70,20 @@ const ethrexMaxOpenFiles = 32768
 // compaction/iterator scratch.
 const ethrexAuxOffHeapBytes = 2 * 1024 * 1024 * 1024
 
-// ethrexFragmentationReserveBytes covers allocator memory that no component
-// reports and no cap governs: glibc arena free lists and the transparent huge
-// pages backing them.
+// ethrexAllocatorSlackBytes covers allocator memory no component reports:
+// jemalloc's retained dirty pages and metadata over the C heap (RocksDB,
+// Pebble, the WriteBatches).
 //
-// This term exists because omitting it got a run killed. A 350 GB fill died
-// with 51.3 GiB of anonymous RSS while RocksDB's own properties accounted for
-// under 10 GiB and the kernel showed only 15 MB of page cache — so roughly
-// half the process was allocator overhead invisible to every budget here. The
-// kernel's own numbers put 16 GiB of that in transparent huge pages.
-//
-// MALLOC_ARENA_MAX=2 in Dockerfile.ethrex attacks the cause and should shrink
-// this considerably; the reserve stays conservative until the memory samples
-// from a full-scale run say otherwise. Reserving too much only makes the Go
-// heap tighter, which costs GC cycles. Reserving too little costs the run.
-const ethrexFragmentationReserveBytes = 12 * 1024 * 1024 * 1024
+// Measured, then sized — not guessed. On the 40 GB same-seed A/B that gated
+// this series (96-core host, 73 GiB realized), the jemalloc leg's off-heap
+// plateaued at ~4.4 GiB from ~35% of Phase 2 onward, against ~3 GiB of
+// directly attributed usage — ~1.5–2 GiB of allocator overhead, FLAT once
+// steady state was reached. The glibc+arena-cap baseline kept climbing to
+// 6.2 GiB on the identical workload. This constant replaces the pre-jemalloc
+// 12 GiB "fragmentation reserve", which was a guess standing in for exactly
+// the retention jemalloc removes; memlimit's post-reserve margin absorbs
+// this slack being an underestimate at larger scale.
+const ethrexAllocatorSlackBytes = 1536 * 1024 * 1024 // 1.5 GiB
 
 // ethrexOffHeapReserveBytes is the total RAM this writer commits OUTSIDE the
 // Go heap. runImpl subtracts it from the host's memory ceiling before deriving
@@ -93,7 +92,7 @@ const ethrexFragmentationReserveBytes = 12 * 1024 * 1024 * 1024
 const ethrexOffHeapReserveBytes = ethrexBlockCacheBytes +
 	ethrexDBWriteBufferBytes +
 	ethrexAuxOffHeapBytes +
-	ethrexFragmentationReserveBytes
+	ethrexAllocatorSlackBytes
 
 // ethrexCompressibleCF reports whether a CF uses LZ4 in the real ethrex client.
 // Mirrors `compressible_tables` in ethrex rocksdb.rs: only block-metadata CFs

--- a/client/ethrex/dbs_cgo.go
+++ b/client/ethrex/dbs_cgo.go
@@ -12,6 +12,7 @@ import (
 	"github.com/linxGnu/grocksdb"
 
 	ethrexinternal "github.com/ethereum/state-actor/internal/ethrex"
+	"github.com/ethereum/state-actor/internal/memstat"
 )
 
 // bulkBackgroundJobs caps RocksDB's background compaction/flush thread pool
@@ -369,6 +370,64 @@ func (d *ethrexDB) Close() {
 		d.cache.Destroy()
 		d.cache = nil
 	}
+}
+
+// stateCFsForMemoryReport are the CFs whose memory is worth attributing
+// individually: the four that carry essentially all of a bulk import's bytes.
+var stateCFsForMemoryReport = []int{
+	cfIdxAccountTrieNodes,
+	cfIdxStorageTrieNodes,
+	cfIdxAccountFlatKeyValue,
+	cfIdxStorageFlatKeyValue,
+}
+
+// memoryReport renders RocksDB's own accounting of where its memory has gone.
+//
+// This exists because the budget constants in this file are ceilings, not
+// measurements: they say what RocksDB is ALLOWED to use, and an OOM means
+// something exceeded an estimate rather than a bound. These properties are
+// RocksDB's ground truth.
+//
+//   - memtables: charged against ethrexDBWriteBufferBytes.
+//   - table-readers: per-SST index/filter/metadata. cache_index_and_filter_blocks
+//     should keep the expensive part in the cache and this number small; if it
+//     grows with the import instead, that setting is not covering what it
+//     should.
+//   - cache / pinned: usage of the shared ethrexBlockCacheBytes LRU. An LRU is
+//     not a hard bound — pinned entries can push usage past capacity — so
+//     cache exceeding its capacity is itself a finding.
+//   - L0 files: the SST count, since nothing compacts them during the import.
+func (d *ethrexDB) memoryReport() string {
+	sum := func(prop string) uint64 {
+		var total uint64
+		for _, idx := range stateCFsForMemoryReport {
+			if idx >= len(d.cfs) || d.cfs[idx] == nil {
+				continue
+			}
+			if v, ok := d.db.GetIntPropertyCF(prop, d.cfs[idx]); ok {
+				total += v
+			}
+		}
+
+		return total
+	}
+
+	// Block-cache usage is a property of the shared cache, so it reads the
+	// same from every CF — take it from one rather than summing four copies.
+	var cacheUsage, cachePinned uint64
+	if len(d.cfs) > cfIdxAccountTrieNodes && d.cfs[cfIdxAccountTrieNodes] != nil {
+		cacheUsage, _ = d.db.GetIntPropertyCF("rocksdb.block-cache-usage", d.cfs[cfIdxAccountTrieNodes])
+		cachePinned, _ = d.db.GetIntPropertyCF("rocksdb.block-cache-pinned-usage", d.cfs[cfIdxAccountTrieNodes])
+	}
+
+	return fmt.Sprintf(
+		"rocksdb memtables=%s table-readers=%s cache=%s cache-pinned=%s L0-files=%d",
+		memstat.FormatBytes(sum("rocksdb.cur-size-all-mem-tables")),
+		memstat.FormatBytes(sum("rocksdb.estimate-table-readers-mem")),
+		memstat.FormatBytes(cacheUsage),
+		memstat.FormatBytes(cachePinned),
+		sum("rocksdb.num-files-at-level0"),
+	)
 }
 
 // put writes a key/value to the CF at cfIdx.

--- a/client/ethrex/dbs_cgo.go
+++ b/client/ethrex/dbs_cgo.go
@@ -8,6 +8,8 @@ import (
 	"math"
 	"os"
 	"runtime"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/linxGnu/grocksdb"
@@ -474,13 +476,32 @@ func (d *ethrexDB) memoryReport() string {
 		cachePinned, _ = d.db.GetIntPropertyCF("rocksdb.block-cache-pinned-usage", d.cfs[cfIdxAccountTrieNodes])
 	}
 
+	// num-files-at-level<N> is a STRING property — reading it through the
+	// int API silently fails and reported a constant 0 for entire runs
+	// (while table-reader memory proved SSTs were accumulating). Parse the
+	// string form instead.
+	sumL0 := func() uint64 {
+		var total uint64
+		for _, idx := range stateCFsForMemoryReport {
+			if idx >= len(d.cfs) || d.cfs[idx] == nil {
+				continue
+			}
+			v := d.db.GetPropertyCF("rocksdb.num-files-at-level0", d.cfs[idx])
+			if n, err := strconv.ParseUint(strings.TrimSpace(v), 10, 64); err == nil {
+				total += n
+			}
+		}
+
+		return total
+	}
+
 	return fmt.Sprintf(
 		"rocksdb memtables=%s table-readers=%s cache=%s cache-pinned=%s L0-files=%d",
 		memstat.FormatBytes(sum("rocksdb.cur-size-all-mem-tables")),
 		memstat.FormatBytes(sum("rocksdb.estimate-table-readers-mem")),
 		memstat.FormatBytes(cacheUsage),
 		memstat.FormatBytes(cachePinned),
-		sum("rocksdb.num-files-at-level0"),
+		sumL0(),
 	)
 }
 

--- a/client/ethrex/dbs_cgo.go
+++ b/client/ethrex/dbs_cgo.go
@@ -23,13 +23,15 @@ import (
 const bulkBackgroundJobs = 8
 
 // defaultStateCFLevelBaseMiB is max_bytes_for_level_base for the four state
-// CFs, in MiB: 2 GiB, matching besu and nethermind. At this value RocksDB
-// still runs SOME size-scored L0 compaction during import (one pass per
-// ~2 GiB of L0), which keeps Close()'s final CompactRange cheap; the
-// defer-everything alternative (set the env below to something huge, e.g.
-// 1048576 = 1 TiB) reaches the ~2.3× write-amplification floor but moves
-// the entire flattening cost into Close. The 40 GB bench ladder decides
-// which ships as the default; both numbers are recorded in the PR.
+// CFs, in MiB: 2 GiB, matching besu and nethermind.
+//
+// Ladder-measured (40 GB target, 96-core host, seed 42, identical roots):
+// RocksDB's 256 MB default wrote 314 GiB physical in 20.8 min; 2 GiB wrote
+// 298 GiB in 15.8 min; the defer-everything variant (1 TiB) wrote the least
+// (272 GiB) but took 19.5 min — its deferred flattening lands in Close as a
+// serial ~400-input merge per state CF. 2 GiB wins on wall by keeping cheap
+// incremental L0 passes overlapped with import while Close stays ~35 s/CF.
+// STATE_ACTOR_ETHREX_LEVELBASE_MIB overrides for experiments.
 const defaultStateCFLevelBaseMiB = 2048
 
 // ethrexStateCFLevelBaseBytes resolves the state-CF level-base, honoring

--- a/client/ethrex/dbs_cgo.go
+++ b/client/ethrex/dbs_cgo.go
@@ -20,7 +20,53 @@ const bulkBackgroundJobs = 8
 
 // ethrexBlockCacheBytes is the shared LRU block cache, mirroring ethrex's
 // crates/storage/backend/rocksdb.rs (4 GiB, shared across all CFs).
+//
+// Paired with cache_index_and_filter_blocks (set per-CF below), this is also
+// the ceiling for index and bloom-filter blocks. That pairing is the point:
+// RocksDB's default pre-loads them into each table reader instead, outside
+// every budget and unevictable for as long as the SST stays open. At the
+// scale this writer targets — billions of keys across the four big state CFs,
+// with 10-bit filters and 131-byte storage_flatkeyvalue keys — that is several
+// GiB of RAM that grows monotonically with every SST written, and it is one
+// of the terms that OOM-killed a 350 GB ethrex run mid-import.
 const ethrexBlockCacheBytes = 4 * 1024 * 1024 * 1024
+
+// ethrexDBWriteBufferBytes caps TOTAL memtable memory across all CFs.
+//
+// The per-CF write buffers below mirror ethrex, but they are per-CF ceilings
+// that RocksDB does not sum: the four big state CFs alone would permit
+// 512 MiB x 6 = 12 GiB resident. db_write_buffer_size bounds the sum, flushing
+// the largest memtable when the budget is exceeded. Keeping the per-CF shape
+// intact matters — it governs flushed SST sizes, and Close()'s CompactRange
+// rewrites with the same per-CF options either way.
+const ethrexDBWriteBufferBytes = 4 * 1024 * 1024 * 1024
+
+// ethrexMaxOpenFiles is a backstop on RocksDB's table cache, deliberately set
+// where it cannot bind. With L0 compaction triggers pinned to MaxInt32 (below)
+// SSTs accumulate for the whole import — a 700 GB DB at ~512 MiB per flushed
+// file is ~1400 of them, and the db_write_buffer_size cap can only shrink
+// files, not enlarge them. Sizing this an order of magnitude above that keeps
+// residual per-table-reader overhead bounded (a handle plus footer metadata,
+// once cache_index_and_filter_blocks moves the expensive part into the cache)
+// without risking reopen churn during Close()'s CompactRange, which needs
+// every input file open at once. RLIMIT_NOFILE is not the constraint: CI
+// raises it to the kernel max before the container starts.
+const ethrexMaxOpenFiles = 32768
+
+// ethrexAuxOffHeapBytes is an ESTIMATE (not a bound) of the off-heap RAM this
+// writer commits beyond the two budgets above: the batchSink WriteBatches
+// (six in Phase 2; up to 8 workers x 2 in Phase 0, each flushing at 64 MiB),
+// the Pebble streamsort store's two 256 MiB memtable arenas, and RocksDB's
+// compaction/iterator scratch.
+const ethrexAuxOffHeapBytes = 2 * 1024 * 1024 * 1024
+
+// ethrexOffHeapReserveBytes is the total RAM this writer commits OUTSIDE the
+// Go heap. runImpl subtracts it from the host's memory ceiling before deriving
+// GOMEMLIMIT, so the Go runtime budgets against what is actually left rather
+// than against memory RocksDB and Pebble have already claimed.
+const ethrexOffHeapReserveBytes = ethrexBlockCacheBytes +
+	ethrexDBWriteBufferBytes +
+	ethrexAuxOffHeapBytes
 
 // ethrexCompressibleCF reports whether a CF uses LZ4 in the real ethrex client.
 // Mirrors `compressible_tables` in ethrex rocksdb.rs: only block-metadata CFs
@@ -142,6 +188,12 @@ func openEthrexDB(dbPath string) (*ethrexDB, error) {
 
 		bbto := grocksdb.NewDefaultBlockBasedTableOptions()
 		bbto.SetBlockCache(cache)
+		// Route index + filter blocks through the shared cache instead of
+		// pre-loading them into per-SST table readers. This is a read-path
+		// memory-placement option only: it changes nothing about the bytes
+		// written, and nothing is read during bulk import, so eviction costs
+		// nothing here. See ethrexBlockCacheBytes for why it is load-bearing.
+		bbto.SetCacheIndexAndFilterBlocks(true)
 
 		switch i {
 		case cfIdxHeaders, cfIdxBodies:
@@ -194,6 +246,12 @@ func openEthrexDB(dbPath string) (*ethrexDB, error) {
 	dbOpts := grocksdb.NewDefaultOptions()
 	dbOpts.SetCreateIfMissing(true)
 	dbOpts.SetCreateIfMissingColumnFamilies(true)
+	// Memory ceilings. Neither affects the produced SSTs — db_write_buffer_size
+	// changes how often memtables flush (and Close()'s CompactRange rewrites
+	// the result at target_file_size_base regardless), max_open_files only
+	// governs the table cache.
+	dbOpts.SetDbWriteBufferSize(ethrexDBWriteBufferBytes)
+	dbOpts.SetMaxOpenFiles(ethrexMaxOpenFiles)
 
 	parallelism := runtime.NumCPU()
 	if parallelism > bulkBackgroundJobs {

--- a/client/ethrex/dbs_cgo.go
+++ b/client/ethrex/dbs_cgo.go
@@ -39,19 +39,20 @@ const ethrexBlockCacheBytes = 512 * 1024 * 1024
 
 // ethrexDBWriteBufferBytes caps TOTAL memtable memory across all CFs.
 //
-// The per-CF write buffers below mirror ethrex, but they are per-CF ceilings
-// that RocksDB does not sum: the four big state CFs alone would permit
-// 512 MiB x 6 = 12 GiB resident. db_write_buffer_size bounds the sum, flushing
-// the largest memtable when the budget is exceeded. Keeping the per-CF shape
-// intact matters — it governs flushed SST sizes, and Close()'s CompactRange
-// rewrites with the same per-CF options either way.
+// The four state CFs are sized at 256 MiB × 4 (see the state-CF case), which
+// sums to exactly this cap — in the steady state the per-CF sizes are the
+// operative flush trigger and this is the backstop for the long tail of
+// smaller CFs pushing the total over. RocksDB does not sum per-CF ceilings on
+// its own; without this cap the previous 512 MiB × 6 shape permitted 12 GiB
+// resident. Flush cadence is process-runtime only — Close()'s CompactRange
+// rewrites the result at target_file_size_base either way.
 const ethrexDBWriteBufferBytes = 4 * 1024 * 1024 * 1024
 
 // ethrexMaxOpenFiles is a backstop on RocksDB's table cache, deliberately set
 // where it cannot bind. With L0 compaction triggers pinned to MaxInt32 (below)
-// SSTs accumulate for the whole import — a 700 GB DB at ~512 MiB per flushed
-// file is ~1400 of them, and the db_write_buffer_size cap can only shrink
-// files, not enlarge them. Sizing this an order of magnitude above that keeps
+// SSTs accumulate for the whole import — a 700 GB DB at ~256 MiB per flushed
+// file is ~2800 of them, and the db_write_buffer_size cap can only shrink
+// files, not enlarge them. Sizing this more than 10× above that keeps
 // residual per-table-reader overhead bounded (a handle plus footer metadata,
 // once cache_index_and_filter_blocks moves the expensive part into the cache)
 // without risking reopen churn during Close()'s CompactRange, which needs
@@ -145,14 +146,17 @@ type ethrexDB struct {
 // leave genesis block keys and trie rows inconsistent, making ethrex silently
 // boot off partial state.
 //
-// Per-CF options (compression, block size, bloom filters, write buffers, blob
-// files, shared 4 GiB block cache) mirror the real ethrex client's
-// crates/storage/backend/rocksdb.rs exactly, so a state-actor-produced DB is
-// byte-representative for benchmarking. The only deliberate deviation is the
-// L0 compaction triggers: ethrex uses 4/20/36, state-actor maxes them to avoid
-// compaction stalls during bulk import — Close() runs CompactRange afterward,
-// which rewrites every SST with these same compression/block/bloom options, so
-// the final on-disk shape matches ethrex regardless.
+// Per-CF options that shape the final bytes (compression, block size, bloom
+// filters, blob files, target_file_size_base) mirror the real ethrex client's
+// crates/storage/backend/rocksdb.rs, so a state-actor-produced DB is
+// byte-representative for benchmarking. Deliberate deviations are all
+// process-runtime knobs that cannot change the compacted output: L0
+// compaction triggers (ethrex 4/20/36, maxed here to avoid stalls during
+// bulk import), state-CF memtables (256 MiB × 4 vs ethrex's 512 MiB × 6 —
+// see the state-CF case), and the block cache (512 MiB vs ethrex's 4 GiB —
+// see ethrexBlockCacheBytes). Close() runs CompactRange afterward, rewriting
+// every SST with the same compression/block/bloom options, so the final
+// on-disk shape matches ethrex regardless.
 func openEthrexDB(dbPath string) (*ethrexDB, error) {
 	// Fresh-dir precondition: a missing or EMPTY directory is fine (callers and
 	// tests routinely `mkdir -p` the datadir first, and t.TempDir() pre-creates
@@ -232,11 +236,23 @@ func openEthrexDB(dbPath string) (*ethrexDB, error) {
 			bbto.SetFilterPolicy(grocksdb.NewBloomFilterFull(10))
 		case cfIdxAccountTrieNodes, cfIdxStorageTrieNodes,
 			cfIdxAccountFlatKeyValue, cfIdxStorageFlatKeyValue:
-			opts.SetWriteBufferSize(512 << 20)
-			opts.SetMaxWriteBufferNumber(6)
-			opts.SetMinWriteBufferNumberToMerge(2)
+			// 256 MiB × 4, matching the besu and nethermind writers — the two
+			// grocksdb bulk paths proven at multi-hundred-GB scale. ethrex's
+			// runtime figure is 512 MiB × 6 with min-merge 2, but memtable
+			// shape is a process-runtime knob: it cannot change a byte of the
+			// compacted output (Close() rewrites at target_file_size_base),
+			// and mirroring it summed to a 12 GiB ceiling across these four
+			// CFs. The per-CF sum now equals ethrexDBWriteBufferBytes, making
+			// the global cap a true backstop instead of the operative flush
+			// trigger. No SetMinWriteBufferNumberToMerge: no peer writer sets
+			// it, and waiting on a second immutable memtable only raised
+			// resident bytes and flush granularity. No memtable prefix bloom:
+			// RocksDB allocates one only under a prefix extractor or
+			// whole-key filtering (memtable.cc), neither configured here —
+			// the previous SetMemTablePrefixBloomSizeRatio(0.2) was inert.
+			opts.SetWriteBufferSize(256 << 20)
+			opts.SetMaxWriteBufferNumber(4)
 			opts.SetTargetFileSizeBase(256 << 20)
-			opts.SetMemTablePrefixBloomSizeRatio(0.2)
 			bbto.SetBlockSize(16 << 10)
 			bbto.SetFilterPolicy(grocksdb.NewBloomFilterFull(10))
 		case cfIdxAccountCodes:

--- a/client/ethrex/dbs_cgo.go
+++ b/client/ethrex/dbs_cgo.go
@@ -87,10 +87,12 @@ const ethrexDBWriteBufferBytes = 4 * 1024 * 1024 * 1024
 const ethrexMaxOpenFiles = 32768
 
 // ethrexAuxOffHeapBytes is an ESTIMATE (not a bound) of the off-heap RAM this
-// writer commits beyond the two budgets above: the batchSink WriteBatches
-// (six in Phase 2; up to 8 workers x 2 in Phase 0, each flushing at 64 MiB),
-// the Pebble streamsort store's two 256 MiB memtable arenas, and RocksDB's
-// compaction/iterator scratch.
+// writer commits beyond the two budgets above: the four shared batchSinks
+// (account trie/flat + code/meta, ~2×64 MiB retained C buffer each), the
+// per-worker storage sink pairs (Phase 0 and Stage B, 16 MiB threshold →
+// ~2×32 MiB retained each; ≤1 GiB at the 16-worker default — see
+// workerFlushThresholdBytes), the Pebble streamsort store's two 256 MiB
+// memtable arenas, and RocksDB's compaction/iterator scratch.
 const ethrexAuxOffHeapBytes = 2 * 1024 * 1024 * 1024
 
 // ethrexAllocatorSlackBytes covers allocator memory no component reports:

--- a/client/ethrex/dbs_cgo.go
+++ b/client/ethrex/dbs_cgo.go
@@ -22,6 +22,29 @@ import (
 // during bulk import.
 const bulkBackgroundJobs = 8
 
+// defaultStateCFLevelBaseMiB is max_bytes_for_level_base for the four state
+// CFs, in MiB: 2 GiB, matching besu and nethermind. At this value RocksDB
+// still runs SOME size-scored L0 compaction during import (one pass per
+// ~2 GiB of L0), which keeps Close()'s final CompactRange cheap; the
+// defer-everything alternative (set the env below to something huge, e.g.
+// 1048576 = 1 TiB) reaches the ~2.3× write-amplification floor but moves
+// the entire flattening cost into Close. The 40 GB bench ladder decides
+// which ships as the default; both numbers are recorded in the PR.
+const defaultStateCFLevelBaseMiB = 2048
+
+// ethrexStateCFLevelBaseBytes resolves the state-CF level-base, honoring
+// the STATE_ACTOR_ETHREX_LEVELBASE_MIB env override (benchmarking knob,
+// same pattern as erigon's STATE_ACTOR_ERIGON_WORKERS).
+func ethrexStateCFLevelBaseBytes() uint64 {
+	if v := os.Getenv("STATE_ACTOR_ETHREX_LEVELBASE_MIB"); v != "" {
+		if mib, err := strconv.ParseUint(v, 10, 64); err == nil && mib > 0 {
+			return mib << 20
+		}
+		log.Printf("ethrex: ignoring invalid STATE_ACTOR_ETHREX_LEVELBASE_MIB=%q", v)
+	}
+	return defaultStateCFLevelBaseMiB << 20
+}
+
 // ethrexBlockCacheBytes is the shared LRU block cache across all CFs.
 //
 // ethrex's own crates/storage/backend/rocksdb.rs uses 4 GiB. This writer uses
@@ -261,6 +284,18 @@ func openEthrexDB(dbPath string) (*ethrexDB, error) {
 			opts.SetWriteBufferSize(256 << 20)
 			opts.SetMaxWriteBufferNumber(4)
 			opts.SetTargetFileSizeBase(256 << 20)
+			// Without this, RocksDB's DEFAULT max_bytes_for_level_base
+			// (256 MB) silently defeats the MaxInt32 L0 triggers above:
+			// ComputeCompactionScore takes max(count-score, L0-size /
+			// max_bytes_for_level_base), so L0 compacted CONTINUOUSLY
+			// through the whole import — measured at 5-7× write
+			// amplification (~1.4-2 TB physically written for a 273 GB
+			// DB) before this was set. besu and nethermind both set
+			// 2 GiB (client/besu/dbs_cgo.go, client/nethermind/
+			// dbs_cgo.go); ethrex was the outlier. The value is
+			// env-tunable for benchmarking the defer-everything-to-Close
+			// variant — see ethrexStateCFLevelBaseBytes.
+			opts.SetMaxBytesForLevelBase(ethrexStateCFLevelBaseBytes())
 			bbto.SetBlockSize(16 << 10)
 			bbto.SetFilterPolicy(grocksdb.NewBloomFilterFull(10))
 		case cfIdxAccountCodes:

--- a/client/ethrex/doc.go
+++ b/client/ethrex/doc.go
@@ -55,9 +55,9 @@
 //     cache_index_and_filter_blocks also bounds index + bloom-filter blocks.
 //     Left at RocksDB's default those blocks sit in per-SST table readers,
 //     outside every budget, growing with each SST for the whole import.
-//   - ethrexDBWriteBufferBytes — total memtable memory. The per-CF write
-//     buffers mirror ethrex and are per-CF ceilings RocksDB does not sum; the
-//     four big state CFs alone would otherwise permit 12 GiB resident.
+//   - ethrexDBWriteBufferBytes — total memtable memory, now a backstop: the
+//     state CFs' 256 MiB × 4 sum to exactly this cap. (The previous mirrored
+//     512 MiB × 6 shape permitted 12 GiB resident, unsummed by RocksDB.)
 //   - ethrexAuxOffHeapBytes — WriteBatches, Pebble arenas, compaction scratch.
 //
 // runImpl subtracts that reserve from the host's memory ceiling (cgroup, then
@@ -68,7 +68,8 @@
 // writer starts, so it governs Phases 0-2 but not main.go's --spec parse, which
 // is where that bytecode is first allocated.
 //
-// None of these knobs change the bytes written: they govern where memory lives
-// while the writer runs, and Close()'s CompactRange rewrites every state CF
-// with the per-CF compression/block/bloom options regardless.
+// None of these knobs change the logical database: KV content and state root
+// are identical regardless (physical SST packing varies with flush cadence),
+// because Close()'s CompactRange rewrites every state CF with the per-CF
+// compression/block/bloom options either way.
 package ethrex

--- a/client/ethrex/doc.go
+++ b/client/ethrex/doc.go
@@ -47,4 +47,28 @@
 // internal/ethrex.Builder is a streaming stack-trie — O(keyLen) RAM regardless of
 // leaf count. PreAlloc storage streams through internal/streamingtrie in Phase 0;
 // Phase 2 storage stays materialized and is bounded by construction.
+//
+// Peak RSS is mostly NOT the Go heap. The off-heap terms are budgeted by the
+// constants in dbs_cgo.go and summed as ethrexOffHeapReserveBytes:
+//
+//   - ethrexBlockCacheBytes — the shared LRU cache, which with
+//     cache_index_and_filter_blocks also bounds index + bloom-filter blocks.
+//     Left at RocksDB's default those blocks sit in per-SST table readers,
+//     outside every budget, growing with each SST for the whole import.
+//   - ethrexDBWriteBufferBytes — total memtable memory. The per-CF write
+//     buffers mirror ethrex and are per-CF ceilings RocksDB does not sum; the
+//     four big state CFs alone would otherwise permit 12 GiB resident.
+//   - ethrexAuxOffHeapBytes — WriteBatches, Pebble arenas, compaction scratch.
+//
+// runImpl subtracts that reserve from the host's memory ceiling (cgroup, then
+// /proc/meminfo) and gives the remainder to internal/memlimit, which caps the
+// Go heap. Without it, GOGC=100 lets the heap reach ~2x a live set that a
+// bytecode-heavy --spec can push into the GiB range, since per-address code is
+// materialized for the whole run rather than streamed. The limit lands when the
+// writer starts, so it governs Phases 0-2 but not main.go's --spec parse, which
+// is where that bytecode is first allocated.
+//
+// None of these knobs change the bytes written: they govern where memory lives
+// while the writer runs, and Close()'s CompactRange rewrites every state CF
+// with the per-CF compression/block/bloom options regardless.
 package ethrex

--- a/client/ethrex/doc.go
+++ b/client/ethrex/doc.go
@@ -59,6 +59,8 @@
 //     state CFs' 256 MiB × 4 sum to exactly this cap. (The previous mirrored
 //     512 MiB × 6 shape permitted 12 GiB resident, unsummed by RocksDB.)
 //   - ethrexAuxOffHeapBytes — WriteBatches, Pebble arenas, compaction scratch.
+//   - ethrexAllocatorSlackBytes — jemalloc overhead over the C heap, sized
+//     from the 40 GB A/B's measured off-heap plateau (see its comment).
 //
 // runImpl subtracts that reserve from the host's memory ceiling (cgroup, then
 // /proc/meminfo) and gives the remainder to internal/memlimit, which caps the

--- a/client/ethrex/memsampler_cgo.go
+++ b/client/ethrex/memsampler_cgo.go
@@ -1,0 +1,61 @@
+//go:build cgo_ethrex
+
+package ethrex
+
+import (
+	"context"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/ethereum/state-actor/internal/memstat"
+)
+
+// memSampleInterval is how often the writer reports its memory split.
+//
+// Chosen against the failure it exists to diagnose: a 350 GB fill runs for
+// hours and dies without warning, so the last line before the kill has to be
+// recent enough to be the cause rather than ancient history. At this cadence a
+// two-hour run adds ~240 lines — noise a CI log absorbs, and the only record
+// that survives a SIGKILL, which by definition cannot be caught or logged.
+const memSampleInterval = 30 * time.Second
+
+// startMemorySampler logs the process memory split every memSampleInterval
+// until the returned stop function is called.
+//
+// The two halves of each report answer different questions. memstat gives RSS
+// (what the OOM killer measures) against the Go runtime's own total, and their
+// difference is memory no Go-side knob governs. db.memoryReport then attributes
+// that difference to RocksDB's own accounting. Anything left over after both is
+// neither Go nor RocksDB — Pebble arenas, or something unaccounted.
+//
+// The caller MUST invoke stop before closing db: the sampler reads DB
+// properties, and grocksdb offers no guard against a closed handle. Deferring
+// stop after the db.Close defer gives the required LIFO ordering.
+func startMemorySampler(ctx context.Context, db *ethrexDB) func() {
+	sampleCtx, cancel := context.WithCancel(ctx)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		ticker := time.NewTicker(memSampleInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-sampleCtx.Done():
+				return
+			case <-ticker.C:
+				log.Printf("  ethrex: mem %s · %s", memstat.Read(), db.memoryReport())
+			}
+		}
+	}()
+
+	return func() {
+		cancel()
+		wg.Wait()
+	}
+}

--- a/client/ethrex/node_sink_cgo.go
+++ b/client/ethrex/node_sink_cgo.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"container/heap"
 	"fmt"
-	"sort"
+	"slices"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -237,8 +237,8 @@ func collectNonZeroSlots(ent entity) []storageSlotKV {
 	if len(kvs) == 0 {
 		return nil
 	}
-	sort.Slice(kvs, func(i, j int) bool {
-		return bytes.Compare(kvs[i].slotHash[:], kvs[j].slotHash[:]) < 0
+	slices.SortFunc(kvs, func(a, b storageSlotKV) int {
+		return bytes.Compare(a.slotHash[:], b.slotHash[:])
 	})
 	return kvs
 }
@@ -261,9 +261,13 @@ func buildStorageTrieBuffered(
 	prefixedSink := ethrexinternal.PrefixedSink(addrHash, captureSink)
 	sb := ethrexinternal.NewBuilder(prefixedSink)
 
+	// Reused nibble buffer: AddLeaf copies its key and never retains the
+	// argument (NodeSink borrow contract), so one 64-byte scratch replaces a
+	// per-slot BytesToNibbles allocation.
+	var nibScratch [64]byte
 	for _, e := range kvs {
 		enc := ethrexinternal.EncodeStorageValue(e.value)
-		if addErr := sb.AddLeaf(ethrexinternal.BytesToNibbles(e.slotHash[:]), enc); addErr != nil {
+		if addErr := sb.AddLeaf(ethrexinternal.AppendNibbles(nibScratch[:0], e.slotHash[:]), enc); addErr != nil {
 			return nil, emptyTrieHash, 0, 0, fmt.Errorf("ethrex: storage leaf: %w", addErr)
 		}
 		storageSlotsCreated++
@@ -301,9 +305,10 @@ func buildStorageTrieInline(
 	prefixedSink := ethrexinternal.PrefixedSink(addrHash, inlineSink)
 	sb := ethrexinternal.NewBuilder(prefixedSink)
 
+	var nibScratch [64]byte
 	for _, e := range kvs {
 		enc := ethrexinternal.EncodeStorageValue(e.value)
-		if addErr := sb.AddLeaf(ethrexinternal.BytesToNibbles(e.slotHash[:]), enc); addErr != nil {
+		if addErr := sb.AddLeaf(ethrexinternal.AppendNibbles(nibScratch[:0], e.slotHash[:]), enc); addErr != nil {
 			return emptyTrieHash, 0, 0, fmt.Errorf("ethrex: storage leaf: %w", addErr)
 		}
 		storageSlotsCreated++

--- a/client/ethrex/node_sink_cgo.go
+++ b/client/ethrex/node_sink_cgo.go
@@ -222,13 +222,16 @@ func collectNonZeroSlots(ent entity) []storageSlotKV {
 		return nil
 	}
 	kvs := make([]storageSlotKV, 0, len(ent.slots))
-	for slotKey, slotVal := range ent.slots {
-		if slotVal.IsZero() {
+	var zero common.Hash
+	for _, s := range ent.slots {
+		if s.Value == zero {
 			continue
 		}
+		v := new(uint256.Int)
+		v.SetBytes32(s.Value[:])
 		kvs = append(kvs, storageSlotKV{
-			slotHash: crypto.Keccak256Hash(slotKey[:]),
-			value:    slotVal.Clone(),
+			slotHash: crypto.Keccak256Hash(s.Key[:]),
+			value:    v,
 		})
 	}
 	if len(kvs) == 0 {

--- a/client/ethrex/node_sink_cgo.go
+++ b/client/ethrex/node_sink_cgo.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/holiman/uint256"
 	"github.com/linxGnu/grocksdb"
 
 	ethrexinternal "github.com/ethereum/state-actor/internal/ethrex"
@@ -208,10 +207,11 @@ func isLeafFullPathHelper(path []byte) bool {
 }
 
 // storageSlotKV is a (slotHash, value) pair used when sorting slots for the
-// storage trie build.
+// storage trie build. value stays the raw 32 bytes end-to-end — the encoders
+// trim it directly (EncodeStorageValueBytes32); no integer types involved.
 type storageSlotKV struct {
 	slotHash common.Hash
-	value    *uint256.Int
+	value    common.Hash
 }
 
 // collectNonZeroSlots builds a sorted []storageSlotKV from ent.slots, skipping
@@ -227,11 +227,9 @@ func collectNonZeroSlots(ent entity) []storageSlotKV {
 		if s.Value == zero {
 			continue
 		}
-		v := new(uint256.Int)
-		v.SetBytes32(s.Value[:])
 		kvs = append(kvs, storageSlotKV{
 			slotHash: crypto.Keccak256Hash(s.Key[:]),
-			value:    v,
+			value:    s.Value,
 		})
 	}
 	if len(kvs) == 0 {
@@ -266,7 +264,7 @@ func buildStorageTrieBuffered(
 	// per-slot BytesToNibbles allocation.
 	var nibScratch [64]byte
 	for _, e := range kvs {
-		enc := ethrexinternal.EncodeStorageValue(e.value)
+		enc := ethrexinternal.EncodeStorageValueBytes32(e.value)
 		if addErr := sb.AddLeaf(ethrexinternal.AppendNibbles(nibScratch[:0], e.slotHash[:]), enc); addErr != nil {
 			return nil, emptyTrieHash, 0, 0, fmt.Errorf("ethrex: storage leaf: %w", addErr)
 		}
@@ -307,7 +305,7 @@ func buildStorageTrieInline(
 
 	var nibScratch [64]byte
 	for _, e := range kvs {
-		enc := ethrexinternal.EncodeStorageValue(e.value)
+		enc := ethrexinternal.EncodeStorageValueBytes32(e.value)
 		if addErr := sb.AddLeaf(ethrexinternal.AppendNibbles(nibScratch[:0], e.slotHash[:]), enc); addErr != nil {
 			return emptyTrieHash, 0, 0, fmt.Errorf("ethrex: storage leaf: %w", addErr)
 		}

--- a/client/ethrex/node_sink_cgo.go
+++ b/client/ethrex/node_sink_cgo.go
@@ -15,23 +15,38 @@ import (
 	ethrexinternal "github.com/ethereum/state-actor/internal/ethrex"
 )
 
-// flushThresholdBytes is the WriteBatch flush threshold during bulk import.
+// flushThresholdBytes is the WriteBatch flush threshold for the long-lived
+// shared sinks during bulk import.
 const flushThresholdBytes = 64 * 1024 * 1024
+
+// workerFlushThresholdBytes is the smaller threshold for PER-WORKER sinks
+// (Phase 0 and Stage B): a cleared WriteBatch retains its high-water C++
+// buffer for the sink's lifetime, so N workers × 2 sinks × ~2× threshold is
+// resident C heap — 16 MiB keeps 16 workers under ~1 GiB where 64 MiB would
+// be ~4 GiB.
+const workerFlushThresholdBytes = 16 * 1024 * 1024
 
 // batchSink wraps a grocksdb.WriteBatch targeting a specific CF and a shared
 // flush mechanism. It is used for the trie-node CFs (account_trie_nodes and
 // storage_trie_nodes) where NodeSink callbacks write (path, value) pairs.
 type batchSink struct {
-	db    *ethrexDB
-	cfIdx int
-	batch *grocksdb.WriteBatch
-	bytes int
+	db        *ethrexDB
+	cfIdx     int
+	batch     *grocksdb.WriteBatch
+	bytes     int
+	threshold int
 }
 
 // newBatchSink constructs a batchSink for the given CF index.
 // Caller must call Close() to flush any pending writes and free the WriteBatch.
 func newBatchSink(db *ethrexDB, cfIdx int) *batchSink {
-	return &batchSink{db: db, cfIdx: cfIdx, batch: grocksdb.NewWriteBatch()}
+	return newBatchSinkWithThreshold(db, cfIdx, flushThresholdBytes)
+}
+
+// newBatchSinkWithThreshold is newBatchSink with an explicit flush threshold —
+// per-worker sinks pass workerFlushThresholdBytes.
+func newBatchSinkWithThreshold(db *ethrexDB, cfIdx, threshold int) *batchSink {
+	return &batchSink{db: db, cfIdx: cfIdx, batch: grocksdb.NewWriteBatch(), threshold: threshold}
 }
 
 // put adds a key/value to the batch and triggers a flush if the threshold
@@ -44,7 +59,7 @@ func (s *batchSink) put(key, value []byte) error {
 
 // maybeFlush flushes the WriteBatch if the byte threshold is exceeded.
 func (s *batchSink) maybeFlush() error {
-	if s.bytes < flushThresholdBytes {
+	if s.bytes < s.threshold {
 		return nil
 	}
 	return s.flushAsync()
@@ -93,43 +108,11 @@ func (s *batchSink) Close() error {
 // Parallel pipeline types (Phase 2 of writeState)
 // ---------------------------------------------------------------------------
 
-// parallelStorageSlotThreshold is the per-account slot count above which storage
-// trie building is NOT dispatched to a worker. Accounts exceeding this threshold
-// are processed inline (single-threaded) by Stage C to bound worst-case memory.
-const parallelStorageSlotThreshold = 1 << 16 // 65536 slots ≈ 64 MiB buffered
-
-// storageRow is one (path, value) pair captured from the buffering storage sink.
-// path is already address-prefixed (as PrefixedSink would emit), so Stage C can
-// apply isLeafFullPathHelper and route directly without re-prefixing.
-type storageRow struct {
-	path  []byte
-	value []byte
-}
-
-// bufferingStorageSink returns a NodeSink that appends every (path, value) pair
-// to *rows instead of writing RocksDB. The caller wraps the raw Builder sink
-// with ethrexinternal.PrefixedSink first so that the captured paths are already
-// address-prefixed.
-func bufferingStorageSink(rows *[]storageRow) ethrexinternal.NodeSink {
-	return func(path, value []byte) error {
-		p := make([]byte, len(path))
-		copy(p, path)
-		v := make([]byte, len(value))
-		copy(v, value)
-		*rows = append(*rows, storageRow{path: p, value: v})
-		return nil
-	}
-}
-
 // accountWorkItem is sent from Stage A (reader) to the worker pool (Stage B).
 type accountWorkItem struct {
 	seq      uint64
 	addrHash common.Hash
 	ent      entity
-	// bigAccount is true when len(ent.slots) > parallelStorageSlotThreshold.
-	// Workers emit an accountResult with bigAccount=true and no storageRows;
-	// Stage C builds their storage inline at their seq position.
-	bigAccount bool
 	// hasPreAllocRoot is true when preAllocStorageRoots[addrHash] exists.
 	// Workers use preAllocRoot directly — no storage trie build needed.
 	hasPreAllocRoot bool
@@ -147,20 +130,17 @@ type accountStatDelta struct {
 }
 
 // accountResult is produced by Stage B workers and sent to Stage C for
-// ordered application. Fields relevant only to big accounts are labelled.
+// ordered application. Storage rows are ALREADY WRITTEN (each worker owns a
+// pair of storage batchSinks and streams the trie build directly into them),
+// so a result carries only scalars — the reorder heap holds tiny payloads
+// regardless of how large an account's storage was.
 type accountResult struct {
-	seq      uint64
-	addrHash common.Hash
-	// bigAccount is true when storage must be built inline by Stage C.
-	bigAccount bool
-	// bigEnt holds the entity for big accounts so Stage C can build storage inline.
-	bigEnt entity
-	// storageRows holds address-prefixed (path, value) rows for normal accounts.
-	storageRows []storageRow
+	seq         uint64
+	addrHash    common.Hash
 	storageRoot common.Hash
 	codeHash    common.Hash
 	code        []byte // nil for EOAs; non-nil for contracts (used by Stage C writeCode)
-	accountRLP  []byte // empty for big accounts; Stage C recomputes after inline build
+	accountRLP  []byte
 	stats       accountStatDelta
 	// buildErr carries a storage-build error from a worker.
 	buildErr error
@@ -241,47 +221,12 @@ func collectNonZeroSlots(ent entity) []storageSlotKV {
 	return kvs
 }
 
-// buildStorageTrieBuffered builds the storage trie for ent entirely in memory,
-// returning the address-prefixed captured rows and the storage root.
-// It does NOT touch RocksDB. Used by Stage B workers.
-func buildStorageTrieBuffered(
-	addrHash common.Hash,
-	ent entity,
-	emptyTrieHash common.Hash,
-) (rows []storageRow, storageRoot common.Hash, storageSlotsCreated, storageBytes uint64, err error) {
-	kvs := collectNonZeroSlots(ent)
-	if kvs == nil {
-		return nil, emptyTrieHash, 0, 0, nil
-	}
-
-	var capturedRows []storageRow
-	captureSink := bufferingStorageSink(&capturedRows)
-	prefixedSink := ethrexinternal.PrefixedSink(addrHash, captureSink)
-	sb := ethrexinternal.NewBuilder(prefixedSink)
-
-	// Reused nibble buffer: AddLeaf copies its key and never retains the
-	// argument (NodeSink borrow contract), so one 64-byte scratch replaces a
-	// per-slot BytesToNibbles allocation.
-	var nibScratch [64]byte
-	for _, e := range kvs {
-		enc := ethrexinternal.EncodeStorageValueBytes32(e.value)
-		if addErr := sb.AddLeaf(ethrexinternal.AppendNibbles(nibScratch[:0], e.slotHash[:]), enc); addErr != nil {
-			return nil, emptyTrieHash, 0, 0, fmt.Errorf("ethrex: storage leaf: %w", addErr)
-		}
-		storageSlotsCreated++
-		storageBytes += uint64(len(enc))
-	}
-
-	root, rootErr := sb.Root()
-	if rootErr != nil {
-		return nil, emptyTrieHash, 0, 0, fmt.Errorf("ethrex: storage root: %w", rootErr)
-	}
-	return capturedRows, root, storageSlotsCreated, storageBytes, nil
-}
-
-// buildStorageTrieInline builds the storage trie for ent and writes rows
-// directly to storageSink / storageFkvSink (no buffering). Used by Stage C for
-// big accounts.
+// buildStorageTrieInline builds the storage trie for ent, streaming every row
+// directly into storageSink / storageFkvSink — no per-account buffering, so
+// account size does not drive memory. Stage B workers call it with their own
+// per-worker sink pair (the same pattern Phase 0 has always used for these
+// two CFs); write order across accounts is therefore arbitrary, which the
+// memtable path is indifferent to.
 func buildStorageTrieInline(
 	addrHash common.Hash,
 	ent entity,

--- a/client/ethrex/phase0_cgo.go
+++ b/client/ethrex/phase0_cgo.go
@@ -97,8 +97,8 @@ func runPhase0Storage(
 			// Each worker owns its own write batches targeting the two storage CFs.
 			// Per-worker batches avoid contention and keep each worker's writes
 			// isolated to its assigned addrHash-prefixed keyspace.
-			workerTrieSink := newBatchSink(db, cfIdxStorageTrieNodes)
-			workerFkvSink := newBatchSink(db, cfIdxStorageFlatKeyValue)
+			workerTrieSink := newBatchSinkWithThreshold(db, cfIdxStorageTrieNodes, workerFlushThresholdBytes)
+			workerFkvSink := newBatchSinkWithThreshold(db, cfIdxStorageFlatKeyValue, workerFlushThresholdBytes)
 			defer func() {
 				// Close both sinks, but report only the first failure: cancelDrain
 				// keeps the first cause, so capture it explicitly rather than letting

--- a/client/ethrex/phase0_cgo.go
+++ b/client/ethrex/phase0_cgo.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/holiman/uint256"
 
 	"github.com/ethereum/state-actor/generator"
 	ethrexinternal "github.com/ethereum/state-actor/internal/ethrex"
@@ -146,9 +145,10 @@ func runPhase0Storage(
 				var localBytes uint64
 				statSink := func(_, _, value common.Hash) error {
 					slotW.Slot()
-					enc := ethrexinternal.EncodeStorageValue(new(uint256.Int).SetBytes32(value[:]))
+					// Length arithmetic only — the previous full encode (with a
+					// uint256 conversion) existed solely to measure len(enc).
 					localSlots++
-					localBytes += uint64(len(enc))
+					localBytes += uint64(ethrexinternal.StorageValueRLPLength(value))
 					return nil
 				}
 

--- a/client/ethrex/run_cgo.go
+++ b/client/ethrex/run_cgo.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -13,6 +14,7 @@ import (
 	"github.com/ethereum/state-actor/generator"
 	"github.com/ethereum/state-actor/genesis"
 	"github.com/ethereum/state-actor/internal/genesisheader"
+	"github.com/ethereum/state-actor/internal/memlimit"
 )
 
 // runImpl is the cgo_ethrex orchestrator.
@@ -37,6 +39,14 @@ func runImpl(ctx context.Context, cfg generator.Config, opts Options) (*generato
 	if cfg.Archive {
 		return nil, errors.New("ethrex: --archive is not supported by the ethrex writer")
 	}
+
+	// Bound the Go heap against what RocksDB and Pebble have NOT already
+	// claimed. Without this the default GOGC=100 lets the heap reach ~2x the
+	// live set, and a spec that pins several GiB of PreAlloc bytecode for the
+	// whole run makes that doubling large enough to matter. An explicit
+	// GOMEMLIMIT wins; a declined limit is logged rather than swallowed,
+	// because it means this host gets no protection.
+	log.Printf("ethrex: %s", memlimit.Set(ethrexOffHeapReserveBytes))
 
 	g := cfg.Genesis
 	if g == nil {

--- a/client/ethrex/run_cgo.go
+++ b/client/ethrex/run_cgo.go
@@ -48,6 +48,14 @@ func runImpl(ctx context.Context, cfg generator.Config, opts Options) (*generato
 	// because it means this host gets no protection.
 	log.Printf("ethrex: %s", memlimit.Set(ethrexOffHeapReserveBytes))
 
+	// Disk expectation up front: --target-size budgets the trie+code CFs
+	// only (the cross-client sizecal contract); ethrex's flat-KV layer is
+	// additional and the realized datadir lands at ≈1.8× the target
+	// (measured 40 GB→73 GiB, 150 GB→273 GiB; docs/CALIBRATION.md).
+	if cfg.TargetSize > 0 {
+		log.Printf("ethrex: expect ≈1.8× --target-size on disk (flat-KV layer is additional; see docs/CALIBRATION.md)")
+	}
+
 	g := cfg.Genesis
 	if g == nil {
 		// Fork hardcoded to ethrex's MaxForkForClient ("osaka"). Only reached

--- a/client/ethrex/run_cgo.go
+++ b/client/ethrex/run_cgo.go
@@ -76,6 +76,12 @@ func runImpl(ctx context.Context, cfg generator.Config, opts Options) (*generato
 	}
 	defer db.Close()
 
+	// Ordering matters: defers run LIFO, so this stops the sampler BEFORE
+	// db.Close() runs — it reads DB properties and grocksdb does not guard
+	// against a closed handle.
+	stopMemorySampler := startMemorySampler(ctx, db)
+	defer stopMemorySampler()
+
 	accountSink := newBatchSink(db, cfIdxAccountTrieNodes)
 	defer accountSink.Close()
 	storageSink := newBatchSink(db, cfIdxStorageTrieNodes)

--- a/client/ethrex/run_cgo.go
+++ b/client/ethrex/run_cgo.go
@@ -92,15 +92,11 @@ func runImpl(ctx context.Context, cfg generator.Config, opts Options) (*generato
 
 	accountSink := newBatchSink(db, cfIdxAccountTrieNodes)
 	defer accountSink.Close()
-	storageSink := newBatchSink(db, cfIdxStorageTrieNodes)
-	defer storageSink.Close()
 
 	// Flat-KV sinks: every leaf full-path row also lands in the flat-KV CFs so
 	// the produced DB models a synced node (see writeState + ethrex store.rs).
 	accountFkvSink := newBatchSink(db, cfIdxAccountFlatKeyValue)
 	defer accountFkvSink.Close()
-	storageFkvSink := newBatchSink(db, cfIdxStorageFlatKeyValue)
-	defer storageFkvSink.Close()
 
 	// Bytecode sinks: route account_codes + account_code_metadata through the
 	// same batched, WAL-disabled path as the trie/flat-KV writes instead of
@@ -112,7 +108,9 @@ func runImpl(ctx context.Context, cfg generator.Config, opts Options) (*generato
 	codeMetaSink := newBatchSink(db, cfIdxAccountCodeMetadata)
 	defer codeMetaSink.Close()
 
-	stateRoot, stats, err := writeState(ctx, cfg, db, accountSink, storageSink, accountFkvSink, storageFkvSink, codeSink, codeMetaSink)
+	// Storage CFs get no shared sinks: Phase 0 and Stage B write them through
+	// per-worker batchSinks (writeState's pipeline doc has the ordering story).
+	stateRoot, stats, err := writeState(ctx, cfg, db, accountSink, accountFkvSink, codeSink, codeMetaSink)
 	if err != nil {
 		return nil, fmt.Errorf("ethrex: writeState: %w", err)
 	}

--- a/client/ethrex/state_writer_cgo.go
+++ b/client/ethrex/state_writer_cgo.go
@@ -33,9 +33,12 @@ import (
 //     Stage B (N workers): compute storage trie in memory for normal accounts.
 //     Stage C (writer): apply results in strict seq order — always addrHash-sorted.
 //
-// RAM bound: internal/ethrex.Builder accumulates all leaves in memory. This
-// is correct for the e2e fixture and moderate --target-size. See doc.go for
-// the ceiling note.
+// RAM bound: internal/ethrex.Builder is streaming — O(keyLen), independent of
+// leaf count (see its doc comment). The Go-heap terms that DO scale with the
+// run are seenCodeHash below (one entry per distinct code hash) and the
+// in-flight pipeline (~5x numWorkers accountResults, each holding one
+// account's buffered storage rows). Everything else lives off-heap in RocksDB
+// and Pebble; see doc.go's "Memory" section for the whole budget.
 //
 // Flat-KV / snap-sync layout: leaf full-path rows are routed ONLY to the
 // flat-KV CFs (never duplicated into the trie-node CFs), modelling a snap-synced

--- a/client/ethrex/state_writer_cgo.go
+++ b/client/ethrex/state_writer_cgo.go
@@ -8,9 +8,12 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"log"
 	mrand "math/rand"
+	"os"
 	"runtime"
 	"slices"
+	"strconv"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -23,15 +26,38 @@ import (
 	"github.com/ethereum/state-actor/internal/streamsort"
 )
 
-// maxPhase2Workers caps the Stage-B pool, mirroring maxPhase0Workers and the
-// cap every peer writer uses (besu, nethermind, geth; erigon adopted it "to
-// match the proven cap from reth, besu, and nethermind"). The bound is
-// memory, not CPU: in-flight work is ≈5×N accounts (workCh 2N + workers N +
-// resultCh 2N), each holding up to parallelStorageSlotThreshold buffered
-// storage rows ≈ 64 MiB of LIVE Go heap — memory a GOMEMLIMIT cannot shed,
-// only stall the collector against. Uncapped runtime.NumCPU() made that
-// ceiling scale with whatever host the image happened to land on.
-const maxPhase2Workers = 8
+// defaultMaxPhase2Workers caps the Stage-B pool at min(NumCPU, 16).
+//
+// The old justification for 8 — each in-flight account held up to ~64 MiB of
+// buffered storage rows — died with the buffering: workers now stream rows
+// straight into their own batchSink pair, so a result is scalars and the
+// per-worker memory term is the sink batches (2 × ~2×workerFlushThresholdBytes
+// ≈ 64 MiB C heap per worker, ≤1 GiB at 16). 16 rather than NumCPU because
+// Stage C (account trie + code writes, strictly sequential) and RocksDB's
+// 8 background jobs bound the useful parallelism; measurement showed 96
+// workers only ~17% faster than 8 under the OLD buffered design — the ladder
+// re-measures under this one. Overridable for experiments, erigon-style.
+const defaultMaxPhase2Workers = 16
+
+// phase2Workers resolves the Stage-B pool size, honoring the
+// STATE_ACTOR_ETHREX_WORKERS env override (same pattern as erigon's
+// STATE_ACTOR_ERIGON_WORKERS: "to exploit many-core hosts").
+func phase2Workers() int {
+	if v := os.Getenv("STATE_ACTOR_ETHREX_WORKERS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+		log.Printf("ethrex: ignoring invalid STATE_ACTOR_ETHREX_WORKERS=%q", v)
+	}
+	n := runtime.NumCPU()
+	if n > defaultMaxPhase2Workers {
+		n = defaultMaxPhase2Workers
+	}
+	if n < 1 {
+		n = 1
+	}
+	return n
+}
 
 // writeState builds the full ethrex state from cfg and writes it to db.
 // Returns the state root hash and stats.
@@ -63,9 +89,7 @@ func writeState(
 	cfg generator.Config,
 	db *ethrexDB,
 	accountSink *batchSink,
-	storageSink *batchSink,
 	accountFkvSink *batchSink,
-	storageFkvSink *batchSink,
 	codeSink *batchSink,
 	codeMetaSink *batchSink,
 ) (common.Hash, *generator.Stats, error) {
@@ -229,28 +253,30 @@ func writeState(
 
 	// Phase 2: 3-stage ordered parallel pipeline.
 	//
-	// Ordering guarantee: all four CF write streams (account_trie_nodes,
-	// account_flatkeyvalue, storage_trie_nodes, storage_flatkeyvalue) stay
-	// addrHash-ascending because Stage C applies every account in seq (= sorter
-	// output) order. Workers compute storage tries in memory without writing
-	// RocksDB; only Stage C writes — in strict seq order via the reorder heap.
+	// Ordering: the ACCOUNT CFs (account_trie_nodes, account_flatkeyvalue)
+	// stay addrHash-ascending — the account-trie Builder requires it, and only
+	// Stage C feeds it, in strict seq (= sorter output) order via the reorder
+	// heap. The STORAGE CFs are written by Stage-B workers through per-worker
+	// sinks in arbitrary cross-account order — exactly how Phase 0 has always
+	// written these same two CFs (per-account keyspaces are disjoint;
+	// RocksDB serialises concurrent Write internally — besu's writer
+	// documents the same). The memtable path is order-agnostic.
 	//
 	// Stage A (single reader goroutine):
 	//   sorter.Iterate yields (addrHash, entity) in addrHash-ascending order.
 	//   Each item is stamped with a monotonically increasing seq and sent to
-	//   the work channel. Accounts with >parallelStorageSlotThreshold slots are
-	//   flagged bigAccount so Stage C handles their storage inline.
+	//   the work channel.
 	//
-	// Stage B (numWorkers goroutines):
-	//   Each worker computes the storage trie entirely in memory (no RocksDB
-	//   access), producing an accountResult with buffered rows and storageRoot.
-	//   Workers do not share mutable state.
+	// Stage B (phase2Workers goroutines):
+	//   Each worker owns a (storage_trie_nodes, storage_flatkeyvalue) batchSink
+	//   pair and STREAMS the storage trie build directly into it — no
+	//   per-account buffering, so account size does not drive memory and the
+	//   old bigAccount special case is gone. Emits a scalar-only result.
 	//
-	// Stage C (single writer goroutine):
+	// Stage C (the calling goroutine):
 	//   A min-heap reorder buffer drains results in strict seq order.
-	//   Per account: (1) replay buffered storage rows into storageSink/storageFkvSink
-	//   (or build inline for big accounts); (2) dedup and write code; (3) add
-	//   account leaf to accountBuilder; (4) accumulate stats.
+	//   Per account: (1) dedup and write code; (2) add the account leaf to
+	//   accountBuilder; (3) accumulate stats.
 
 	// entitiesQueued is the exact count Put into the sorter above (synthetic
 	// EOAs/contracts + deduped genesis allocs) — the Phase-2 progress total.
@@ -263,13 +289,7 @@ func writeState(
 
 	accountBuilder := ethrexinternal.NewBuilder(accountTrieNodeSink)
 
-	numWorkers := runtime.NumCPU()
-	if numWorkers > maxPhase2Workers {
-		numWorkers = maxPhase2Workers
-	}
-	if numWorkers < 1 {
-		numWorkers = 1
-	}
+	numWorkers := phase2Workers()
 
 	// Bounded channels: cap in-flight work at 2*numWorkers so buffered storage
 	// row memory is bounded and Stage A cannot race far ahead of Stage C.
@@ -322,11 +342,6 @@ func writeState(
 				item.preAllocRoot = preRoot
 			}
 
-			// Big accounts are flagged so Stage C processes them inline.
-			if !item.hasPreAllocRoot && len(ent.slots) > parallelStorageSlotThreshold {
-				item.bigAccount = true
-			}
-
 			select {
 			case workCh <- item:
 				return nil
@@ -339,18 +354,29 @@ func writeState(
 		}
 	}()
 
-	// Stage B: worker pool — pure in-memory storage trie computation.
+	// Stage B: worker pool — streams each account's storage trie build into a
+	// per-worker sink pair (Phase 0's pattern for these same CFs).
 	var workerWg sync.WaitGroup
 	for w := 0; w < numWorkers; w++ {
 		workerWg.Add(1)
 		go func() {
 			defer workerWg.Done()
+			wTrieSink := newBatchSinkWithThreshold(db, cfIdxStorageTrieNodes, workerFlushThresholdBytes)
+			wFkvSink := newBatchSinkWithThreshold(db, cfIdxStorageFlatKeyValue, workerFlushThresholdBytes)
+			defer func() {
+				if err := wTrieSink.Close(); err != nil {
+					setErr(fmt.Errorf("ethrex: worker storage sink close: %w", err))
+				}
+				if err := wFkvSink.Close(); err != nil {
+					setErr(fmt.Errorf("ethrex: worker storage fkv sink close: %w", err))
+				}
+			}()
 			for item := range workCh {
 				if pipelineCtx.Err() != nil {
 					// Pipeline cancelled; drain workCh to unblock Stage A.
 					continue
 				}
-				res := computeAccountResult(item, emptyCodeHash, emptyTrieHash)
+				res := computeAccountResult(item, emptyCodeHash, emptyTrieHash, wTrieSink, wFkvSink)
 				select {
 				case resultCh <- res:
 				case <-pipelineCtx.Done():
@@ -368,49 +394,25 @@ func writeState(
 
 	// Stage C: single writer goroutine — strictly in-seq application.
 	// Runs on the calling goroutine after launching Stage A and B goroutines.
-	// The heap is bounded by the in-flight window in the steady state, but
-	// under seq skew — one slow sub-threshold account while later results
-	// keep arriving — it can transiently exceed it (moving a result off
-	// resultCh frees the slot for more work). Skew is bounded in practice by
-	// parallelStorageSlotThreshold routing big accounts to Stage C inline;
-	// noted deliberately rather than fixed.
+	// The heap is bounded by the in-flight window in the steady state and can
+	// transiently exceed it under seq skew (moving a result off resultCh frees
+	// the slot for more work) — but results are now scalars, so even large
+	// skew costs kilobytes, not buffered row sets.
 	reorder := newResultHeap()
 	var nextSeq uint64
 	var writerErr error
+
+	// Reused nibble scratch for the account leaf (Stage C is single-threaded;
+	// AddLeaf copies its key — NodeSink borrow contract).
+	var acctNibScratch [64]byte
 
 	applyResult := func(res *accountResult) error {
 		if res.buildErr != nil {
 			return res.buildErr
 		}
 
-		storageRoot := res.storageRoot
-
-		if res.bigAccount {
-			// Build storage inline (directly into RocksDB) at this seq position.
-			var slotCount, slotBytes uint64
-			var inlineErr error
-			storageRoot, slotCount, slotBytes, inlineErr = buildStorageTrieInline(
-				res.addrHash, res.bigEnt, emptyTrieHash, storageSink, storageFkvSink,
-			)
-			if inlineErr != nil {
-				return inlineErr
-			}
-			res.stats.StorageSlotsCreated = slotCount
-			res.stats.StorageBytes = slotBytes
-		} else {
-			// Replay buffered storage rows into RocksDB in their captured order.
-			for _, row := range res.storageRows {
-				if isLeafFullPathHelper(row.path) {
-					if err := storageFkvSink.put(row.path, row.value); err != nil {
-						return err
-					}
-				} else {
-					if err := storageSink.put(row.path, row.value); err != nil {
-						return err
-					}
-				}
-			}
-		}
+		// Storage rows were already streamed to RocksDB by the Stage-B worker;
+		// only the strictly-ordered account-side work happens here.
 
 		// Write code (dedup via seenCodeHash; Stage C owns this map).
 		if len(res.code) > 0 {
@@ -419,17 +421,10 @@ func writeState(
 			}
 		}
 
-		// Recompute accountRLP for big accounts now that storageRoot is known.
-		accountRLP := res.accountRLP
-		if res.bigAccount {
-			accountRLP = ethrexinternal.EncodeAccountState(
-				res.bigEnt.nonce, res.bigEnt.balance, storageRoot, res.codeHash,
-			)
-			res.stats.AccountBytes = uint64(len(accountRLP))
-			res.stats.IsContract = len(res.code) != 0 || storageRoot != emptyTrieHash
-		}
-
-		if err := accountBuilder.AddLeaf(ethrexinternal.BytesToNibbles(res.addrHash[:]), accountRLP); err != nil {
+		if err := accountBuilder.AddLeaf(
+			ethrexinternal.AppendNibbles(acctNibScratch[:0], res.addrHash[:]),
+			res.accountRLP,
+		); err != nil {
 			return fmt.Errorf("ethrex: account leaf: %w", err)
 		}
 
@@ -487,13 +482,7 @@ func writeState(
 	if err := accountSink.flushSync(); err != nil {
 		return common.Hash{}, nil, err
 	}
-	if err := storageSink.flushSync(); err != nil {
-		return common.Hash{}, nil, err
-	}
 	if err := accountFkvSink.flushSync(); err != nil {
-		return common.Hash{}, nil, err
-	}
-	if err := storageFkvSink.flushSync(); err != nil {
 		return common.Hash{}, nil, err
 	}
 	// Code sinks too: their defer Close() in run_cgo.go drops the flush error, so
@@ -515,36 +504,32 @@ func writeState(
 	return stateRoot, stats, nil
 }
 
-// computeAccountResult is the pure per-account computation run by Stage B workers.
-// It does not touch RocksDB or any shared state.
+// computeAccountResult is the per-account computation run by Stage B workers.
+// Storage rows stream directly into the worker's own sink pair (wTrieSink /
+// wFkvSink) during the build — the result carries only scalars.
 //
-// For bigAccount items: skips storage building, populates bigEnt so Stage C can
-// build inline. Still computes codeHash (pure, no I/O).
-// For hasPreAllocRoot items: uses the pre-computed root directly.
-func computeAccountResult(item *accountWorkItem, emptyCodeHash, emptyTrieHash common.Hash) *accountResult {
+// For hasPreAllocRoot items: uses the pre-computed root directly (Phase 0
+// already wrote that entity's storage rows).
+func computeAccountResult(
+	item *accountWorkItem,
+	emptyCodeHash, emptyTrieHash common.Hash,
+	wTrieSink, wFkvSink *batchSink,
+) *accountResult {
 	res := &accountResult{
-		seq:        item.seq,
-		addrHash:   item.addrHash,
-		bigAccount: item.bigAccount,
-	}
-
-	if item.bigAccount {
-		// Storage is built inline by Stage C. Pass the entity through.
-		res.bigEnt = item.ent
+		seq:      item.seq,
+		addrHash: item.addrHash,
 	}
 
 	storageRoot := emptyTrieHash
 
 	if item.hasPreAllocRoot {
 		storageRoot = item.preAllocRoot
-		// No slots to process; storageRows stays nil.
-	} else if !item.bigAccount && len(item.ent.slots) > 0 {
-		rows, root, slotCount, slotBytes, err := buildStorageTrieBuffered(item.addrHash, item.ent, emptyTrieHash)
+	} else if len(item.ent.slots) > 0 {
+		root, slotCount, slotBytes, err := buildStorageTrieInline(item.addrHash, item.ent, emptyTrieHash, wTrieSink, wFkvSink)
 		if err != nil {
 			res.buildErr = err
 			return res
 		}
-		res.storageRows = rows
 		storageRoot = root
 		res.stats.StorageSlotsCreated = slotCount
 		res.stats.StorageBytes = slotBytes
@@ -561,13 +546,12 @@ func computeAccountResult(item *accountWorkItem, emptyCodeHash, emptyTrieHash co
 	res.codeHash = codeHash
 	res.code = item.ent.code
 
-	if !item.bigAccount {
-		// Pre-compute accountRLP for normal accounts (storageRoot is final here).
-		accountRLP := ethrexinternal.EncodeAccountState(item.ent.nonce, item.ent.balance, storageRoot, codeHash)
-		res.accountRLP = accountRLP
-		res.stats.AccountBytes = uint64(len(accountRLP))
-		res.stats.IsContract = len(item.ent.code) != 0 || storageRoot != emptyTrieHash
-	}
+	// storageRoot is final here for every account, so accountRLP always
+	// pre-computes in the worker.
+	accountRLP := ethrexinternal.EncodeAccountState(item.ent.nonce, item.ent.balance, storageRoot, codeHash)
+	res.accountRLP = accountRLP
+	res.stats.AccountBytes = uint64(len(accountRLP))
+	res.stats.IsContract = len(item.ent.code) != 0 || storageRoot != emptyTrieHash
 
 	return res
 }

--- a/client/ethrex/state_writer_cgo.go
+++ b/client/ethrex/state_writer_cgo.go
@@ -73,11 +73,12 @@ func phase2Workers() int {
 //     Stage C (writer): apply results in strict seq order — always addrHash-sorted.
 //
 // RAM bound: internal/ethrex.Builder is streaming — O(keyLen), independent of
-// leaf count (see its doc comment). The Go-heap terms that DO scale with the
-// run are seenCodeHash below (one entry per distinct code hash) and the
-// in-flight pipeline (~5x numWorkers accountResults, each holding one
-// account's buffered storage rows). Everything else lives off-heap in RocksDB
-// and Pebble; see doc.go's "Memory" section for the whole budget.
+// leaf count (see its doc comment). Storage rows stream from Stage-B workers
+// straight into per-worker sinks (no per-account buffering), so the Go-heap
+// terms that scale with the run are seenCodeHash (one entry per distinct
+// REAL contract code) and the scalar in-flight pipeline (~5×numWorkers tiny
+// results). Everything else lives off-heap in RocksDB and Pebble; see
+// doc.go's "Memory" section for the whole budget.
 //
 // Flat-KV / snap-sync layout: leaf full-path rows are routed ONLY to the
 // flat-KV CFs (never duplicated into the trie-node CFs), modelling a snap-synced
@@ -186,16 +187,17 @@ func writeState(
 	plan := cfg.AutoFill
 	if plan != nil {
 		cfg.Progress.Stage("ethrex: phase 1/2 — generating accounts")
-		for i := 0; i < plan.NumEOAs; i++ {
-			if ctx.Err() != nil {
-				return common.Hash{}, nil, ctx.Err()
-			}
+		err := runPhase1Pipeline(ctx, cfg, sorter, plan.NumEOAs, "EOAs", func() phase1Draw {
 			acc := plan.DrawEOA(rng)
-			blob := encodeEntity(acc.StateAccount.Nonce, acc.StateAccount.Balance, acc.Code, nil)
-			if err := sorter.Put(acc.AddrHash[:], blob); err != nil {
-				return common.Hash{}, nil, err
+			return phase1Draw{
+				addrHash: acc.AddrHash,
+				nonce:    acc.StateAccount.Nonce,
+				balance:  acc.StateAccount.Balance,
+				code:     acc.Code,
 			}
-			cfg.Progress.Tick(int64(i+1), int64(plan.NumEOAs), "EOAs")
+		})
+		if err != nil {
+			return common.Hash{}, nil, err
 		}
 	}
 
@@ -235,19 +237,21 @@ func writeState(
 
 	if plan != nil {
 		cfg.Progress.Stage("ethrex: phase 1/2 — generating contracts")
-		for i := 0; i < plan.NumContracts; i++ {
-			if ctx.Err() != nil {
-				return common.Hash{}, nil, ctx.Err()
-			}
+		// contract.Storage passes through directly (entitySlot aliases
+		// entitygen.StorageSlot) — the previous per-contract map rebuild did
+		// ~750 M pointless inserts per 150 GB run on the serial draw loop.
+		err := runPhase1Pipeline(ctx, cfg, sorter, plan.NumContracts, "contracts", func() phase1Draw {
 			contract := plan.DrawContract(rng)
-			// contract.Storage passes through directly (entitySlot aliases
-			// entitygen.StorageSlot) — the previous per-contract map rebuild
-			// did ~750 M pointless inserts per 150 GB run on this serial loop.
-			blob := encodeEntity(contract.StateAccount.Nonce, contract.StateAccount.Balance, contract.Code, contract.Storage)
-			if err := sorter.Put(contract.AddrHash[:], blob); err != nil {
-				return common.Hash{}, nil, err
+			return phase1Draw{
+				addrHash: contract.AddrHash,
+				nonce:    contract.StateAccount.Nonce,
+				balance:  contract.StateAccount.Balance,
+				code:     contract.Code,
+				slots:    contract.Storage,
 			}
-			cfg.Progress.Tick(int64(i+1), int64(plan.NumContracts), "contracts")
+		})
+		if err != nil {
+			return common.Hash{}, nil, err
 		}
 	}
 
@@ -502,6 +506,134 @@ func writeState(
 
 	stats.TotalBytes = stats.AccountBytes + stats.StorageBytes + stats.CodeBytes
 	return stateRoot, stats, nil
+}
+
+// phase1Draw carries one drawn entity from the RNG goroutine to the encode
+// workers. Every referenced slice is freshly allocated by the draw, so
+// hand-off is ownership transfer, not borrowing.
+type phase1Draw struct {
+	addrHash common.Hash
+	nonce    uint64
+	balance  *uint256.Int
+	code     []byte
+	slots    []entitySlot
+}
+
+// phase1Blob is one encoded spill entry headed for the single Put goroutine.
+type phase1Blob struct {
+	addrHash common.Hash
+	blob     []byte
+}
+
+// phase1EncodeWorkers sizes the encode pool. Encoding is cheap per entity;
+// the serial ends (RNG draw, sorter.Put) bound the pipeline, so a small pool
+// suffices.
+const phase1EncodeWorkers = 8
+
+// runPhase1Pipeline drives count draws through encode workers into the
+// sorter. The DRAW stays on the calling goroutine — the RNG sequence is the
+// cross-client invariance contract (erigon's writer documents the same
+// split: "the RNG draw stays single-threaded on the main goroutine for
+// cross-client invariance; only the CPU-bound encode is parallelised").
+// sorter.Put runs on exactly one goroutine (streamsort is single-writer);
+// Put ORDER is irrelevant — keys are unique addrHashes and streamsort sorts.
+func runPhase1Pipeline(
+	ctx context.Context,
+	cfg generator.Config,
+	sorter *streamsort.Store,
+	count int,
+	tickLabel string,
+	draw func() phase1Draw,
+) error {
+	workers := phase1EncodeWorkers
+	if n := runtime.NumCPU(); n < workers {
+		workers = n
+	}
+	if workers < 1 {
+		workers = 1
+	}
+
+	p1Ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var firstErr error
+	var errMu sync.Mutex
+	setErr := func(e error) {
+		errMu.Lock()
+		if firstErr == nil {
+			firstErr = e
+			cancel()
+		}
+		errMu.Unlock()
+	}
+
+	drawCh := make(chan phase1Draw, 4*workers)
+	blobCh := make(chan phase1Blob, 4*workers)
+
+	var encWg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		encWg.Add(1)
+		go func() {
+			defer encWg.Done()
+			for d := range drawCh {
+				if p1Ctx.Err() != nil {
+					continue // drain to unblock the draw goroutine
+				}
+				b := phase1Blob{
+					addrHash: d.addrHash,
+					blob:     encodeEntity(d.nonce, d.balance, d.code, d.slots),
+				}
+				select {
+				case blobCh <- b:
+				case <-p1Ctx.Done():
+				}
+			}
+		}()
+	}
+	go func() {
+		encWg.Wait()
+		close(blobCh)
+	}()
+
+	var putWg sync.WaitGroup
+	putWg.Add(1)
+	go func() {
+		defer putWg.Done()
+		var done int64
+		for b := range blobCh {
+			if p1Ctx.Err() != nil {
+				continue // drain
+			}
+			if err := sorter.Put(b.addrHash[:], b.blob); err != nil {
+				setErr(err)
+				continue
+			}
+			done++
+			cfg.Progress.Tick(done, int64(count), tickLabel)
+		}
+	}()
+
+	// The draw loop: sequential, on this goroutine, in index order.
+	for i := 0; i < count; i++ {
+		if p1Ctx.Err() != nil {
+			break
+		}
+		d := draw()
+		select {
+		case drawCh <- d:
+		case <-p1Ctx.Done():
+		}
+	}
+	close(drawCh)
+	putWg.Wait()
+
+	errMu.Lock()
+	err := firstErr
+	errMu.Unlock()
+	if err != nil {
+		return err
+	}
+	return ctx.Err()
 }
 
 // computeAccountResult is the per-account computation run by Stage B workers.

--- a/client/ethrex/state_writer_cgo.go
+++ b/client/ethrex/state_writer_cgo.go
@@ -71,17 +71,30 @@ func writeState(
 	emptyCodeHash := common.HexToHash(ethrexinternal.EmptyCodeHashHex)
 	emptyTrieHash := common.HexToHash(ethrexinternal.EmptyTrieHashHex)
 
-	// seenCodeHash deduplicates account_codes + account_code_metadata writes.
-	// Owned exclusively by Stage C.
+	// seenCodeHash deduplicates account_codes + account_code_metadata writes
+	// for REAL contract code only (≈ plan.NumContracts entries). Owned
+	// exclusively by Stage C.
+	//
+	// EIP-7702 delegation designators are deliberately NOT deduplicated:
+	// 30% of autofill EOAs carry one with a unique random target
+	// (internal/autofill/eoa_flavor.go), so tracking them grew this map to
+	// ~57 M entries ≈ 2.4-4.9 GiB — the dominant Go-heap term of a large
+	// run. A duplicate put of an identical (hash → code) pair is idempotent
+	// (same key, same value; RocksDB last-write-wins and compaction
+	// collapses it), so dedup buys nothing there but the map itself.
 	seenCodeHash := make(map[common.Hash]struct{})
 
 	// writeCode writes code for a given codeHash if not already seen.
 	// Always writes even for empty code (ethrex stores the empty-code entry).
 	writeCode := func(codeHash common.Hash, code []byte) error {
-		if _, seen := seenCodeHash[codeHash]; seen {
-			return nil
+		isDelegation := len(code) == 23 &&
+			code[0] == 0xEF && code[1] == 0x01 && code[2] == 0x00
+		if !isDelegation {
+			if _, seen := seenCodeHash[codeHash]; seen {
+				return nil
+			}
+			seenCodeHash[codeHash] = struct{}{}
 		}
-		seenCodeHash[codeHash] = struct{}{}
 		encoded := ethrexinternal.EncodeCode(code)
 		if err := codeSink.put(codeHash[:], encoded); err != nil {
 			return fmt.Errorf("ethrex: put account_codes: %w", err)

--- a/client/ethrex/state_writer_cgo.go
+++ b/client/ethrex/state_writer_cgo.go
@@ -619,7 +619,7 @@ type entity struct {
 func encodeEntity(nonce uint64, balance *uint256.Int, code []byte, slots []entitySlot) []byte {
 	if len(code) == 0 && len(slots) == 0 {
 		// EOA path.
-		balBytes := balance.ToBig().Bytes()
+		balBytes := balance.Bytes()
 		out := make([]byte, 1+8+1+len(balBytes))
 		out[0] = byte(entityEOA)
 		binary.BigEndian.PutUint64(out[1:9], nonce)
@@ -627,7 +627,7 @@ func encodeEntity(nonce uint64, balance *uint256.Int, code []byte, slots []entit
 		copy(out[10:], balBytes)
 		return out
 	}
-	balBytes := balance.ToBig().Bytes()
+	balBytes := balance.Bytes()
 	size := 1 + 8 + 1 + len(balBytes) + 4 + len(code) + 4 + len(slots)*64
 	out := make([]byte, 0, size)
 	out = append(out, byte(entityContract))

--- a/client/ethrex/state_writer_cgo.go
+++ b/client/ethrex/state_writer_cgo.go
@@ -3,12 +3,14 @@
 package ethrex
 
 import (
+	"bytes"
 	"container/heap"
 	"context"
 	"encoding/binary"
 	"fmt"
 	mrand "math/rand"
 	"runtime"
+	"slices"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -16,6 +18,7 @@ import (
 	"github.com/holiman/uint256"
 
 	"github.com/ethereum/state-actor/generator"
+	"github.com/ethereum/state-actor/internal/entitygen"
 	ethrexinternal "github.com/ethereum/state-actor/internal/ethrex"
 	"github.com/ethereum/state-actor/internal/streamsort"
 )
@@ -187,8 +190,20 @@ func writeState(
 			balance = uint256.NewInt(0)
 		}
 		code := cfg.GenesisCode[addr]
-		storage := cfg.GenesisStorage[addr]
-		blob := encodeEntity(acc.Nonce, balance, code, storage)
+		var slots []entitySlot
+		if storage := cfg.GenesisStorage[addr]; len(storage) > 0 {
+			slots = make([]entitySlot, 0, len(storage))
+			for k, v := range storage {
+				slots = append(slots, entitySlot{Key: k, Value: v})
+			}
+			// Sort by raw key for deterministic blob bytes (map iteration
+			// is random). Downstream order is irrelevant — Stage B re-sorts
+			// by keccak — this is spill reproducibility only.
+			slices.SortFunc(slots, func(a, b entitySlot) int {
+				return bytes.Compare(a.Key[:], b.Key[:])
+			})
+		}
+		blob := encodeEntity(acc.Nonce, balance, code, slots)
 		if err := sorter.Put(addrHash[:], blob); err != nil {
 			return common.Hash{}, nil, err
 		}
@@ -201,11 +216,10 @@ func writeState(
 				return common.Hash{}, nil, ctx.Err()
 			}
 			contract := plan.DrawContract(rng)
-			slotMap := make(map[common.Hash]common.Hash, len(contract.Storage))
-			for _, s := range contract.Storage {
-				slotMap[s.Key] = s.Value
-			}
-			blob := encodeEntity(contract.StateAccount.Nonce, contract.StateAccount.Balance, contract.Code, slotMap)
+			// contract.Storage passes through directly (entitySlot aliases
+			// entitygen.StorageSlot) — the previous per-contract map rebuild
+			// did ~750 M pointless inserts per 150 GB run on this serial loop.
+			blob := encodeEntity(contract.StateAccount.Nonce, contract.StateAccount.Balance, contract.Code, contract.Storage)
 			if err := sorter.Put(contract.AddrHash[:], blob); err != nil {
 				return common.Hash{}, nil, err
 			}
@@ -569,14 +583,26 @@ const (
 	entityContract entityKind = 2
 )
 
+// entitySlot is one raw (key, value) storage pair. Aliased to
+// entitygen.StorageSlot so autofill contract storage passes through with no
+// conversion. Deliberately pointer-free (geth's entityBlobSlot precedent,
+// client/geth/entity_blob.go): a []entitySlot backing array is one GC-opaque
+// block, where the previous map[common.Hash]*uint256.Int made every one of
+// ~750 M slots an independently traced heap object and every entity a
+// build-map → random-order-encode → rebuild-map round trip.
+type entitySlot = entitygen.StorageSlot
+
 type entity struct {
 	kind    entityKind
 	nonce   uint64
 	balance *uint256.Int
 	code    []byte
-	// slots maps raw storage key (common.Hash) → value (uint256).
-	// Populated from GenesisStorage[addr] and AutoFill contract storage.
-	slots map[common.Hash]*uint256.Int
+	// slots holds raw (key, value) pairs in blob order. Zero values are
+	// filtered by collectNonZeroSlots; order is irrelevant downstream
+	// (Stage B re-sorts by keccak(slotKey)). Keys are unique by
+	// construction: spec storage comes from a map, autofill keys are
+	// 32-byte RNG draws.
+	slots []entitySlot
 }
 
 // encodeEntity serialises an entity to the streamsort blob.
@@ -590,7 +616,7 @@ type entity struct {
 //	[0x02] [nonce u64 BE] [balance_len u8] [balance bytes]
 //	[code_len u32 BE] [code bytes]
 //	[slot_count u32 BE] [slot_count × (32B key, 32B value)]
-func encodeEntity(nonce uint64, balance *uint256.Int, code []byte, slots map[common.Hash]common.Hash) []byte {
+func encodeEntity(nonce uint64, balance *uint256.Int, code []byte, slots []entitySlot) []byte {
 	if len(code) == 0 && len(slots) == 0 {
 		// EOA path.
 		balBytes := balance.ToBig().Bytes()
@@ -617,9 +643,9 @@ func encodeEntity(nonce uint64, balance *uint256.Int, code []byte, slots map[com
 	var slotCountBuf [4]byte
 	binary.BigEndian.PutUint32(slotCountBuf[:], uint32(len(slots)))
 	out = append(out, slotCountBuf[:]...)
-	for k, v := range slots {
-		out = append(out, k[:]...)
-		out = append(out, v[:]...)
+	for _, s := range slots {
+		out = append(out, s.Key[:]...)
+		out = append(out, s.Value[:]...)
 	}
 	return out
 }
@@ -681,19 +707,15 @@ func decodeEntity(blob []byte) (entity, error) {
 		}
 		slotCount := int(binary.BigEndian.Uint32(blob[pos : pos+4]))
 		pos += 4
-		e.slots = make(map[common.Hash]*uint256.Int, slotCount)
+		e.slots = make([]entitySlot, slotCount)
 		for i := 0; i < slotCount; i++ {
 			if err := need(pos, 64); err != nil {
 				return entity{}, err
 			}
-			var k, v common.Hash
-			copy(k[:], blob[pos:pos+32])
+			copy(e.slots[i].Key[:], blob[pos:pos+32])
 			pos += 32
-			copy(v[:], blob[pos:pos+32])
+			copy(e.slots[i].Value[:], blob[pos:pos+32])
 			pos += 32
-			u := new(uint256.Int)
-			u.SetBytes32(v[:])
-			e.slots[k] = u
 		}
 	}
 	return e, nil

--- a/client/ethrex/state_writer_cgo.go
+++ b/client/ethrex/state_writer_cgo.go
@@ -125,7 +125,17 @@ func writeState(
 	}
 
 	// Phase 1: queue all entities into a streamsort keyed by addrHash.
-	sorter, err := streamsort.New("")
+	//
+	// Spill under the datadir, not os.TempDir(): the spill is ~0.4× the
+	// target size (~130 GB for a 350 GB run), and "" would put it wherever
+	// /tmp points — tmpfs (i.e. RAM) on some hosts, container storage under
+	// docker/podman — invisible either way. The datadir volume is the one
+	// disk a state-actor run is guaranteed to have sized for the job. Same
+	// choice as this writer's own Phase 0 (streamingtrie.StorageRoot gets
+	// cfg.DBPath), reth, and erigon — erigon's comment documents the tmpfs
+	// hazard explicitly. Store.Close removes the spill dir before the DB
+	// handle closes, so the shipped datadir stays clean.
+	sorter, err := streamsort.New(cfg.DBPath)
 	if err != nil {
 		return common.Hash{}, nil, fmt.Errorf("ethrex: streamsort.New: %w", err)
 	}

--- a/client/ethrex/state_writer_cgo.go
+++ b/client/ethrex/state_writer_cgo.go
@@ -530,6 +530,13 @@ type phase1Blob struct {
 // suffices.
 const phase1EncodeWorkers = 8
 
+// phase1BatchSize is the hand-off granularity between the pipeline stages.
+// Per-ENTITY channel ops measured as a regression on the EOA phase (1:31 →
+// 3:10 at 40 GB): at ~525k draws/s the ~1-2 µs of contended send+recv per
+// entity doubles the loop. Batching amortises it ~256× (one slice per op);
+// the ladder's re-run confirmed the EOA phase back at draw-bound speed.
+const phase1BatchSize = 256
+
 // runPhase1Pipeline drives count draws through encode workers into the
 // sorter. The DRAW stays on the calling goroutine — the RNG sequence is the
 // cross-client invariance contract (erigon's writer documents the same
@@ -567,24 +574,27 @@ func runPhase1Pipeline(
 		errMu.Unlock()
 	}
 
-	drawCh := make(chan phase1Draw, 4*workers)
-	blobCh := make(chan phase1Blob, 4*workers)
+	drawCh := make(chan []phase1Draw, 2*workers)
+	blobCh := make(chan []phase1Blob, 2*workers)
 
 	var encWg sync.WaitGroup
 	for w := 0; w < workers; w++ {
 		encWg.Add(1)
 		go func() {
 			defer encWg.Done()
-			for d := range drawCh {
+			for batch := range drawCh {
 				if p1Ctx.Err() != nil {
 					continue // drain to unblock the draw goroutine
 				}
-				b := phase1Blob{
-					addrHash: d.addrHash,
-					blob:     encodeEntity(d.nonce, d.balance, d.code, d.slots),
+				out := make([]phase1Blob, len(batch))
+				for i, d := range batch {
+					out[i] = phase1Blob{
+						addrHash: d.addrHash,
+						blob:     encodeEntity(d.nonce, d.balance, d.code, d.slots),
+					}
 				}
 				select {
-				case blobCh <- b:
+				case blobCh <- out:
 				case <-p1Ctx.Done():
 				}
 			}
@@ -600,27 +610,39 @@ func runPhase1Pipeline(
 	go func() {
 		defer putWg.Done()
 		var done int64
-		for b := range blobCh {
+		for batch := range blobCh {
 			if p1Ctx.Err() != nil {
 				continue // drain
 			}
-			if err := sorter.Put(b.addrHash[:], b.blob); err != nil {
-				setErr(err)
-				continue
+			for _, b := range batch {
+				if err := sorter.Put(b.addrHash[:], b.blob); err != nil {
+					setErr(err)
+					break
+				}
+				done++
+				cfg.Progress.Tick(done, int64(count), tickLabel)
 			}
-			done++
-			cfg.Progress.Tick(done, int64(count), tickLabel)
 		}
 	}()
 
 	// The draw loop: sequential, on this goroutine, in index order.
+	batch := make([]phase1Draw, 0, phase1BatchSize)
 	for i := 0; i < count; i++ {
 		if p1Ctx.Err() != nil {
 			break
 		}
-		d := draw()
+		batch = append(batch, draw())
+		if len(batch) == phase1BatchSize {
+			select {
+			case drawCh <- batch:
+			case <-p1Ctx.Done():
+			}
+			batch = make([]phase1Draw, 0, phase1BatchSize)
+		}
+	}
+	if len(batch) > 0 && p1Ctx.Err() == nil {
 		select {
-		case drawCh <- d:
+		case drawCh <- batch:
 		case <-p1Ctx.Done():
 		}
 	}

--- a/client/ethrex/state_writer_cgo.go
+++ b/client/ethrex/state_writer_cgo.go
@@ -20,6 +20,16 @@ import (
 	"github.com/ethereum/state-actor/internal/streamsort"
 )
 
+// maxPhase2Workers caps the Stage-B pool, mirroring maxPhase0Workers and the
+// cap every peer writer uses (besu, nethermind, geth; erigon adopted it "to
+// match the proven cap from reth, besu, and nethermind"). The bound is
+// memory, not CPU: in-flight work is ≈5×N accounts (workCh 2N + workers N +
+// resultCh 2N), each holding up to parallelStorageSlotThreshold buffered
+// storage rows ≈ 64 MiB of LIVE Go heap — memory a GOMEMLIMIT cannot shed,
+// only stall the collector against. Uncapped runtime.NumCPU() made that
+// ceiling scale with whatever host the image happened to land on.
+const maxPhase2Workers = 8
+
 // writeState builds the full ethrex state from cfg and writes it to db.
 // Returns the state root hash and stats.
 //
@@ -217,6 +227,9 @@ func writeState(
 	accountBuilder := ethrexinternal.NewBuilder(accountTrieNodeSink)
 
 	numWorkers := runtime.NumCPU()
+	if numWorkers > maxPhase2Workers {
+		numWorkers = maxPhase2Workers
+	}
 	if numWorkers < 1 {
 		numWorkers = 1
 	}
@@ -318,6 +331,12 @@ func writeState(
 
 	// Stage C: single writer goroutine — strictly in-seq application.
 	// Runs on the calling goroutine after launching Stage A and B goroutines.
+	// The heap is bounded by the in-flight window in the steady state, but
+	// under seq skew — one slow sub-threshold account while later results
+	// keep arriving — it can transiently exceed it (moving a result off
+	// resultCh frees the slot for more work). Skew is bounded in practice by
+	// parallelStorageSlotThreshold routing big accounts to Stage C inline;
+	// noted deliberately rather than fixed.
 	reorder := newResultHeap()
 	var nextSeq uint64
 	var writerErr error

--- a/docs/CALIBRATION.md
+++ b/docs/CALIBRATION.md
@@ -60,10 +60,13 @@ producing a datadir no real node ever has.
 
 - **Sort spill:** ≈0.5× target under the datadir volume (moved off `/tmp`
   deliberately), freed before `Close()`.
-- **Write amplification:** with `max_bytes_for_level_base` set (2 GiB default,
-  `STATE_ACTOR_ETHREX_LEVELBASE_MIB` to override) physical writes are ≈2-3×
-  the final size. Before that fix, RocksDB's 256 MB default silently ran L0
-  compactions all import long: 5-7× measured.
+- **Write amplification:** ladder-measured at the 40 GB target (73 GiB
+  realized; whole-device sector deltas, so spill and filesystem overhead
+  included): RocksDB's 256 MB `max_bytes_for_level_base` default wrote
+  314 GiB physical; the 2 GiB default ships because it was fastest by wall
+  (298 GiB, −24% time); the defer-everything variant wrote least (272 GiB)
+  but pays it back in a serial Close mega-compaction. Override with
+  `STATE_ACTOR_ETHREX_LEVELBASE_MIB`.
 
 Rule of thumb for provisioning an ethrex run: **free disk ≈ 2.4× the target**
 (1.82× final + ~0.5× spill co-resident at the Phase-2 peak), plus headroom for

--- a/docs/CALIBRATION.md
+++ b/docs/CALIBRATION.md
@@ -1,0 +1,76 @@
+# CALIBRATION — what `--target-size` buys per client
+
+`internal/sizecal/factors.go` has referenced this document since inception; it
+now exists. It answers the question every large run eventually asks: *why is
+the datadir bigger than my `--target-size`?*
+
+## The contract
+
+`--target-size` is converted to synthetic entity counts through ONE global
+constant, `bytesPerSlot = 140` (plus `bytesPerAccount = 175`), which budgets
+the **trie component only**. This is deliberate and load-bearing:
+
+- **The constant must be identical across clients.** Same seed + same target ⇒
+  same entity set ⇒ same genesis state root on every client — the
+  `cross-client-genesis-root` CI gate pins exactly this. A per-client
+  `bytesPerSlot` would give each client a different entity set and different
+  roots; it is forbidden by design, not an oversight.
+- Flat-state layers (Pebble snapshot, Bonsai flat, reth MDBX flat tables,
+  Nethermind flat rows, ethrex FlatKeyValue) are **additional** and
+  deliberately uncounted — they differ per client and cannot be budgeted by a
+  shared constant.
+
+So the honest number per client is the **realized/target factor** below, not a
+change to the constant.
+
+## Realized/target factors (measured, seed 42, autofill shape 20/10/70)
+
+| client | factor | provenance |
+|---|---|---|
+| ethrex | **≈1.82×** | measured: 40 GB→73 GiB, 150 GB→273 GiB (bloatnet host, 2026-08) |
+| geth | TBM | to be measured by the cross-client 40 GB comparison run |
+| besu | TBM | 〃 |
+| nethermind | TBM | 〃 |
+| reth | TBM | 〃 |
+| erigon | TBM | 〃 |
+
+TBM entries are filled by the standing measurement protocol: same host, same
+seed, `--target-size=40GB` per client, record `du -sh` of the produced datadir.
+
+## Where ethrex's 1.82× comes from (byte model, reproduces measurement to ~8%)
+
+```
+1.82× = 1.00×  trie + code CFs      ← the sizecal budget, hit almost exactly
+              (storage_trie_nodes realizes ≈132 B/slot vs the 140 budget;
+               account_trie_nodes ≈172 B/account vs 175)
+      + 0.74×  FlatKeyValue CFs     ← the budget's documented exclusion
+              (storage_flatkeyvalue ≈31% of the DB: a 131-byte raw-nibble
+               key per ~33-byte value; account_flatkeyvalue ≈10%)
+      + 0.08×  RocksDB structure    (indexes, filters, restart arrays)
+```
+
+The FlatKeyValue layer is not optional bloat: upstream ethrex generates it
+from the trie in a background task (`flatkeyvalue_generator`, store.rs) and a
+steady-state node holds **both** layers; the writer pre-completes generation
+(`misc_values["last_written"] = 0xff`) so the datadir is instantly usable.
+The generator never deletes trie rows, so nothing here can be dropped without
+producing a datadir no real node ever has.
+
+## Transient disk on top of the final size (ethrex)
+
+- **Sort spill:** ≈0.5× target under the datadir volume (moved off `/tmp`
+  deliberately), freed before `Close()`.
+- **Write amplification:** with `max_bytes_for_level_base` set (2 GiB default,
+  `STATE_ACTOR_ETHREX_LEVELBASE_MIB` to override) physical writes are ≈2-3×
+  the final size. Before that fix, RocksDB's 256 MB default silently ran L0
+  compactions all import long: 5-7× measured.
+
+Rule of thumb for provisioning an ethrex run: **free disk ≈ 2.4× the target**
+(1.82× final + ~0.5× spill co-resident at the Phase-2 peak), plus headroom for
+the Close-time compaction transient.
+
+## Spill sizing (all clients that use streamsort)
+
+Entity-blob spill ≈ accounts×~90 B + slots×64 B + full contract code bytes;
+for the standard autofill shape that lands at ≈0.5× target. besu, nethermind
+and geth currently spill to `os.TempDir()` — see issue #130.

--- a/docs/CALIBRATION.md
+++ b/docs/CALIBRATION.md
@@ -25,17 +25,19 @@ change to the constant.
 
 ## Realized/target factors (measured, seed 42, autofill shape 20/10/70)
 
-| client | factor | provenance |
-|---|---|---|
-| ethrex | **≈1.82×** | measured: 40 GB→73 GiB, 150 GB→273 GiB (bloatnet host, 2026-08) |
-| geth | TBM | to be measured by the cross-client 40 GB comparison run |
-| besu | TBM | 〃 |
-| nethermind | TBM | 〃 |
-| reth | TBM | 〃 |
-| erigon | TBM | 〃 |
+| client | factor | wall @40 GB | provenance |
+|---|---|---|---|
+| ethrex | **≈1.82×** (73 G) | **13.5 min** | measured 2026-08 (bloatnet host, seed 42); 150 GB→273 GiB confirms scale-invariance |
+| nethermind | ≈1.37× (55 G) | 29.8 min | same run set |
+| geth | ≈1.47× (59 G) | 31.3 min | same run set |
+| besu | ≈1.42× (57 G) | 53.0 min | same run set |
+| reth | TBM | TBM | needs the same 40 GB protocol |
+| erigon | TBM | TBM | 〃 |
 
-TBM entries are filled by the standing measurement protocol: same host, same
-seed, `--target-size=40GB` per client, record `du -sh` of the produced datadir.
+All four measured runs produced the identical genesis state root
+(0xa7bcafd7…5e11ac38) — the cross-client invariant holding on one host.
+TBM entries follow the standing protocol: same host, same seed,
+`--target-size=40GB`, record wall + `du -sh` of the produced datadir.
 
 ## Where ethrex's 1.82× comes from (byte model, reproduces measurement to ~8%)
 

--- a/internal/ethrex/account.go
+++ b/internal/ethrex/account.go
@@ -1,8 +1,6 @@
 package ethrex
 
 import (
-	"math/big"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/holiman/uint256"
 )
@@ -20,7 +18,7 @@ import (
 //	-> 0xf84d07893635c9adc5dea00000a056e81f171b...a0c5d2460186f7...
 func EncodeAccountState(nonce uint64, balance *uint256.Int, storageRoot, codeHash common.Hash) []byte {
 	encNonce := rlpEncodeUint64(nonce)
-	encBal := rlpEncodeBigInt(balance.ToBig())
+	encBal := rlpEncodeUint256(balance)
 	encStorage := rlpEncodeBytes(storageRoot[:])
 	encCode := rlpEncodeBytes(codeHash[:])
 
@@ -36,7 +34,37 @@ func EncodeAccountState(nonce uint64, balance *uint256.Int, storageRoot, codeHas
 // The value is encoded as a minimal big-endian integer (stripping leading zeros).
 // Callers must skip zero values — do not call this for v == 0.
 func EncodeStorageValue(v *uint256.Int) []byte {
-	return rlpEncodeBigInt(v.ToBig())
+	return rlpEncodeUint256(v)
+}
+
+// EncodeStorageValueBytes32 is EncodeStorageValue for a raw 32-byte value:
+// leading zeros are trimmed by subslicing — no intermediate integer types.
+// Byte-identical to EncodeStorageValue(new(uint256.Int).SetBytes32(v[:])).
+// Callers must skip zero values.
+func EncodeStorageValueBytes32(v common.Hash) []byte {
+	i := 0
+	for i < 32 && v[i] == 0 {
+		i++
+	}
+	return rlpEncodeBytes(v[i:])
+}
+
+// StorageValueRLPLength returns len(EncodeStorageValueBytes32(v)) without
+// encoding — for stat accounting that only needs the byte count.
+func StorageValueRLPLength(v common.Hash) int {
+	i := 0
+	for i < 32 && v[i] == 0 {
+		i++
+	}
+	n := 32 - i
+	switch {
+	case n == 1 && v[i] < 0x80:
+		return 1
+	case n == 0:
+		return 1 // 0x80
+	default:
+		return 1 + n // n <= 32 <= 55: single length-prefix byte
+	}
 }
 
 // rlpEncodeUint64 encodes a uint64 as an RLP integer (minimal big-endian, no leading zeros).
@@ -48,14 +76,15 @@ func rlpEncodeUint64(n uint64) []byte {
 	return rlpEncodeBytes(b)
 }
 
-// rlpEncodeBigInt encodes a *big.Int as an RLP integer (minimal big-endian).
-// Negative values and zero produce 0x80 (RLP null/zero).
-func rlpEncodeBigInt(n *big.Int) []byte {
-	if n == nil || n.Sign() <= 0 {
+// rlpEncodeUint256 encodes a *uint256.Int as an RLP integer (minimal
+// big-endian). nil and zero produce 0x80 (RLP null/zero). Byte-identical to
+// the previous big.Int round trip (uint256.Bytes() is minimal big-endian)
+// without the ToBig allocation ladder.
+func rlpEncodeUint256(n *uint256.Int) []byte {
+	if n == nil || n.IsZero() {
 		return []byte{0x80}
 	}
-	b := n.Bytes() // big-endian, no leading zeros
-	return rlpEncodeBytes(b)
+	return rlpEncodeBytes(n.Bytes())
 }
 
 // minBEBytesU64 returns the minimal big-endian encoding of a uint64.

--- a/internal/ethrex/builder.go
+++ b/internal/ethrex/builder.go
@@ -22,6 +22,12 @@ var ErrKeysOutOfOrder = errors.New("Builder: keys must be inserted in strictly a
 // pathNibbles before writing to the DB. The Builder itself is keyspace-agnostic.
 //
 // A non-nil error from NodeSink is propagated back from AddLeaf or Root.
+//
+// Borrow contract: both slices are only valid for the duration of the call —
+// the Builder reuses its internal buffers across leaves (geth StackTrie's
+// callback contract). Sinks that retain data must copy; every production sink
+// already does (batchSink copies into the C write batch on put,
+// bufferingStorageSink clones, PrefixedSink builds a fresh key).
 type NodeSink func(pathNibbles []byte, value []byte) error
 
 // Builder is a streaming Merkle-Patricia trie builder that emits ethrex trie
@@ -120,8 +126,14 @@ func (b *Builder) AddLeaf(keyNibbles []byte, value []byte) error {
 		return err
 	}
 	b.leafCount++
-	b.prevKey = append(b.prevKey[:0:0], keyNibbles...)
-	b.prevVal = append(b.prevVal[:0:0], value...)
+	// Reuse the backing arrays across leaves ([:0], NOT the previous [:0:0]
+	// which zeroed capacity and forced a fresh allocation per leaf — 2×~750 M
+	// allocations per large run). Safe because nothing retains prevKey/prevVal
+	// memory past insert(): emitLeafRows clones every emitted key, EncodeLeaf
+	// copies the value into fresh RLP, and sinks operate under the NodeSink
+	// borrow contract (see its doc).
+	b.prevKey = append(b.prevKey[:0], keyNibbles...)
+	b.prevVal = append(b.prevVal[:0], value...)
 	return nil
 }
 

--- a/internal/ethrex/nibbles.go
+++ b/internal/ethrex/nibbles.go
@@ -11,12 +11,17 @@ const (
 // BytesToNibbles unpacks each byte into two nibbles (high nibble first, low nibble second).
 // No leaf flag is appended. Example: [0x2f] -> [0x02, 0x0f].
 func BytesToNibbles(b []byte) []byte {
-	out := make([]byte, len(b)*2)
-	for i, by := range b {
-		out[i*2] = by >> 4
-		out[i*2+1] = by & 0x0f
+	return AppendNibbles(make([]byte, 0, len(b)*2), b)
+}
+
+// AppendNibbles is BytesToNibbles in append form: allocation-free when dst has
+// capacity. Callers may reuse dst across Builder.AddLeaf calls — AddLeaf copies
+// the key and does not retain the argument.
+func AppendNibbles(dst, b []byte) []byte {
+	for _, by := range b {
+		dst = append(dst, by>>4, by&0x0f)
 	}
-	return out
+	return dst
 }
 
 // CompactEncode applies the hex-prefix (compact) encoding to a nibble slice.
@@ -30,6 +35,12 @@ func BytesToNibbles(b []byte) []byte {
 //
 // After the flag byte, remaining nibble pairs are packed two-per-byte.
 func CompactEncode(nibbles []byte, isLeaf bool) []byte {
+	return appendCompact(make([]byte, 0, 1+len(nibbles)/2), nibbles, isLeaf)
+}
+
+// appendCompact is CompactEncode in append form (single source of truth for
+// the flag-byte rules above). Byte-identical output.
+func appendCompact(dst, nibbles []byte, isLeaf bool) []byte {
 	odd := len(nibbles)%2 != 0
 
 	var flagByte byte
@@ -43,13 +54,12 @@ func CompactEncode(nibbles []byte, isLeaf bool) []byte {
 		flagByte |= 0x20
 	}
 
+	dst = append(dst, flagByte)
 	rest := nibbles[start:]
-	out := make([]byte, 1+len(rest)/2)
-	out[0] = flagByte
-	for i := 0; i < len(rest)/2; i++ {
-		out[1+i] = (rest[i*2] << 4) | rest[i*2+1]
+	for i := 0; i+1 < len(rest); i += 2 {
+		dst = append(dst, (rest[i]<<4)|rest[i+1])
 	}
-	return out
+	return dst
 }
 
 // commonPrefixLen returns the number of leading nibbles that a and b share.

--- a/internal/ethrex/node_rlp.go
+++ b/internal/ethrex/node_rlp.go
@@ -1,9 +1,48 @@
 package ethrex
 
+import (
+	"sync"
+
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
 // node_rlp.go — RLP encoders for ethrex trie node types.
 //
 // All three encoders mirror ethrex crates/common/trie/rlp.rs lines 26-85.
 // The encoding is used both for DB storage and for computing NodeRef hashes.
+
+// nodeEncoder holds the per-encode scratch state: compact/payload build
+// buffers and a reused keccak hasher for child refs. Outputs of the three
+// Encode* functions are always FRESHLY allocated (rlpEncodeListRaw copies the
+// payload), so callers may retain them; only the intermediates are pooled.
+// Pooled because encoders run concurrently (Phase-0 workers + Stage-B workers
+// each drive their own Builder).
+type nodeEncoder struct {
+	compact []byte
+	payload []byte
+	out32   [32]byte
+	h       crypto.KeccakState
+}
+
+var encoderPool = sync.Pool{New: func() any {
+	return &nodeEncoder{h: crypto.NewKeccakState()}
+}}
+
+// appendChildRefOf appends the child-reference encoding of child to dst:
+// byte-identical to appendChildRef(dst, NodeRef(child)) but hashing into the
+// encoder's scratch instead of allocating a KeccakState + 32-byte digest per
+// child (geth's hasher.hashDataTo precedent).
+func (e *nodeEncoder) appendChildRefOf(dst, child []byte) []byte {
+	if len(child) < 32 {
+		// Inline: the raw bytes are already valid RLP; splice directly.
+		return append(dst, child...)
+	}
+	e.h.Reset()
+	e.h.Write(child)
+	e.h.Read(e.out32[:])
+	dst = append(dst, 0xa0)
+	return append(dst, e.out32[:]...)
+}
 
 // EncodeLeaf encodes a leaf node as a 2-item RLP list:
 //
@@ -11,11 +50,15 @@ package ethrex
 //
 // Mirrors ethrex LeafNode RLPEncode (rlp.rs:78-85).
 func EncodeLeaf(remainingPath []byte, value []byte) []byte {
-	compact := CompactEncode(remainingPath, true)
-	encPath := rlpEncodeBytes(compact)
-	encVal := rlpEncodeBytes(value)
-	payload := append(encPath, encVal...)
-	return rlpEncodeListRaw(payload)
+	e := encoderPool.Get().(*nodeEncoder)
+	e.compact = appendCompact(e.compact[:0], remainingPath, true)
+	p := e.payload[:0]
+	p = appendRLPBytes(p, e.compact)
+	p = appendRLPBytes(p, value)
+	out := rlpEncodeListRaw(p)
+	e.payload = p
+	encoderPool.Put(e)
+	return out
 }
 
 // EncodeExtension encodes an extension node as a 2-item RLP list:
@@ -26,15 +69,15 @@ func EncodeLeaf(remainingPath []byte, value []byte) []byte {
 // is embedded via the NodeRef rule (inline if < 32 bytes, hash-ref if >= 32).
 // Mirrors ethrex ExtensionNode RLPEncode (rlp.rs:70-76).
 func EncodeExtension(prefixPath []byte, childEncoded []byte) []byte {
-	compact := CompactEncode(prefixPath, false)
-	encPath := rlpEncodeBytes(compact)
-
-	ref := NodeRef(childEncoded)
-	var childRLP []byte
-	childRLP = appendChildRef(childRLP, ref)
-
-	payload := append(encPath, childRLP...)
-	return rlpEncodeListRaw(payload)
+	e := encoderPool.Get().(*nodeEncoder)
+	e.compact = appendCompact(e.compact[:0], prefixPath, false)
+	p := e.payload[:0]
+	p = appendRLPBytes(p, e.compact)
+	p = e.appendChildRefOf(p, childEncoded)
+	out := rlpEncodeListRaw(p)
+	e.payload = p
+	encoderPool.Put(e)
+	return out
 }
 
 // EncodeBranch encodes a branch node as a 17-item RLP list.
@@ -47,24 +90,52 @@ func EncodeExtension(prefixPath []byte, childEncoded []byte) []byte {
 // children[i] is the raw RLP of child i (may be nil if the slot is empty).
 // Mirrors ethrex BranchNode RLPEncode (rlp.rs:26-68).
 func EncodeBranch(children [16][]byte, value []byte) []byte {
-	var payload []byte
+	e := encoderPool.Get().(*nodeEncoder)
+	// Preallocate for the worst case (16 hashed refs + value) once; the pooled
+	// buffer retains its capacity, so steady state is zero-alloc here where the
+	// previous `var payload []byte` paid ~10 append-grow reallocs per branch.
+	p := e.payload[:0]
+	if cap(p) < 17*33+8 {
+		p = make([]byte, 0, 17*33+8)
+	}
 	for i := 0; i < 16; i++ {
 		child := children[i]
 		if len(child) == 0 {
-			payload = append(payload, 0x80)
+			p = append(p, 0x80)
 		} else {
-			ref := NodeRef(child)
-			payload = appendChildRef(payload, ref)
+			p = e.appendChildRefOf(p, child)
 		}
 	}
 	// Branch value (item 16).
-	payload = append(payload, rlpEncodeBytes(value)...)
-	return rlpEncodeListRaw(payload)
+	p = appendRLPBytes(p, value)
+	out := rlpEncodeListRaw(p)
+	e.payload = p
+	encoderPool.Put(e)
+	return out
 }
 
 // ---------------------------------------------------------------------------
 // Minimal RLP helpers (no external RLP library dependency in production code)
 // ---------------------------------------------------------------------------
+
+// appendRLPBytes is rlpEncodeBytes in append form; byte-identical output.
+func appendRLPBytes(dst, b []byte) []byte {
+	n := len(b)
+	switch {
+	case n == 1 && b[0] < 0x80:
+		return append(dst, b[0])
+	case n == 0:
+		return append(dst, 0x80)
+	case n <= 55:
+		dst = append(dst, 0x80+byte(n))
+		return append(dst, b...)
+	default:
+		lenBytes := minBEBytes(n)
+		dst = append(dst, 0xb7+byte(len(lenBytes)))
+		dst = append(dst, lenBytes...)
+		return append(dst, b...)
+	}
+}
 
 // rlpEncodeBytes encodes a byte slice as an RLP byte string.
 func rlpEncodeBytes(b []byte) []byte {

--- a/internal/memlimit/doc.go
+++ b/internal/memlimit/doc.go
@@ -11,9 +11,9 @@
 //
 // Set reads the host's real ceiling (cgroup v2, then cgroup v1, then
 // /proc/meminfo), subtracts the caller's declared off-heap reserve, and hands
-// the Go heap a heapDivisor share of the remainder (a third today — see the
-// heapDivisor comment for why not half). The rest absorbs the soft limit's
-// transient overshoot and, above all, the reserve being an underestimate.
+// the Go heap a heapDivisor share of the remainder (half — see the
+// heapDivisor comment for the history). The rest absorbs the soft limit's
+// transient overshoot and the reserve being an underestimate.
 //
 // A limit below the live heap is worse than no limit: the collector then runs
 // continuously (Go caps it at 50% of CPU) and the process crawls instead of

--- a/internal/memlimit/doc.go
+++ b/internal/memlimit/doc.go
@@ -1,0 +1,24 @@
+// Package memlimit derives and applies a Go soft memory limit
+// (runtime/debug.SetMemoryLimit) for writers whose peak RSS is a mix of Go
+// heap and off-heap cgo allocations.
+//
+// The problem: with GOGC=100 and no limit, the Go heap grows to roughly twice
+// the live set before a collection. A writer that pins several GiB of spec
+// bytecode for a whole run therefore reserves several GiB more it never
+// needs — on top of a RocksDB/Pebble footprint the Go runtime cannot see,
+// because block caches and memtable arenas are C malloc. On a memory-capped
+// host the OOM killer measures the sum.
+//
+// Set reads the host's real ceiling (cgroup v2, then cgroup v1, then
+// /proc/meminfo), subtracts the caller's declared off-heap reserve, and hands
+// the Go heap half of what is left. The other half absorbs page cache and the
+// transient overshoot a soft limit permits.
+//
+// A limit below the live heap is worse than no limit: the collector then runs
+// continuously (Go caps it at 50% of CPU) and the process crawls instead of
+// failing fast. Set declines to apply anything below minUsefulLimit and
+// reports why, rather than guessing.
+//
+// Set never overrides a limit that is already in effect, so an explicit
+// GOMEMLIMIT in the environment always wins.
+package memlimit

--- a/internal/memlimit/doc.go
+++ b/internal/memlimit/doc.go
@@ -11,8 +11,9 @@
 //
 // Set reads the host's real ceiling (cgroup v2, then cgroup v1, then
 // /proc/meminfo), subtracts the caller's declared off-heap reserve, and hands
-// the Go heap half of what is left. The other half absorbs page cache and the
-// transient overshoot a soft limit permits.
+// the Go heap a heapDivisor share of the remainder (a third today — see the
+// heapDivisor comment for why not half). The rest absorbs the soft limit's
+// transient overshoot and, above all, the reserve being an underestimate.
 //
 // A limit below the live heap is worse than no limit: the collector then runs
 // continuously (Go caps it at 50% of CPU) and the process crawls instead of

--- a/internal/memlimit/memlimit.go
+++ b/internal/memlimit/memlimit.go
@@ -1,0 +1,223 @@
+package memlimit
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"runtime/debug"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// Memory-ceiling sources, in the order detect consults them. The smallest
+// real value wins: a container under cgroup v2 sees both its own memory.max
+// and the host's MemTotal, and only the former binds it.
+const (
+	cgroupV2MaxPath = "/sys/fs/cgroup/memory.max"
+	cgroupV1MaxPath = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+	procMemInfoPath = "/proc/meminfo"
+)
+
+const (
+	// heapDivisor splits the post-reserve memory between the Go heap and
+	// everything the limit cannot govern: page cache, the writer's dirty
+	// writeback, and the overshoot a SOFT limit tolerates between the
+	// collector noticing and finishing. Half each is deliberately
+	// unaggressive — the goal is to cap a 2x GOGC blowup, not to run the
+	// heap as tight as it will go.
+	heapDivisor = 2
+
+	// minUsefulLimit is the floor below which applying a limit does more
+	// harm than not applying one. See the package doc: a limit under the
+	// live heap converts an OOM kill into an unbounded GC stall, which is
+	// strictly harder to diagnose. Below this, Set reports and declines.
+	minUsefulLimit = 2 << 30
+
+	// unlimitedSentinel is the threshold above which a cgroup limit means
+	// "no limit". cgroup v2 writes the literal "max"; cgroup v1 writes a
+	// near-uint64-max page count scaled to bytes, whose exact value varies
+	// with page size, so compare against a threshold rather than a constant.
+	unlimitedSentinel = 1 << 62
+)
+
+// Result reports what Set decided. A zero Applied with an empty Reason means
+// Set was never called.
+type Result struct {
+	// Applied is true when this call installed the limit.
+	Applied bool
+	// Limit is the Go soft memory limit in bytes. When Applied is false but
+	// a limit was already in effect, it carries that pre-existing value.
+	Limit int64
+	// Total is the detected memory ceiling in bytes; 0 when detection failed.
+	Total uint64
+	// Source names where Total came from.
+	Source string
+	// Reason explains why no limit was applied. Empty when Applied.
+	Reason string
+}
+
+// String renders a one-line summary suitable for a startup log.
+func (r Result) String() string {
+	if r.Applied {
+		return fmt.Sprintf("Go memory limit set to %s (%s reports %s)",
+			formatGiB(uint64(r.Limit)), r.Source, formatGiB(r.Total))
+	}
+	if r.Reason == "" {
+		return "no Go memory limit applied"
+	}
+	return "no Go memory limit applied: " + r.Reason
+}
+
+var (
+	setOnce   sync.Once
+	setResult Result
+)
+
+// Set installs a Go soft memory limit derived from the host's memory ceiling
+// minus reserve, the caller's expected off-heap (cgo) footprint in bytes.
+//
+// It is idempotent: the first call decides, and every later call returns that
+// same Result. Callers should log the Result — a declined limit is a signal
+// worth surfacing, not a silent no-op.
+func Set(reserve uint64) Result {
+	setOnce.Do(func() { setResult = apply(reserve) })
+
+	return setResult
+}
+
+// apply performs the one-time decision behind Set.
+func apply(reserve uint64) Result {
+	// SetMemoryLimit(-1) reads the current limit without changing it. Anything
+	// other than the default means GOMEMLIMIT was set in the environment or an
+	// earlier caller already chose — either way, defer to it.
+	if current := debug.SetMemoryLimit(-1); current != math.MaxInt64 {
+		return Result{
+			Limit:  current,
+			Reason: fmt.Sprintf("a limit of %s is already in effect", formatGiB(uint64(current))),
+		}
+	}
+
+	total, source, ok := detect()
+	if !ok {
+		return Result{Reason: "could not determine the host memory ceiling"}
+	}
+
+	limit := Budget(total, reserve)
+	if limit == 0 {
+		return Result{
+			Total:  total,
+			Source: source,
+			Reason: fmt.Sprintf(
+				"%s reports %s and %s is reserved off-heap, leaving less than the %s floor",
+				source, formatGiB(total), formatGiB(reserve), formatGiB(minUsefulLimit)),
+		}
+	}
+
+	debug.SetMemoryLimit(limit)
+
+	return Result{Applied: true, Limit: limit, Total: total, Source: source}
+}
+
+// Budget computes the Go soft memory limit for a host with total bytes of
+// usable memory and reserve bytes committed outside the Go heap. It returns 0
+// when no useful limit can be derived — see minUsefulLimit.
+//
+// The subtraction cannot overflow int64: (total-reserve) is at most MaxUint64,
+// and halving that yields exactly MaxInt64.
+func Budget(total, reserve uint64) int64 {
+	if total == 0 || reserve >= total {
+		return 0
+	}
+
+	limit := (total - reserve) / heapDivisor
+	if limit < minUsefulLimit {
+		return 0
+	}
+
+	return int64(limit)
+}
+
+// detect returns the smallest real memory ceiling among the known sources,
+// along with the name of the source that supplied it.
+func detect() (uint64, string, bool) {
+	var (
+		best   uint64
+		source string
+	)
+
+	consider := func(value uint64, ok bool, name string) {
+		if !ok || value == 0 {
+			return
+		}
+		if best == 0 || value < best {
+			best, source = value, name
+		}
+	}
+
+	if raw, err := os.ReadFile(cgroupV2MaxPath); err == nil {
+		value, ok := parseCgroupLimit(raw)
+		consider(value, ok, "cgroup v2 memory.max")
+	}
+	if raw, err := os.ReadFile(cgroupV1MaxPath); err == nil {
+		value, ok := parseCgroupLimit(raw)
+		consider(value, ok, "cgroup v1 memory.limit_in_bytes")
+	}
+	if raw, err := os.ReadFile(procMemInfoPath); err == nil {
+		value, ok := parseMemTotal(raw)
+		consider(value, ok, "/proc/meminfo MemTotal")
+	}
+
+	return best, source, best > 0
+}
+
+// parseCgroupLimit reads a cgroup memory-limit file. It reports ok=false for
+// the two spellings of "unlimited" (v2's literal "max", v1's near-uint64-max
+// sentinel) so an unbounded cgroup does not shadow a real ceiling.
+func parseCgroupLimit(raw []byte) (uint64, bool) {
+	field := strings.TrimSpace(string(raw))
+	if field == "" || field == "max" {
+		return 0, false
+	}
+
+	value, err := strconv.ParseUint(field, 10, 64)
+	if err != nil || value >= unlimitedSentinel {
+		return 0, false
+	}
+
+	return value, true
+}
+
+// parseMemTotal extracts MemTotal from /proc/meminfo content. The value is
+// reported in kB, which this converts to bytes.
+func parseMemTotal(raw []byte) (uint64, bool) {
+	for line := range strings.SplitSeq(string(raw), "\n") {
+		rest, found := strings.CutPrefix(line, "MemTotal:")
+		if !found {
+			continue
+		}
+
+		fields := strings.Fields(rest)
+		if len(fields) == 0 {
+			return 0, false
+		}
+
+		value, err := strconv.ParseUint(fields[0], 10, 64)
+		if err != nil {
+			return 0, false
+		}
+		// Guard the kB→bytes shift against a value large enough to wrap.
+		if value > math.MaxUint64>>10 {
+			return 0, false
+		}
+
+		return value << 10, true
+	}
+
+	return 0, false
+}
+
+// formatGiB renders a byte count as GiB with one decimal, for log lines.
+func formatGiB(bytes uint64) string {
+	return strconv.FormatFloat(float64(bytes)/(1<<30), 'f', 1, 64) + " GiB"
+}

--- a/internal/memlimit/memlimit.go
+++ b/internal/memlimit/memlimit.go
@@ -13,6 +13,14 @@ import (
 // Memory-ceiling sources, in the order detect consults them. The smallest
 // real value wins: a container under cgroup v2 sees both its own memory.max
 // and the host's MemTotal, and only the former binds it.
+//
+// Known limitation: the cgroup paths are root-relative. Under a private
+// cgroup namespace (docker/podman — every deployment this writer targets)
+// that IS the calling container's own limit. A nested cgroup withOUT a
+// namespace (e.g. `systemd-run -p MemoryMax=`) keeps its limit at a subtree
+// path that would need a /proc/self/cgroup walk to find; detection then
+// falls back to MemTotal, which errs toward a higher (less protective)
+// ceiling. Deliberately not handled until a real run path needs it.
 const (
 	cgroupV2MaxPath = "/sys/fs/cgroup/memory.max"
 	cgroupV1MaxPath = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
@@ -130,7 +138,7 @@ func apply(reserve uint64) Result {
 // when no useful limit can be derived — see minUsefulLimit.
 //
 // The subtraction cannot overflow int64: (total-reserve) is at most MaxUint64,
-// and halving that yields exactly MaxInt64.
+// and dividing by heapDivisor (>= 2) keeps the result at or under MaxInt64.
 func Budget(total, reserve uint64) int64 {
 	if total == 0 || reserve >= total {
 		return 0

--- a/internal/memlimit/memlimit.go
+++ b/internal/memlimit/memlimit.go
@@ -31,16 +31,18 @@ const (
 	// heapDivisor splits the post-reserve memory between the Go heap and the
 	// margin absorbing what a soft limit cannot govern.
 	//
-	// A third, not a half, and the difference is a lesson rather than a
-	// preference. The margin's real job turned out not to be page cache — a
-	// host that OOM-killed this writer showed only 15 MB of it — but the
-	// caller's reserve being WRONG. That run reserved 10 GiB off-heap against
-	// an actual ~25 GiB, so the heap was handed memory that was already spoken
-	// for. A reserve is an estimate of memory nobody measures directly; the
-	// margin has to be big enough to absorb the estimate being under.
+	// Half, now that the reserve is measured rather than guessed. The
+	// interim divisor-3 was chosen when the caller's reserve carried a
+	// 12 GiB guess for unmeasured allocator behavior — "the margin's real
+	// job is absorbing the reserve being wrong". The 40 GB A/B that gated
+	// this constant measured the jemalloc off-heap plateau (~4.4 GiB)
+	// UNDER the budgeted caps, so the reserve now over-covers observation
+	// and the margin returns to its designed job: soft-limit overshoot
+	// plus residual estimate error. TestBudgetLeavesRoomForTheReserve pins
+	// the paired invariant (limit+reserve ≤ 3/4 of the host — see there).
 	//
 	// Erring high costs GC cycles. Erring low costs the whole run, hours in.
-	heapDivisor = 3
+	heapDivisor = 2
 
 	// minUsefulLimit is the floor below which applying a limit does more
 	// harm than not applying one. See the package doc: a limit under the

--- a/internal/memlimit/memlimit.go
+++ b/internal/memlimit/memlimit.go
@@ -20,13 +20,19 @@ const (
 )
 
 const (
-	// heapDivisor splits the post-reserve memory between the Go heap and
-	// everything the limit cannot govern: page cache, the writer's dirty
-	// writeback, and the overshoot a SOFT limit tolerates between the
-	// collector noticing and finishing. Half each is deliberately
-	// unaggressive — the goal is to cap a 2x GOGC blowup, not to run the
-	// heap as tight as it will go.
-	heapDivisor = 2
+	// heapDivisor splits the post-reserve memory between the Go heap and the
+	// margin absorbing what a soft limit cannot govern.
+	//
+	// A third, not a half, and the difference is a lesson rather than a
+	// preference. The margin's real job turned out not to be page cache — a
+	// host that OOM-killed this writer showed only 15 MB of it — but the
+	// caller's reserve being WRONG. That run reserved 10 GiB off-heap against
+	// an actual ~25 GiB, so the heap was handed memory that was already spoken
+	// for. A reserve is an estimate of memory nobody measures directly; the
+	// margin has to be big enough to absorb the estimate being under.
+	//
+	// Erring high costs GC cycles. Erring low costs the whole run, hours in.
+	heapDivisor = 3
 
 	// minUsefulLimit is the floor below which applying a limit does more
 	// harm than not applying one. See the package doc: a limit under the

--- a/internal/memlimit/memlimit_test.go
+++ b/internal/memlimit/memlimit_test.go
@@ -2,6 +2,7 @@ package memlimit
 
 import (
 	"math"
+	"runtime/debug"
 	"strings"
 	"testing"
 )
@@ -222,6 +223,12 @@ func TestResultString(t *testing.T) {
 // It deliberately does not assert Applied — the test binary inherits whatever
 // GOMEMLIMIT the runner has set, and declining in that case is correct.
 func TestSetIsIdempotent(t *testing.T) {
+	// Set may install a real process-global limit (when the runner has no
+	// GOMEMLIMIT); restore whatever was in effect so the rest of this test
+	// binary does not run under a limit this test chose.
+	prev := debug.SetMemoryLimit(-1)
+	t.Cleanup(func() { debug.SetMemoryLimit(prev) })
+
 	first := Set(1 * gib)
 	second := Set(100 * gib)
 

--- a/internal/memlimit/memlimit_test.go
+++ b/internal/memlimit/memlimit_test.go
@@ -8,6 +8,10 @@ import (
 
 const gib = uint64(1) << 30
 
+// benchmarkHostBytes is MemTotal on the CI host that OOM-killed a 350 GB
+// ethrex fill (61.9 GiB), taken from that run's podman info.
+const benchmarkHostBytes = uint64(66467475456)
+
 // TestBudget pins the split arithmetic, including the two cases where Budget
 // must decline: a reserve that swallows the host, and a remainder too small
 // for a limit to help rather than stall the collector.
@@ -19,12 +23,14 @@ func TestBudget(t *testing.T) {
 		want    int64
 	}{
 		{
-			// The host that OOM-killed the ethrex 350 GB run: 61.9 GiB with
-			// the writer's 10 GiB off-heap reserve subtracted, halved.
+			// The host that OOM-killed the ethrex 350 GB run, with the
+			// writer's off-heap reserve subtracted. Expressed via heapDivisor
+			// so retuning the split does not require editing arithmetic here;
+			// TestBudgetLeavesRoomForTheReserve pins the property that matters.
 			name:    "benchmark host",
-			total:   66467475456,
-			reserve: 10 * gib,
-			want:    int64((66467475456 - 10*gib) / 2),
+			total:   benchmarkHostBytes,
+			reserve: 18*gib + 512*1024*1024,
+			want:    int64((benchmarkHostBytes - (18*gib + 512*1024*1024)) / heapDivisor),
 		},
 		{
 			name:    "reserve equals total",
@@ -46,7 +52,7 @@ func TestBudget(t *testing.T) {
 		},
 		{
 			name:    "remainder exactly at the useful floor",
-			total:   14 * gib,
+			total:   10*gib + heapDivisor*minUsefulLimit,
 			reserve: 10 * gib,
 			want:    minUsefulLimit,
 		},
@@ -57,12 +63,13 @@ func TestBudget(t *testing.T) {
 			want:    0,
 		},
 		{
-			// Halving MaxUint64 lands exactly on MaxInt64; the conversion in
-			// Budget must not wrap negative.
+			// The widest possible input: the conversion in Budget must not
+			// wrap negative. At heapDivisor 2 this lands exactly on MaxInt64,
+			// so the guard is load-bearing for any divisor below that.
 			name:    "maximum total does not overflow int64",
 			total:   math.MaxUint64,
 			reserve: 0,
-			want:    math.MaxInt64,
+			want:    int64(uint64(math.MaxUint64) / heapDivisor),
 		},
 	}
 
@@ -72,6 +79,32 @@ func TestBudget(t *testing.T) {
 				t.Errorf("Budget(%d, %d) = %d, want %d", tt.total, tt.reserve, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestBudgetLeavesRoomForTheReserve pins the invariant whose violation caused
+// a 350 GB run to be OOM-killed: the heap limit plus the caller's reserve must
+// leave real headroom under the host, so that a reserve which turns out to be
+// an underestimate still has somewhere to grow.
+//
+// The failing run handed the heap 26 GiB against a 10 GiB reserve on a 61.9
+// GiB host — 36 GiB "budgeted" — and then died at 51.3 GiB RSS because the
+// true off-heap cost was ~25 GiB, not 10. Requiring the budget to sit at or
+// under two thirds of the host keeps that class of miss survivable.
+func TestBudgetLeavesRoomForTheReserve(t *testing.T) {
+	// Reserves spanning plausible mis-estimates of the off-heap cost.
+	for _, reserve := range []uint64{4 * gib, 10 * gib, 18 * gib, 24 * gib} {
+		limit := Budget(benchmarkHostBytes, reserve)
+		if limit == 0 {
+			continue // declined; nothing is committed, so nothing to check
+		}
+
+		budgeted := uint64(limit) + reserve
+		if ceiling := benchmarkHostBytes / 3 * 2; budgeted > ceiling {
+			t.Errorf("reserve %s: budgeted %s exceeds two thirds of the %s host (%s)",
+				formatGiB(reserve), formatGiB(budgeted),
+				formatGiB(benchmarkHostBytes), formatGiB(ceiling))
+		}
 	}
 }
 

--- a/internal/memlimit/memlimit_test.go
+++ b/internal/memlimit/memlimit_test.go
@@ -25,13 +25,14 @@ func TestBudget(t *testing.T) {
 	}{
 		{
 			// The host that OOM-killed the ethrex 350 GB run, with the
-			// writer's off-heap reserve subtracted. Expressed via heapDivisor
-			// so retuning the split does not require editing arithmetic here;
-			// TestBudgetLeavesRoomForTheReserve pins the property that matters.
+			// writer's measured 8 GiB off-heap reserve subtracted. Expressed
+			// via heapDivisor so retuning the split does not require editing
+			// arithmetic here; TestBudgetLeavesRoomForTheReserve pins the
+			// property that matters.
 			name:    "benchmark host",
 			total:   benchmarkHostBytes,
-			reserve: 18*gib + 512*1024*1024,
-			want:    int64((benchmarkHostBytes - (18*gib + 512*1024*1024)) / heapDivisor),
+			reserve: 8 * gib,
+			want:    int64((benchmarkHostBytes - 8*gib) / heapDivisor),
 		},
 		{
 			name:    "reserve equals total",
@@ -91,7 +92,13 @@ func TestBudget(t *testing.T) {
 // The failing run handed the heap 26 GiB against a 10 GiB reserve on a 61.9
 // GiB host — 36 GiB "budgeted" — and then died at 51.3 GiB RSS because the
 // true off-heap cost was ~25 GiB, not 10. Requiring the budget to sit at or
-// under two thirds of the host keeps that class of miss survivable.
+// under three quarters of the host keeps that class of miss survivable.
+//
+// Ceiling policy is paired with heapDivisor: at divisor 2,
+// limit+reserve = T/2 + R/2, which stays under 3T/4 for any reserve up to
+// half the host. (The interim divisor-3 paired with a 2/3 ceiling; keeping
+// 2/3 at divisor 2 would reject reserves > T/3 that divisor 2 legitimately
+// budgets for.) Retune both together, deliberately, or not at all.
 func TestBudgetLeavesRoomForTheReserve(t *testing.T) {
 	// Reserves spanning plausible mis-estimates of the off-heap cost.
 	for _, reserve := range []uint64{4 * gib, 10 * gib, 18 * gib, 24 * gib} {
@@ -101,8 +108,8 @@ func TestBudgetLeavesRoomForTheReserve(t *testing.T) {
 		}
 
 		budgeted := uint64(limit) + reserve
-		if ceiling := benchmarkHostBytes / 3 * 2; budgeted > ceiling {
-			t.Errorf("reserve %s: budgeted %s exceeds two thirds of the %s host (%s)",
+		if ceiling := benchmarkHostBytes / 4 * 3; budgeted > ceiling {
+			t.Errorf("reserve %s: budgeted %s exceeds three quarters of the %s host (%s)",
 				formatGiB(reserve), formatGiB(budgeted),
 				formatGiB(benchmarkHostBytes), formatGiB(ceiling))
 		}

--- a/internal/memlimit/memlimit_test.go
+++ b/internal/memlimit/memlimit_test.go
@@ -1,0 +1,198 @@
+package memlimit
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+const gib = uint64(1) << 30
+
+// TestBudget pins the split arithmetic, including the two cases where Budget
+// must decline: a reserve that swallows the host, and a remainder too small
+// for a limit to help rather than stall the collector.
+func TestBudget(t *testing.T) {
+	tests := []struct {
+		name    string
+		total   uint64
+		reserve uint64
+		want    int64
+	}{
+		{
+			// The host that OOM-killed the ethrex 350 GB run: 61.9 GiB with
+			// the writer's 10 GiB off-heap reserve subtracted, halved.
+			name:    "benchmark host",
+			total:   66467475456,
+			reserve: 10 * gib,
+			want:    int64((66467475456 - 10*gib) / 2),
+		},
+		{
+			name:    "reserve equals total",
+			total:   16 * gib,
+			reserve: 16 * gib,
+			want:    0,
+		},
+		{
+			name:    "reserve exceeds total",
+			total:   8 * gib,
+			reserve: 10 * gib,
+			want:    0,
+		},
+		{
+			name:    "remainder below the useful floor",
+			total:   12 * gib,
+			reserve: 10 * gib,
+			want:    0,
+		},
+		{
+			name:    "remainder exactly at the useful floor",
+			total:   14 * gib,
+			reserve: 10 * gib,
+			want:    minUsefulLimit,
+		},
+		{
+			name:    "undetected total",
+			total:   0,
+			reserve: 10 * gib,
+			want:    0,
+		},
+		{
+			// Halving MaxUint64 lands exactly on MaxInt64; the conversion in
+			// Budget must not wrap negative.
+			name:    "maximum total does not overflow int64",
+			total:   math.MaxUint64,
+			reserve: 0,
+			want:    math.MaxInt64,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Budget(tt.total, tt.reserve); got != tt.want {
+				t.Errorf("Budget(%d, %d) = %d, want %d", tt.total, tt.reserve, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseCgroupLimit covers both spellings of "unlimited", since treating
+// either as a real ceiling would shadow the host's true MemTotal.
+func TestParseCgroupLimit(t *testing.T) {
+	tests := []struct {
+		name   string
+		raw    string
+		want   uint64
+		wantOK bool
+	}{
+		{name: "v2 byte count", raw: "8589934592\n", want: 8 * gib, wantOK: true},
+		{name: "v2 unlimited", raw: "max\n", want: 0, wantOK: false},
+		{name: "v1 unlimited sentinel", raw: "9223372036854771712\n", want: 0, wantOK: false},
+		{name: "empty", raw: "", want: 0, wantOK: false},
+		{name: "whitespace only", raw: "  \n", want: 0, wantOK: false},
+		{name: "not a number", raw: "unexpected\n", want: 0, wantOK: false},
+		{name: "negative", raw: "-1\n", want: 0, wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseCgroupLimit([]byte(tt.raw))
+			if got != tt.want || ok != tt.wantOK {
+				t.Errorf("parseCgroupLimit(%q) = (%d, %t), want (%d, %t)",
+					tt.raw, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}
+
+// TestParseMemTotal pins the kB→bytes conversion and the MemTotal line being
+// found regardless of position.
+func TestParseMemTotal(t *testing.T) {
+	// The header of the failing run's host, as /proc/meminfo renders it.
+	meminfo := "MemTotal:       64909644 kB\nMemFree:        49203620 kB\nBuffers:          123456 kB\n"
+
+	tests := []struct {
+		name   string
+		raw    string
+		want   uint64
+		wantOK bool
+	}{
+		{name: "first line", raw: meminfo, want: 64909644 << 10, wantOK: true},
+		{
+			name:   "not the first line",
+			raw:    "SwapTotal:             0 kB\nMemTotal:        1048576 kB\n",
+			want:   1 * gib,
+			wantOK: true,
+		},
+		{name: "missing", raw: "MemFree: 100 kB\n", want: 0, wantOK: false},
+		{name: "empty", raw: "", want: 0, wantOK: false},
+		{name: "no value", raw: "MemTotal:\n", want: 0, wantOK: false},
+		{name: "not a number", raw: "MemTotal:  lots kB\n", want: 0, wantOK: false},
+		{
+			name:   "value large enough to wrap the kB shift",
+			raw:    "MemTotal: 18446744073709551615 kB\n",
+			want:   0,
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseMemTotal([]byte(tt.raw))
+			if got != tt.want || ok != tt.wantOK {
+				t.Errorf("parseMemTotal(%q) = (%d, %t), want (%d, %t)",
+					tt.raw, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}
+
+// TestResultString checks that each Result shape renders a line a reader can
+// act on — an applied limit names its source, a declined one names its cause.
+func TestResultString(t *testing.T) {
+	tests := []struct {
+		name  string
+		res   Result
+		wants []string
+	}{
+		{
+			name:  "applied",
+			res:   Result{Applied: true, Limit: 26 * int64(gib), Total: 62 * gib, Source: "/proc/meminfo MemTotal"},
+			wants: []string{"26.0 GiB", "62.0 GiB", "/proc/meminfo MemTotal"},
+		},
+		{
+			name:  "declined with a reason",
+			res:   Result{Reason: "could not determine the host memory ceiling"},
+			wants: []string{"no Go memory limit applied", "could not determine"},
+		},
+		{
+			name:  "never called",
+			res:   Result{},
+			wants: []string{"no Go memory limit applied"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.res.String()
+			for _, want := range tt.wants {
+				if !strings.Contains(got, want) {
+					t.Errorf("Result.String() = %q, want it to contain %q", got, want)
+				}
+			}
+		})
+	}
+}
+
+// TestSetIsIdempotent pins the sync.Once contract: repeated calls, including
+// with a different reserve, return the first decision unchanged.
+//
+// It deliberately does not assert Applied — the test binary inherits whatever
+// GOMEMLIMIT the runner has set, and declining in that case is correct.
+func TestSetIsIdempotent(t *testing.T) {
+	first := Set(1 * gib)
+	second := Set(100 * gib)
+
+	if first != second {
+		t.Errorf("Set returned %+v then %+v; want the first decision both times", first, second)
+	}
+}

--- a/internal/memstat/memstat.go
+++ b/internal/memstat/memstat.go
@@ -34,7 +34,10 @@ const (
 // Metric names read from runtime/metrics. goTotalMetric counts every byte the
 // Go runtime has mapped from the OS — heap, stacks, and runtime structures —
 // which is the quantity GOMEMLIMIT actually bounds. goObjectsMetric is the
-// live-object subset, the floor no GC can push below.
+// live objects PLUS dead-not-yet-swept ones (per the runtime/metrics
+// definition), accumulated at size-class granularity — a sawtooth between
+// ≈live and ≈the GC goal (2×live at GOGC=100), NOT a live-set floor.
+// Reading it as live cost a debugging cycle once; divide by ~1-2×.
 const (
 	goTotalMetric   = "/memory/classes/total:bytes"
 	goObjectsMetric = "/memory/classes/heap/objects:bytes"
@@ -47,7 +50,9 @@ type Sample struct {
 	RSS uint64
 	// GoTotal is every byte the Go runtime has mapped from the OS.
 	GoTotal uint64
-	// GoObjects is the bytes held by live heap objects.
+	// GoObjects is /memory/classes/heap/objects: live objects plus dead
+	// objects not yet swept — see the goObjectsMetric comment; not a live
+	// floor.
 	GoObjects uint64
 	// HostAvailable is MemAvailable: memory the kernel believes it can hand
 	// out without swapping, host-wide.

--- a/internal/memstat/memstat.go
+++ b/internal/memstat/memstat.go
@@ -1,0 +1,211 @@
+// Package memstat reads a point-in-time picture of this process's memory:
+// the kernel's resident-set size alongside the Go runtime's own accounting.
+//
+// The two together are the diagnostic. RSS is what the OOM killer measures,
+// and the Go runtime's total is what a GOMEMLIMIT governs. A writer that
+// commits most of its memory through cgo — RocksDB block caches and
+// memtables, Pebble arenas — shows the gap between them as memory no Go-side
+// knob can influence, which is exactly the thing a heap profile cannot see.
+//
+// Sampling is deliberately cheap enough to run on a progress heartbeat:
+// readings come from runtime/metrics rather than runtime.ReadMemStats, so no
+// stop-the-world pause is incurred, and RSS is one small /proc read.
+package memstat
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"runtime/metrics"
+	"strconv"
+	"strings"
+)
+
+// Kernel memory files. Both are absent on non-Linux, in which case the
+// corresponding Sample fields read as 0.
+//
+// procMemInfoPath reports HOST-wide figures even from inside a container:
+// /proc is not namespaced for meminfo, and no lxcfs is in play here.
+const (
+	procStatusPath  = "/proc/self/status"
+	procMemInfoPath = "/proc/meminfo"
+)
+
+// Metric names read from runtime/metrics. goTotalMetric counts every byte the
+// Go runtime has mapped from the OS — heap, stacks, and runtime structures —
+// which is the quantity GOMEMLIMIT actually bounds. goObjectsMetric is the
+// live-object subset, the floor no GC can push below.
+const (
+	goTotalMetric   = "/memory/classes/total:bytes"
+	goObjectsMetric = "/memory/classes/heap/objects:bytes"
+)
+
+// Sample is one reading. All values are bytes; fields the platform does not
+// expose read as 0.
+type Sample struct {
+	// RSS is the process resident-set size as the kernel reports it.
+	RSS uint64
+	// GoTotal is every byte the Go runtime has mapped from the OS.
+	GoTotal uint64
+	// GoObjects is the bytes held by live heap objects.
+	GoObjects uint64
+	// HostAvailable is MemAvailable: memory the kernel believes it can hand
+	// out without swapping, host-wide.
+	//
+	// This is deliberately the HOST's figure, not the container's. /proc is
+	// not namespaced for meminfo, so a container without lxcfs reads through
+	// to the host — which is what we want. It distinguishes "this process
+	// exhausted memory" from "this process was modest and something else, or
+	// unreclaimable page cache, exhausted the host". Those two have opposite
+	// fixes, and an exit code of 137 alone cannot tell them apart.
+	HostAvailable uint64
+	// HostDirty is dirty page cache awaiting writeback, host-wide. Page cache
+	// is normally reclaimable and therefore harmless, but dirty pages are not
+	// reclaimable until written back: a writer that outruns its storage can
+	// pin gigabytes here and drive the host to OOM while its own RSS stays
+	// flat.
+	HostDirty uint64
+	// HostWriteback is page cache actively being written back, host-wide.
+	HostWriteback uint64
+}
+
+// OffHeap returns the resident bytes not accounted for by the Go runtime —
+// cgo allocations (RocksDB, Pebble) plus mapped binary and stacks. It is the
+// term a Go memory limit cannot govern. Returns 0 when RSS is unavailable or
+// when the Go runtime's own total exceeds RSS, which happens legitimately
+// because Go counts reserved-but-unfaulted address space that RSS does not.
+func (s Sample) OffHeap() uint64 {
+	if s.RSS == 0 || s.GoTotal > s.RSS {
+		return 0
+	}
+
+	return s.RSS - s.GoTotal
+}
+
+// String renders the sample as one log line.
+func (s Sample) String() string {
+	return fmt.Sprintf(
+		"rss=%s go-total=%s go-objects=%s off-heap=%s host-avail=%s host-dirty=%s host-writeback=%s",
+		FormatBytes(s.RSS), FormatBytes(s.GoTotal),
+		FormatBytes(s.GoObjects), FormatBytes(s.OffHeap()),
+		FormatBytes(s.HostAvailable), FormatBytes(s.HostDirty),
+		FormatBytes(s.HostWriteback))
+}
+
+// Read takes a sample. It never fails: values it cannot obtain read as 0.
+func Read() Sample {
+	samples := []metrics.Sample{
+		{Name: goTotalMetric},
+		{Name: goObjectsMetric},
+	}
+	metrics.Read(samples)
+
+	s := Sample{RSS: readRSS()}
+	// A metric the runtime does not recognise comes back as KindBad; treat it
+	// as absent rather than reading a garbage union field.
+	if samples[0].Value.Kind() == metrics.KindUint64 {
+		s.GoTotal = samples[0].Value.Uint64()
+	}
+	if samples[1].Value.Kind() == metrics.KindUint64 {
+		s.GoObjects = samples[1].Value.Uint64()
+	}
+
+	if raw, err := os.ReadFile(procMemInfoPath); err == nil {
+		fields := parseMemInfo(raw, "MemAvailable", "Dirty", "Writeback")
+		s.HostAvailable = fields["MemAvailable"]
+		s.HostDirty = fields["Dirty"]
+		s.HostWriteback = fields["Writeback"]
+	}
+
+	return s
+}
+
+// readRSS returns the process resident-set size in bytes, or 0 when the
+// platform does not expose /proc/self/status.
+func readRSS() uint64 {
+	raw, err := os.ReadFile(procStatusPath)
+	if err != nil {
+		return 0
+	}
+
+	value, ok := parseVmRSS(raw)
+	if !ok {
+		return 0
+	}
+
+	return value
+}
+
+// parseVmRSS extracts VmRSS from /proc/self/status content, converting the
+// kernel's kB to bytes.
+func parseVmRSS(raw []byte) (uint64, bool) {
+	for line := range strings.SplitSeq(string(raw), "\n") {
+		rest, found := strings.CutPrefix(line, "VmRSS:")
+		if !found {
+			continue
+		}
+
+		fields := strings.Fields(rest)
+		if len(fields) == 0 {
+			return 0, false
+		}
+
+		value, err := strconv.ParseUint(fields[0], 10, 64)
+		if err != nil {
+			return 0, false
+		}
+
+		return value << 10, true
+	}
+
+	return 0, false
+}
+
+// parseMemInfo extracts the named fields from /proc/meminfo content, keyed by
+// name without the trailing colon. Values are converted from the file's kB to
+// bytes. Fields that are absent or malformed are simply missing from the
+// result, so a caller reading a missing key gets 0.
+func parseMemInfo(raw []byte, names ...string) map[string]uint64 {
+	wanted := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		wanted[name] = struct{}{}
+	}
+
+	out := make(map[string]uint64, len(names))
+	for line := range strings.SplitSeq(string(raw), "\n") {
+		name, rest, found := strings.Cut(line, ":")
+		if !found {
+			continue
+		}
+		if _, want := wanted[name]; !want {
+			continue
+		}
+
+		fields := strings.Fields(rest)
+		if len(fields) == 0 {
+			continue
+		}
+
+		value, err := strconv.ParseUint(fields[0], 10, 64)
+		if err != nil || value > math.MaxUint64>>10 {
+			continue
+		}
+
+		out[name] = value << 10
+	}
+
+	return out
+}
+
+// FormatBytes renders a byte count with a binary unit suffix, at a precision
+// that keeps memory log lines scannable.
+func FormatBytes(bytes uint64) string {
+	switch {
+	case bytes >= 1<<30:
+		return strconv.FormatFloat(float64(bytes)/(1<<30), 'f', 1, 64) + "GiB"
+	case bytes >= 1<<20:
+		return strconv.FormatFloat(float64(bytes)/(1<<20), 'f', 0, 64) + "MiB"
+	default:
+		return strconv.FormatUint(bytes, 10) + "B"
+	}
+}

--- a/internal/memstat/memstat_test.go
+++ b/internal/memstat/memstat_test.go
@@ -1,0 +1,156 @@
+package memstat
+
+import (
+	"runtime"
+	"testing"
+)
+
+// TestParseVmRSS pins the kB→bytes conversion and the tolerated shapes of
+// /proc/self/status, whose field alignment varies between kernels.
+func TestParseVmRSS(t *testing.T) {
+	status := "Name:\tstate-actor\nVmPeak:\t 8000000 kB\nVmRSS:\t 4194304 kB\nThreads:\t42\n"
+
+	tests := []struct {
+		name   string
+		raw    string
+		want   uint64
+		wantOK bool
+	}{
+		{name: "typical status file", raw: status, want: 4194304 << 10, wantOK: true},
+		{name: "first line", raw: "VmRSS: 1024 kB\n", want: 1 << 20, wantOK: true},
+		{name: "extra spacing", raw: "VmRSS:      2048 kB\n", want: 2 << 20, wantOK: true},
+		{name: "missing", raw: "Name:\tx\nVmPeak:\t 100 kB\n", want: 0, wantOK: false},
+		{name: "empty", raw: "", want: 0, wantOK: false},
+		{name: "no value", raw: "VmRSS:\n", want: 0, wantOK: false},
+		{name: "not a number", raw: "VmRSS: lots kB\n", want: 0, wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseVmRSS([]byte(tt.raw))
+			if got != tt.want || ok != tt.wantOK {
+				t.Errorf("parseVmRSS(%q) = (%d, %t), want (%d, %t)",
+					tt.raw, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}
+
+// TestOffHeap pins the guard against a negative difference. The Go runtime
+// counts reserved-but-unfaulted address space that RSS does not, so GoTotal
+// legitimately exceeds RSS and must not underflow.
+func TestOffHeap(t *testing.T) {
+	tests := []struct {
+		name   string
+		sample Sample
+		want   uint64
+	}{
+		{name: "typical", sample: Sample{RSS: 40 << 30, GoTotal: 12 << 30}, want: 28 << 30},
+		{name: "rss unavailable", sample: Sample{RSS: 0, GoTotal: 12 << 30}, want: 0},
+		{name: "go total exceeds rss", sample: Sample{RSS: 8 << 30, GoTotal: 12 << 30}, want: 0},
+		{name: "equal", sample: Sample{RSS: 8 << 30, GoTotal: 8 << 30}, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.sample.OffHeap(); got != tt.want {
+				t.Errorf("OffHeap() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		bytes uint64
+		want  string
+	}{
+		{bytes: 0, want: "0B"},
+		{bytes: 512, want: "512B"},
+		{bytes: 1 << 20, want: "1MiB"},
+		{bytes: 26 << 30, want: "26.0GiB"},
+		{bytes: (3 << 30) + (512 << 20), want: "3.5GiB"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := FormatBytes(tt.bytes); got != tt.want {
+				t.Errorf("FormatBytes(%d) = %q, want %q", tt.bytes, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestReadReportsGoRuntime checks that the runtime/metrics names still exist:
+// a renamed or removed metric silently reads as 0, which would make the whole
+// diagnostic useless exactly when it is needed.
+func TestReadReportsGoRuntime(t *testing.T) {
+	// Hold a live allocation so the object count cannot be legitimately zero.
+	ballast := make([]byte, 8<<20)
+	defer runtime.KeepAlive(ballast)
+
+	got := Read()
+	if got.GoTotal == 0 {
+		t.Errorf("Read().GoTotal is 0; metric %q may have been renamed", goTotalMetric)
+	}
+	if got.GoObjects == 0 {
+		t.Errorf("Read().GoObjects is 0; metric %q may have been renamed", goObjectsMetric)
+	}
+	if got.String() == "" {
+		t.Error("Read().String() is empty")
+	}
+}
+
+// TestParseMemInfo pins extraction of the host-wide fields. Dirty/Writeback
+// distinguish "this process ate memory" from "unreclaimable page cache did",
+// so a silent parse failure here would hide the more likely cause.
+func TestParseMemInfo(t *testing.T) {
+	meminfo := "MemTotal:       64909644 kB\n" +
+		"MemFree:         1203620 kB\n" +
+		"MemAvailable:    2097152 kB\n" +
+		"Dirty:           4194304 kB\n" +
+		"Writeback:       1048576 kB\n"
+
+	got := parseMemInfo([]byte(meminfo), "MemAvailable", "Dirty", "Writeback")
+
+	want := map[string]uint64{
+		"MemAvailable": 2097152 << 10,
+		"Dirty":        4194304 << 10,
+		"Writeback":    1048576 << 10,
+	}
+	for name, w := range want {
+		if got[name] != w {
+			t.Errorf("parseMemInfo()[%q] = %d, want %d", name, got[name], w)
+		}
+	}
+
+	// MemFree was present but not requested; it must not leak into the result.
+	if _, present := got["MemFree"]; present {
+		t.Error("parseMemInfo() returned an unrequested field")
+	}
+}
+
+// TestParseMemInfoTolerates checks that malformed or absent fields degrade to
+// a missing key (reading as 0) rather than a bogus value.
+func TestParseMemInfoTolerates(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{name: "empty", raw: ""},
+		{name: "field absent", raw: "MemTotal: 100 kB\n"},
+		{name: "no value", raw: "Dirty:\n"},
+		{name: "not a number", raw: "Dirty: lots kB\n"},
+		{name: "no colon", raw: "Dirty 100 kB\n"},
+		{name: "wraps the kB shift", raw: "Dirty: 18446744073709551615 kB\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseMemInfo([]byte(tt.raw), "Dirty")
+			if v, present := got["Dirty"]; present {
+				t.Errorf("parseMemInfo(%q)[\"Dirty\"] = %d, want it absent", tt.raw, v)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

Closes #116. The 350 GB ethrex fill was **SIGKILLed (exit 137)** ~38% into Phase 2 on a 62 GiB host — not a state-actor error:

```
Build failed error=running state-actor: init container exited with code 137
```

| Time | Phase | Datadir |
|---|---|---|
| 14:49–15:05 | phase 0 — spec storage (335.5M slots, streamed) | → 60.4 GiB |
| 15:05–15:59 | phase 1 — 422.2M EOAs + 7.34M contracts → Pebble spill in `/tmp` | 60.4 GiB (flat) |
| ~16:00–16:28 | phase 2 — building state trie, **killed at 38.1%** | 60.4 → 312 GiB |

Host: 16 vCPU, `memTotal: 66467475456` = 61.9 GiB, cgroup v2, no swap.

Nothing bounded three compounding memory terms. Only one of them grows during the run, which is what pinned the kill to mid-Phase-2 rather than to startup.

## The three terms

**1. Index + bloom-filter blocks, unbounded and monotonically growing.** RocksDB's default (`cache_index_and_filter_blocks=false`) pre-loads them into each SST's table reader — outside the block cache, outside every budget, unevictable while the file stays open. With L0 triggers pinned to `MaxInt32` for bulk import, the SST count only ever grows. At this scale (~5B keys across the four big state CFs, 10-bit filters, 131-byte `storage_flatkeyvalue` keys) that is several GiB that ratchets upward for the whole import. Now routed through the existing 4 GiB shared cache — the cache size is unchanged, it just became a ceiling instead of a bystander.

**2. Memtables at a 12 GiB ceiling.** The per-CF write buffers mirror ethrex (`512 MiB × 6` on each of the four big state CFs), but RocksDB does not sum them, and no `db_write_buffer_size` capped the total. For comparison, besu and nethermind use `256 MiB × 4`. Now capped globally, leaving the per-CF shape — and therefore flushed SST sizes — intact.

**3. No cap on the Go heap.** `GOGC=100` allows ~2× the live set, and this spec's live set is large: state-actor's own log warns that `entities[6]` and `entities[7]` each materialize `150000 × 24576 B ≈ 3.4 GiB` of PreAlloc bytecode, pinned from parse time to exit (#97 tracks streaming it). New `internal/memlimit` derives `GOMEMLIMIT` from the host's real ceiling minus the writer's declared off-heap reserve.

## `internal/memlimit`

Detects cgroup v2 → cgroup v1 → `/proc/meminfo`, smallest real value wins (both spellings of "unlimited" are rejected so an unbounded cgroup can't shadow the host's true ceiling). Subtracts the caller's off-heap reserve, gives the Go heap half the remainder — the other half absorbs page cache and the overshoot a *soft* limit tolerates.

It declines rather than guesses. An explicit `GOMEMLIMIT` always wins, and a limit that would land below the live heap is reported instead of applied: that trades an OOM kill for an unbounded GC stall, which is strictly harder to diagnose.

This follows the precedent in `client/erigon/snapshot_cgo.go:79-94`, but **derived rather than fixed** — erigon's `8<<30` is right for erigon's ~2–5 GB live set and would sit *below* this workload's, causing exactly the stall above.

The reserve is derived from the RocksDB constants (`ethrexOffHeapReserveBytes`), so the two halves of this PR can't drift apart.

## The datadir is byte-identical

Every knob here is process-runtime only — none touches the bytes written:

- `cache_index_and_filter_blocks`, block cache size, `max_open_files`, `GOMEMLIMIT` decide where memory lives while we run.
- `db_write_buffer_size` changes how often memtables flush, but `Close()`'s `CompactRange` rewrites every state CF at `target_file_size_base` regardless.
- Compression, block size, `format_version`, filter policy, blob settings, `target_file_size_base` — the options that make the DB byte-representative — are untouched.
- The state root and every row come from `internal/ethrex.Builder` and `writeState`, not from RocksDB configuration. RocksDB only decides how identical KV pairs pack into SSTs.

`TestEthrexGoldenStateRoot` and `TestGenesisDumpGolden` (byte-exact against `testdata/genesis_dump.json`) pin this, and both pass against a rebuilt image.

## Verification

Image rebuilt from `Dockerfile.ethrex` (the cgo files can't compile without librocksdb), then:

```
=== RUN   TestGenesisDumpGolden
--- PASS: TestGenesisDumpGolden (0.15s)
=== RUN   TestGenesisHeaderGolden
--- PASS: TestGenesisHeaderGolden (0.00s)
=== RUN   TestEthrexGoldenStateRoot
--- PASS: TestEthrexGoldenStateRoot (0.07s)
```

Checked with `-v` specifically to confirm they **execute** rather than skip — a skipped golden test would prove nothing here.

Decision matrix exercised in real containers, not unit-tested in isolation:

```
unlimited        → limit set to 24.4 GiB (/proc/meminfo MemTotal reports 58.8 GiB)
--memory=32g     → limit set to 11.0 GiB (cgroup v2 memory.max reports 32.0 GiB)
--memory=8g      → declined: 8.0 GiB minus 10.0 GiB reserve is under the 2.0 GiB floor
GOMEMLIMIT=4GiB  → declined: a limit of 4.0 GiB is already in effect
```

The first row is #116's exact configuration (no container memory limit); on the 62 GiB CI host it caps the Go heap at ~26 GiB.

Also: `go vet ./...` clean, full untagged suite passes, `internal/memlimit` unit tests cover the split arithmetic and both cgroup "unlimited" spellings. `gofmt` flags ~26 pre-existing files, none touched here.

## Also in this PR

`state_writer_cgo.go`'s RAM-bound comment claimed `internal/ethrex.Builder` accumulates all leaves in memory. It does not — it is streaming and O(keyLen), as its own doc comment and `builder_reference_test.go` attest. That note pointed at the wrong culprit for exactly this failure, so it is corrected to name the terms that do scale.

## What this does NOT fix

**The same run was heading for ~715 GiB against a 350 GB target.** Extrapolating the observed Phase-2 write rate (249 GiB at 38.1%, and storage is uniform over accounts) gives ~653 GiB + 60 GiB from Phase 0. The `# ~436 GB` annotation in the benchmarkoor config is stale.

The cause: `sizecal.bytesPerSlot = 140` is documented as *trie-only*, with flat-state rows explicitly not counted — but ethrex writes **both** a `storage_trie_nodes` row and a `storage_flatkeyvalue` row per slot, so its real cost is ~2×. The autofill plan reproduces the log's numbers exactly (`bCode = 0.10 × 375.8 GB → 7,340,032` contracts; `bAcct = 0.20 × … → 422,156,694` EOAs; `bStorage = 0.70 × … → 35 KiB/contract ≈ 256 slots` → ~1.88B autofill slots).

**This cannot be fixed with a per-client `bytesPerSlot`.** `factors.go:47-48` and `README.md:216` both state the constant must be identical across clients for the `cross-client-genesis-root` gate; `SizeApproximator.SlotsForBytes` takes a `client` param that every implementation deliberately ignores. Diverging it would give ethrex a different synthetic entity set and therefore a different state root. The options are to raise the global constant for all clients (coordinated golden-root update) or to document the multiplier — worth its own issue.

So until then: this run needs ~700 GB free on `/schelk`, or `target_size` dropped to ~175 GB for ethrex.

**Small hosts still get a fixed RocksDB budget.** 4 GiB cache + 4 GiB memtables are constants, so ethrex commits ~10 GiB off-heap before the Go heap gets anything — which is why the `--memory=8g` row declines. Strictly better than before (12 GiB of memtables → 4), but scaling the RocksDB budget to detected memory the way `memlimit` now does for the heap is the natural follow-up if `--client=ethrex` should be usable on a laptop.
