### PR TITLE
client/besu: enhance db config produced by state-actor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+### Changed
+- **Besu DB now created with all 16 mainnet Bonsai column families.**
+  A fresh mainnet Besu init creates every `KeyValueSegmentIdentifier`
+  segment with `BONSAI` in its format set except the ignorable
+  `CHAIN_PRUNER_STATE` — 16 CFs. state-actor previously created only the
+  8 it writes to, leaving Besu to auto-create the other 8 on first boot
+  (`create_missing_column_families`), so the pre-boot DB layout and CF-ID
+  assignment did not match a Besu-initialized database. The 8 additional
+  CFs (legacy privacy 0x03/0x04/0x0c, backward-sync 0x0d–0x0f, snap-sync
+  0x10/0x11) are now created empty, in Besu's enum order, from the new
+  single-source-of-truth `keys.BonsaiCFNames()`. All persisted settings
+  (LZ4, SST format_version 5, 32 KiB blocks, BloomFilter(10), BlobDB on
+  BLOCKCHAIN + TRIE_LOG_STORAGE with GC on TRIE_LOG only) were verified
+  against a mainnet Besu RocksDB LOG and already matched.
+
 ### Added
 - **Nethermind flat-DB state generation (closes #111).** `--client=nethermind`
   now always writes Nethermind's flat-state layout — an eighth RocksDB

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 ## Why
 
-You want a pre-populated Ethereum database that a client can boot against directly &mdash; for cross-client determinism tests, devnet bootstrapping, EIP-7702 / ERC-20 fixtures, or state-bloat experiments. The alternative (run the client's `init` against a genesis with millions of `alloc` entries) is slow and client-specific. State Actor writes each client's on-disk format directly: Pebble for geth, MDBX + RocksDB + nippy-jar for reth, single RocksDB + 8 Bonsai column families for besu, seven RocksDB instances + a flat column DB for nethermind, single RocksDB + 20 column families for ethrex, Erigon v3 flat snapshot `.kv` files + a minimal MDBX for erigon.
+You want a pre-populated Ethereum database that a client can boot against directly &mdash; for cross-client determinism tests, devnet bootstrapping, EIP-7702 / ERC-20 fixtures, or state-bloat experiments. The alternative (run the client's `init` against a genesis with millions of `alloc` entries) is slow and client-specific. State Actor writes each client's on-disk format directly: Pebble for geth, MDBX + RocksDB + nippy-jar for reth, single RocksDB + 16 Bonsai column families for besu, seven RocksDB instances + a flat column DB for nethermind, single RocksDB + 20 column families for ethrex, Erigon v3 flat snapshot `.kv` files + a minimal MDBX for erigon.
 
 Three flags carry most of the weight: `--client` (which client's format to write), `--spec` (concrete entities to include, declared in YAML), `--target-size` (the DB-size budget; auto-fills mainnet-shaped 20 % / 10 % / 70 % across account-trie / bytecode / storage up to the cap). One of `--spec` or `--target-size` is required; everything else has a sane default.
 

--- a/client/besu/dbs_cgo.go
+++ b/client/besu/dbs_cgo.go
@@ -23,24 +23,36 @@ const bulkBackgroundJobs = 8
 // → fewer L0 SSTs but more RAM per CF.
 const perCFWriteBufferBytes = 256 * 1024 * 1024
 
-// Besu opens ONE RocksDB instance under <datadir>/database/ with all 8 column
-// families declared. Even TRIE_LOG_STORAGE (no genesis-time writes) must be
-// declared on OpenDb — RocksDB compares the open's CF list against on-disk
-// CFs and fails if any is missing on subsequent reopens.
+// Besu opens ONE RocksDB instance under <datadir>/database/ with all 16
+// column families a fresh mainnet Bonsai init creates (keys.BonsaiCFNames).
+// Even CFs that receive no genesis-time writes (TRIE_LOG_STORAGE, the
+// backward-sync/snap-sync/legacy-privacy CFs) must be declared on OpenDb —
+// RocksDB compares the open's CF list against on-disk CFs and fails if any
+// is missing on subsequent reopens — and creating them empty keeps the DB
+// layout identical to one initialized by Besu itself.
 
-// CF indices into besuDB.cfs. Must match the order of cfNames in openBesuDB.
+// CF indices into besuDB.cfs. Must match keys.BonsaiCFNames() order
+// (KeyValueSegmentIdentifier enum order); pinned by TestCFIndicesMatchNames.
 const (
 	cfIdxDefault = iota
 	cfIdxBlockchain
+	cfIdxPrivateTransactions
+	cfIdxPrivateState
 	cfIdxAccountInfoState
 	cfIdxCodeStorage
 	cfIdxAccountStorageStorage
 	cfIdxTrieBranchStorage
 	cfIdxTrieLogStorage
 	cfIdxVariables
+	cfIdxGoQuorumPrivateStorage
+	cfIdxBackwardSyncHeaders
+	cfIdxBackwardSyncBlocks
+	cfIdxBackwardSyncChain
+	cfIdxSnapsyncMissingAccountRange
+	cfIdxSnapsyncAccountToFix
 )
 
-// besuDB holds the open grocksdb handle and the 8 CF handles. Caller closes
+// besuDB holds the open grocksdb handle and the 16 CF handles. Caller closes
 // via Close() when done.
 type besuDB struct {
 	db   *grocksdb.DB
@@ -49,10 +61,10 @@ type besuDB struct {
 
 	// Held for Destroy() during Close. grocksdb requires explicit option-bag
 	// cleanup or it leaks C++ allocations.
-	dbOpts        *grocksdb.Options
-	cfOpts        []*grocksdb.Options
-	tableOpts     []*grocksdb.BlockBasedTableOptions
-	bloomFilter   *grocksdb.NativeFilterPolicy
+	dbOpts      *grocksdb.Options
+	cfOpts      []*grocksdb.Options
+	tableOpts   []*grocksdb.BlockBasedTableOptions
+	bloomFilter *grocksdb.NativeFilterPolicy
 }
 
 // openBesuDB creates a fresh Besu Bonsai RocksDB at <datadir>/database/.
@@ -84,19 +96,10 @@ func openBesuDB(datadir string) (*besuDB, error) {
 		return nil, fmt.Errorf("besu: mkdir datadir: %w", err)
 	}
 
-	// CF names use LITERAL bytes (0x01..0x0b for segment CFs, UTF-8 "default"
+	// CF names use LITERAL bytes (0x01..0x11 for segment CFs, UTF-8 "default"
 	// for the default CF) per KeyValueSegmentIdentifier.java:27-77. Order
 	// must match the cfIdx* constants above.
-	cfNames := []string{
-		string(keys.CFDefault),
-		string(keys.CFBlockchain),
-		string(keys.CFAccountInfoState),
-		string(keys.CFCodeStorage),
-		string(keys.CFAccountStorageStorage),
-		string(keys.CFTrieBranchStorage),
-		string(keys.CFTrieLogStorage),
-		string(keys.CFVariables),
-	}
+	cfNames := keys.BonsaiCFNames()
 
 	// Match Besu's per-CF settings from RocksDBColumnarKeyValueStorage.java:
 	// LZ4 compression, block-based table format_version=5, 32KB blocks,
@@ -194,9 +197,10 @@ func openBesuDB(datadir string) (*besuDB, error) {
 // the bulk write's suppressed compactions, parallelised across MaxBackgroundJobs.
 func (b *besuDB) Close() {
 	if b.db != nil {
-		// CompactRange the user CFs only. The Default CF is empty in our
-		// usage; the Blockchain + TRIE_LOG_STORAGE CFs receive few writes
-		// at genesis and a CompactRange on them is near-instant.
+		// CompactRange the written CFs only. The Default CF and the
+		// mainnet-parity CFs (legacy privacy, backward-sync, snap-sync)
+		// are empty in our usage; the Blockchain CF receives few writes
+		// at genesis and a CompactRange on it is near-instant.
 		emptyRange := grocksdb.Range{Start: nil, Limit: nil}
 		for _, idx := range []int{
 			cfIdxAccountInfoState,

--- a/client/besu/dbs_cgo_test.go
+++ b/client/besu/dbs_cgo_test.go
@@ -1,0 +1,46 @@
+//go:build cgo_besu
+
+package besu
+
+import (
+	"testing"
+
+	"github.com/ethereum/state-actor/internal/besu/keys"
+)
+
+// TestCFIndicesMatchNames pins each cfIdx* constant to its CF name in
+// keys.BonsaiCFNames(). The constants index into besuDB.cfs, whose order
+// is exactly the BonsaiCFNames open order — a drift between the two would
+// silently write genesis data into the wrong column family.
+func TestCFIndicesMatchNames(t *testing.T) {
+	names := keys.BonsaiCFNames()
+	cases := []struct {
+		idx  int
+		want string
+	}{
+		{cfIdxDefault, string(keys.CFDefault)},
+		{cfIdxBlockchain, string(keys.CFBlockchain)},
+		{cfIdxPrivateTransactions, string(keys.CFPrivateTransactions)},
+		{cfIdxPrivateState, string(keys.CFPrivateState)},
+		{cfIdxAccountInfoState, string(keys.CFAccountInfoState)},
+		{cfIdxCodeStorage, string(keys.CFCodeStorage)},
+		{cfIdxAccountStorageStorage, string(keys.CFAccountStorageStorage)},
+		{cfIdxTrieBranchStorage, string(keys.CFTrieBranchStorage)},
+		{cfIdxTrieLogStorage, string(keys.CFTrieLogStorage)},
+		{cfIdxVariables, string(keys.CFVariables)},
+		{cfIdxGoQuorumPrivateStorage, string(keys.CFGoQuorumPrivateStorage)},
+		{cfIdxBackwardSyncHeaders, string(keys.CFBackwardSyncHeaders)},
+		{cfIdxBackwardSyncBlocks, string(keys.CFBackwardSyncBlocks)},
+		{cfIdxBackwardSyncChain, string(keys.CFBackwardSyncChain)},
+		{cfIdxSnapsyncMissingAccountRange, string(keys.CFSnapsyncMissingAccountRange)},
+		{cfIdxSnapsyncAccountToFix, string(keys.CFSnapsyncAccountToFix)},
+	}
+	if len(cases) != len(names) {
+		t.Fatalf("cfIdx constants cover %d CFs, BonsaiCFNames has %d", len(cases), len(names))
+	}
+	for _, c := range cases {
+		if names[c.idx] != c.want {
+			t.Errorf("BonsaiCFNames[%d] = %x, want %x", c.idx, names[c.idx], c.want)
+		}
+	}
+}

--- a/client/besu/doc.go
+++ b/client/besu/doc.go
@@ -4,10 +4,13 @@
 //
 // # Approach
 //
-// Open one RocksDB instance under <datadir>/database/ with the 8 column
-// families Besu Bonsai expects (default + BLOCKCHAIN + ACCOUNT_INFO_STATE +
-// CODE_STORAGE + ACCOUNT_STORAGE_STORAGE + TRIE_BRANCH_STORAGE +
-// TRIE_LOG_STORAGE + VARIABLES). Stream synthetic accounts through a temp
+// Open one RocksDB instance under <datadir>/database/ with the 16 column
+// families a fresh mainnet Besu Bonsai init creates (keys.BonsaiCFNames:
+// default + BLOCKCHAIN + ACCOUNT_INFO_STATE + CODE_STORAGE +
+// ACCOUNT_STORAGE_STORAGE + TRIE_BRANCH_STORAGE + TRIE_LOG_STORAGE +
+// VARIABLES, which receive writes, plus the legacy-privacy /
+// backward-sync / snap-sync CFs, which stay empty but make the layout
+// match a Besu-initialized DB). Stream synthetic accounts through a temp
 // Pebble DB (Phase 1), iterate them in addrHash-sorted order to feed the
 // Bonsai path-keyed trie builder (Phase 2), write per-account flat state +
 // per-account storage trie nodes via NodeSink, then assemble the genesis

--- a/client/besu/golden_test.go
+++ b/client/besu/golden_test.go
@@ -88,16 +88,7 @@ func readWorldRoot(datadir string) (common.Hash, []byte, error) {
 	dbPath := filepath.Join(datadir, "database")
 
 	// Match the writer's CF set so RocksDB can open the DB.
-	cfNames := []string{
-		string(keys.CFDefault),
-		string(keys.CFBlockchain),
-		string(keys.CFAccountInfoState),
-		string(keys.CFCodeStorage),
-		string(keys.CFAccountStorageStorage),
-		string(keys.CFTrieBranchStorage),
-		string(keys.CFTrieLogStorage),
-		string(keys.CFVariables),
-	}
+	cfNames := keys.BonsaiCFNames()
 	cfOpts := make([]*grocksdb.Options, len(cfNames))
 	for i := range cfOpts {
 		cfOpts[i] = grocksdb.NewDefaultOptions()

--- a/client/besu/run.go
+++ b/client/besu/run.go
@@ -26,7 +26,7 @@ var errNotImplemented = errors.New(
 // It delegates to the build-tag-gated runImpl:
 //
 //   - Built with `-tags cgo_besu` (Docker only): runImpl in run_cgo.go opens
-//     one grocksdb instance with 8 column families, drives entitygen →
+//     one grocksdb instance with 16 column families, drives entitygen →
 //     trie.Builder → grocksdb writes, assembles the genesis block.
 //   - Built without the tag (local default): runImpl in run_stub.go returns
 //     errNotImplemented.
@@ -39,4 +39,3 @@ func Run(ctx context.Context, cfg generator.Config, opts Options) (*generator.St
 	}
 	return runImpl(ctx, cfg, opts)
 }
-

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -96,7 +96,7 @@ State Actor generates Ethereum state in three phases:
 │  │  Key: ethereum-config-...      Value: chain_config_json            │ │
 │  ├─────────────────────────────────────────────────────────────────────┤ │
 │  │  reth: MDBX state tables + RocksDB history + nippy-jar static_files│ │
-│  │  besu: single RocksDB w/ 8 Bonsai column families + chainspec.json │ │
+│  │  besu: single RocksDB w/ 16 Bonsai column families + chainspec.json│ │
 │  │  nethermind: 7 RocksDB + flat column DB + parity chainspec sidecar │ │
 │  │  ethrex: single RocksDB w/ 20 CFs + metadata.json + genesis sidecar│ │
 │  │  erigon: Erigon v3 flat .kv snapshots + minimal MDBX               │ │
@@ -220,7 +220,7 @@ configurable worker pool / batch size at the generator level.
   tables, with a per-batch `dirSize` sample driving the target-size
   early stop.
 - **besu** (`client/besu/state_writer_cgo.go:60-160`): cgo + librocksdb.
-  Single RocksDB with 8 Bonsai column families; per-entity raw-bytes
+  Single RocksDB with 16 Bonsai column families; per-entity raw-bytes
   accumulator drives the target-size stop.
 - **nethermind** (`client/nethermind/{run_cgo,entitygen_cgo}.go`): cgo
   + grocksdb. Seven RocksDB instances plus an eighth flat-state column DB

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -99,7 +99,7 @@ See [`RUNBOOK.md#geth`](RUNBOOK.md#geth) for the boot command, and [`client/geth
 
 ```bash
 go run . --db=/tmp/sa-reth --client=reth --target-size=100MB        # MDBX + RocksDB + static files
-go run . --db=/tmp/sa-besu --client=besu --target-size=100MB        # single RocksDB, 8 Bonsai CFs
+go run . --db=/tmp/sa-besu --client=besu --target-size=100MB        # single RocksDB, 16 Bonsai CFs
 go run . --db=/tmp/sa-neth --client=nethermind --target-size=100MB  # 7 RocksDB + flat column DB
 go run . --db=/tmp/sa-ethrex --client=ethrex --target-size=100MB   # single RocksDB, 20 CFs
 go run . --db=/tmp/sa-erigon --client=erigon --target-size=100MB   # Erigon v3 flat .kv snapshots + minimal MDBX

--- a/internal/besu/keys/cf.go
+++ b/internal/besu/keys/cf.go
@@ -56,4 +56,70 @@ var (
 	// RocksDB requires "default" to be declared on open; no writes needed.
 	// Name is UTF-8 string "default", NOT a single-byte ID.
 	CFDefault = []byte("default")
+
+	// The CFs below receive no writes from state-actor. Besu still creates
+	// all of them on a fresh mainnet Bonsai init (every segment with BONSAI
+	// in its format set, minus ignorable CHAIN_PRUNER_STATE), so we create
+	// them empty to match a Besu-initialized database layout byte for byte.
+
+	// CFPrivateTransactions — legacy private transactions, retained for DB
+	// backwards compatibility. KeyValueSegmentIdentifier.java:33.
+	CFPrivateTransactions = []byte{3}
+
+	// CFPrivateState — legacy private state, retained for DB backwards
+	// compatibility. KeyValueSegmentIdentifier.java:34.
+	CFPrivateState = []byte{4}
+
+	// CFGoQuorumPrivateStorage — legacy GoQuorum private storage, retained
+	// for DB backwards compatibility. KeyValueSegmentIdentifier.java:60.
+	CFGoQuorumPrivateStorage = []byte{12}
+
+	// CFBackwardSyncHeaders — backward-sync header cache.
+	// KeyValueSegmentIdentifier.java:62.
+	CFBackwardSyncHeaders = []byte{13}
+
+	// CFBackwardSyncBlocks — backward-sync block cache.
+	// KeyValueSegmentIdentifier.java:63.
+	CFBackwardSyncBlocks = []byte{14}
+
+	// CFBackwardSyncChain — backward-sync chain cache.
+	// KeyValueSegmentIdentifier.java:64.
+	CFBackwardSyncChain = []byte{15}
+
+	// CFSnapsyncMissingAccountRange — snap-sync healing bookkeeping.
+	// KeyValueSegmentIdentifier.java:65.
+	CFSnapsyncMissingAccountRange = []byte{16}
+
+	// CFSnapsyncAccountToFix — snap-sync healing bookkeeping.
+	// KeyValueSegmentIdentifier.java:66.
+	CFSnapsyncAccountToFix = []byte{17}
 )
+
+// BonsaiCFNames returns the 16 column family names a fresh mainnet Bonsai
+// Besu creates, in KeyValueSegmentIdentifier enum order. Creation order
+// determines RocksDB CF IDs, so both the DB writer and any reopener must
+// use this exact ordering to mirror a Besu-initialized database.
+//
+// CHAIN_PRUNER_STATE (0x12) is deliberately absent: Besu registers it as
+// an ignorable segment when chain pruning and history-expiry pruning are
+// off (the mainnet default) and does not create it on a fresh init.
+func BonsaiCFNames() []string {
+	return []string{
+		string(CFDefault),
+		string(CFBlockchain),
+		string(CFPrivateTransactions),
+		string(CFPrivateState),
+		string(CFAccountInfoState),
+		string(CFCodeStorage),
+		string(CFAccountStorageStorage),
+		string(CFTrieBranchStorage),
+		string(CFTrieLogStorage),
+		string(CFVariables),
+		string(CFGoQuorumPrivateStorage),
+		string(CFBackwardSyncHeaders),
+		string(CFBackwardSyncBlocks),
+		string(CFBackwardSyncChain),
+		string(CFSnapsyncMissingAccountRange),
+		string(CFSnapsyncAccountToFix),
+	}
+}

--- a/internal/besu/keys/sentinels_test.go
+++ b/internal/besu/keys/sentinels_test.go
@@ -30,7 +30,7 @@ func TestSentinelKeyLengths(t *testing.T) {
 }
 
 // TestCFByteIDs pins the single-byte CF identifiers.
-// CF names are raw bytes 1, 6..11 — NOT the ASCII characters '1', '6'.
+// CF names are raw bytes 1, 3..4, 6..17 — NOT ASCII characters like '1'.
 func TestCFByteIDs(t *testing.T) {
 	cases := []struct {
 		name string
@@ -38,12 +38,20 @@ func TestCFByteIDs(t *testing.T) {
 		want byte
 	}{
 		{"CFBlockchain", CFBlockchain, 0x01},
+		{"CFPrivateTransactions", CFPrivateTransactions, 0x03},
+		{"CFPrivateState", CFPrivateState, 0x04},
 		{"CFAccountInfoState", CFAccountInfoState, 0x06},
 		{"CFCodeStorage", CFCodeStorage, 0x07},
 		{"CFAccountStorageStorage", CFAccountStorageStorage, 0x08},
 		{"CFTrieBranchStorage", CFTrieBranchStorage, 0x09},
 		{"CFTrieLogStorage", CFTrieLogStorage, 0x0a},
 		{"CFVariables", CFVariables, 0x0b},
+		{"CFGoQuorumPrivateStorage", CFGoQuorumPrivateStorage, 0x0c},
+		{"CFBackwardSyncHeaders", CFBackwardSyncHeaders, 0x0d},
+		{"CFBackwardSyncBlocks", CFBackwardSyncBlocks, 0x0e},
+		{"CFBackwardSyncChain", CFBackwardSyncChain, 0x0f},
+		{"CFSnapsyncMissingAccountRange", CFSnapsyncMissingAccountRange, 0x10},
+		{"CFSnapsyncAccountToFix", CFSnapsyncAccountToFix, 0x11},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -54,6 +62,47 @@ func TestCFByteIDs(t *testing.T) {
 				t.Fatalf("%s: byte=%#x, want %#x", c.name, c.cf[0], c.want)
 			}
 		})
+	}
+}
+
+// TestBonsaiCFNames pins the fresh-mainnet-init CF set: count, creation
+// order (KeyValueSegmentIdentifier enum order — determines RocksDB CF IDs),
+// and the deliberate absence of CHAIN_PRUNER_STATE (0x12), which Besu
+// treats as ignorable and does not create with mainnet-default pruning
+// settings.
+func TestBonsaiCFNames(t *testing.T) {
+	want := []string{
+		"default",
+		"\x01", // BLOCKCHAIN
+		"\x03", // PRIVATE_TRANSACTIONS (legacy, retained)
+		"\x04", // PRIVATE_STATE (legacy, retained)
+		"\x06", // ACCOUNT_INFO_STATE
+		"\x07", // CODE_STORAGE
+		"\x08", // ACCOUNT_STORAGE_STORAGE
+		"\x09", // TRIE_BRANCH_STORAGE
+		"\x0a", // TRIE_LOG_STORAGE
+		"\x0b", // VARIABLES
+		"\x0c", // GOQUORUM_PRIVATE_STORAGE (legacy, retained)
+		"\x0d", // BACKWARD_SYNC_HEADERS
+		"\x0e", // BACKWARD_SYNC_BLOCKS
+		"\x0f", // BACKWARD_SYNC_CHAIN
+		"\x10", // SNAPSYNC_MISSING_ACCOUNT_RANGE
+		"\x11", // SNAPSYNC_ACCOUNT_TO_FIX
+	}
+	got := BonsaiCFNames()
+	if len(got) != len(want) {
+		t.Fatalf("BonsaiCFNames: %d CFs, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("BonsaiCFNames[%d] = %x, want %x", i, got[i], want[i])
+		}
+	}
+	for _, name := range got {
+		if name == "\x12" {
+			t.Fatal("BonsaiCFNames must not contain CHAIN_PRUNER_STATE (0x12): " +
+				"mainnet-default Besu treats it as ignorable and does not create it")
+		}
 	}
 }
 


### PR DESCRIPTION
This updates Besu DB to match the configs as dumped in 
[LOG-config-mainnet-besu.txt](https://github.com/user-attachments/files/30558046/LOG-config-mainnet-besu.txt)

Draft, as I did not verify the LLM-produced result yet 