### PR TITLE
fix(reth): write auth designators with the EIP-7702 compact variant

### DIFF
--- a/client/reth/bytecode_writer_cgo.go
+++ b/client/reth/bytecode_writer_cgo.go
@@ -15,10 +15,26 @@ package reth
 //	                          position, 1 = JUMPDEST; LSB-first within each byte
 //	                          (bitvec<u8, Lsb0> layout)
 //
+// Wire format (reth Compact, Eip7702 variant) — delegation designators only:
+//
+//	[u32 BE: 23]
+//	[raw_bytes]             — 0xEF 0x01 0x00 || 20-byte delegate address
+//	[u8: 0x04]              — EIP7702_BYTECODE_ID; no original_len, no jump table
+//
 // Reth uses LegacyAnalyzed for all regular contracts. The LEGACY_RAW (0x00)
 // variant appears in from_compact for backward compat but is never written by
 // new_raw (which always runs analyze_legacy and writes LegacyAnalyzed).
 // We match that behaviour exactly.
+//
+// A designator MUST NOT be written as LegacyAnalyzed. reth's from_compact
+// rebuilds that variant through new_analyzed, which never inspects the 0xEF01
+// prefix, so the account ends up holding the 23 designator bytes as ordinary
+// executable code: calling it dies on the undefined 0xEF opcode
+// (OpcodeNotFound, all gas consumed) instead of dispatching to the delegate.
+// Only EIP7702_BYTECODE_ID routes from_compact through new_raw, which
+// classifies by prefix. The bug is invisible to the state root — the trie
+// commits keccak(code), not the variant tag — and geth is unaffected because
+// it stores raw code and parses the prefix at call time.
 
 import (
 	"encoding/binary"
@@ -35,6 +51,21 @@ import (
 // bytecodeAnalyzed is the discriminant for the LegacyAnalyzed variant.
 // Matches compact_ids::LEGACY_ANALYZED_BYTECODE_ID = 2 in reth-primitives-traits.
 const bytecodeAnalyzed uint8 = 2
+
+// bytecodeEip7702 is the discriminant for the Eip7702 variant.
+// Matches compact_ids::EIP7702_BYTECODE_ID = 4 in reth-primitives-traits.
+const bytecodeEip7702 uint8 = 4
+
+// eip7702DesignatorLen is revm's EIP7702_BYTECODE_LEN: 2 (magic) + 1 (version)
+// + 20 (address). revm accepts a designator only at exactly this length and
+// version; anything else that merely starts with 0xEF01 is an
+// Eip7702DecodeError there, so it stays legacy code here (matching geth, whose
+// ParseDelegation is equally strict).
+const eip7702DesignatorLen = 23
+
+// eip7702DesignatorPrefix is the 3-byte EIP-7702 header — revm's
+// EIP7702_MAGIC_BYTES (0xEF01) followed by EIP7702_VERSION (0).
+var eip7702DesignatorPrefix = [3]byte{0xEF, 0x01, 0x00}
 
 // opcode constants used by the bytecode analysis pass.
 const (
@@ -112,15 +143,21 @@ func (w *BytecodeWriter) Write(code []byte) (common.Hash, bool, error) {
 //
 // Mirrors revm_bytecode::Bytecode::to_compact exactly:
 //
-//  1. Analyze the bytecode (find JUMPDESTs, compute padding) — same logic as
-//     revm_bytecode::legacy::analyze_legacy().
-//  2. Write:
+//  1. EIP-7702 delegation designators take the Eip7702 variant (see
+//     encodeEip7702Compact) — reth's to_compact branches on is_legacy(), and
+//     only that variant survives the from_compact round-trip as a delegation.
+//  2. Everything else: analyze the bytecode (find JUMPDESTs, compute padding)
+//     — same logic as revm_bytecode::legacy::analyze_legacy() — then write:
 //     [u32 BE analyzed_len][analyzed_bytes][u8=2][u64 BE original_len][jump_table]
 //
 // jump_table is ceil(analyzed_len/8) bytes; bit i (LSB-first within each byte)
 // is set iff the opcode at position i is JUMPDEST. This is bitvec<u8, Lsb0>
 // layout.
 func encodeBytecodeCompact(code []byte) []byte {
+	if isEip7702Designator(code) {
+		return encodeEip7702Compact(code)
+	}
+
 	originalLen := len(code)
 
 	// --- analysis pass: mirror analyze_legacy ---
@@ -218,4 +255,31 @@ func encodeBytecodeCompact(code []byte) []byte {
 // These opcodes have 1-byte immediates not tracked by the PUSH analysis pass.
 func isDupnSwapnExchange(op uint8) bool {
 	return op == opDUPN || op == opSWAPN || op == opEXCHANGE
+}
+
+// isEip7702Designator reports whether code is a well-formed EIP-7702
+// delegation designator, using revm's acceptance rule from
+// Bytecode::new_eip7702_raw: exactly 23 bytes, 0xEF01 magic, version byte 0.
+// Anything looser (wrong length, unsupported version) is an
+// Eip7702DecodeError in revm, so it must keep the legacy encoding.
+func isEip7702Designator(code []byte) bool {
+	return len(code) == eip7702DesignatorLen &&
+		code[0] == eip7702DesignatorPrefix[0] &&
+		code[1] == eip7702DesignatorPrefix[1] &&
+		code[2] == eip7702DesignatorPrefix[2]
+}
+
+// encodeEip7702Compact encodes a delegation designator the way reth's
+// to_compact does for the Eip7702 variant: the raw bytes verbatim (revm keeps
+// designators unpadded, original_len == 23) followed by the discriminant.
+// from_compact hands these bytes to new_raw, which re-derives the delegation
+// from the 0xEF01 prefix — no original_len or jump table is stored.
+//
+//	[u32 BE: 23][23 raw bytes][u8: 0x04]
+func encodeEip7702Compact(code []byte) []byte {
+	buf := make([]byte, 4+len(code)+1)
+	binary.BigEndian.PutUint32(buf, uint32(len(code)))
+	copy(buf[4:], code)
+	buf[4+len(code)] = bytecodeEip7702
+	return buf
 }

--- a/client/reth/bytecode_writer_cgo_test.go
+++ b/client/reth/bytecode_writer_cgo_test.go
@@ -3,6 +3,7 @@
 package reth
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"testing"
@@ -218,6 +219,123 @@ func TestEncodeBytecodeCompactWireFormat(t *testing.T) {
 			t.Errorf("jump_table byte = 0x%02X, want 0x80 (JUMPDEST at pos 7)", jtByte)
 		}
 	})
+}
+
+// delegationDesignator builds a well-formed EIP-7702 designator pointing at
+// target: 0xEF 0x01 0x00 || 20-byte address.
+func delegationDesignator(target common.Address) []byte {
+	code := make([]byte, 0, 23)
+	code = append(code, 0xEF, 0x01, 0x00)
+	return append(code, target[:]...)
+}
+
+// TestEncodeBytecodeCompactEip7702 pins the Eip7702 variant for delegation
+// designators. Writing them as LegacyAnalyzed is silently wrong: reth's
+// from_compact rebuilds that variant via new_analyzed, which skips the 0xEF01
+// prefix check, so calling the delegated EOA executes 0xEF and aborts with
+// OpcodeNotFound (consuming the whole gas limit) instead of dispatching to the
+// delegate. The state root can't catch it — the trie commits keccak(code).
+func TestEncodeBytecodeCompactEip7702(t *testing.T) {
+	target := common.HexToAddress("0xa9cb82ea3c688e8c8153e60c1e340840459f66a6")
+	code := delegationDesignator(target)
+
+	encoded := encodeBytecodeCompact(code)
+
+	// [u32 BE 23][23 raw bytes][u8 0x04] — no original_len, no jump table.
+	if len(encoded) != 4+eip7702DesignatorLen+1 {
+		t.Fatalf("encoded length: got %d want %d", len(encoded), 4+eip7702DesignatorLen+1)
+	}
+	if rawLen := binary.BigEndian.Uint32(encoded[0:4]); rawLen != eip7702DesignatorLen {
+		t.Errorf("raw length header: got %d want %d", rawLen, eip7702DesignatorLen)
+	}
+	if got := encoded[4 : 4+eip7702DesignatorLen]; !bytes.Equal(got, code) {
+		t.Errorf("payload: got %x want %x", got, code)
+	}
+	if variant := encoded[4+eip7702DesignatorLen]; variant != bytecodeEip7702 {
+		t.Errorf("variant: got %d want %d (EIP7702_BYTECODE_ID)", variant, bytecodeEip7702)
+	}
+}
+
+// TestEncodeBytecodeCompactNonDesignators keeps the legacy encoding for
+// everything revm's Bytecode::new_eip7702_raw would reject. Tagging those as
+// Eip7702 would be worse than the bug it fixes: reth's from_compact calls
+// new_raw, whose new_raw_checked would return an Eip7702DecodeError and panic
+// the node at DB-read time.
+func TestEncodeBytecodeCompactNonDesignators(t *testing.T) {
+	addr := common.HexToAddress("0xa9cb82ea3c688e8c8153e60c1e340840459f66a6")
+	designator := delegationDesignator(addr)
+
+	cases := []struct {
+		name string
+		code []byte
+	}{
+		{"one_byte_short", designator[:len(designator)-1]},
+		{"one_byte_long", append(append([]byte{}, designator...), 0x00)},
+		{"unsupported_version", append([]byte{0xEF, 0x01, 0x01}, addr[:]...)},
+		{"eof_magic", append([]byte{0xEF, 0x00, 0x00}, addr[:]...)},
+		{"bare_ef_opcode", []byte{0xEF}},
+		{"ordinary_contract", []byte{0x60, 0x40, 0x5B, 0x00}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded := encodeBytecodeCompact(tc.code)
+			analyzedLen := int(binary.BigEndian.Uint32(encoded[0:4]))
+			if variant := encoded[4+analyzedLen]; variant != bytecodeAnalyzed {
+				t.Errorf("variant: got %d want %d (LEGACY_ANALYZED_BYTECODE_ID)",
+					variant, bytecodeAnalyzed)
+			}
+		})
+	}
+}
+
+// TestBytecodeWriterEip7702Roundtrip walks a designator through the real
+// writer: the value stored under keccak(designator) must be the Eip7702
+// encoding, and the code hash must stay keccak(raw code) so the account leaf
+// and the committed state root keep agreeing.
+func TestBytecodeWriterEip7702Roundtrip(t *testing.T) {
+	tmp := t.TempDir()
+	envs, err := OpenEnvs(tmp, true)
+	if err != nil {
+		t.Fatalf("OpenEnvs: %v", err)
+	}
+	defer envs.Close()
+
+	code := delegationDesignator(common.HexToAddress("0xc700a71c3ee17f9106ff87e3a27dc52ce9d551eb"))
+
+	var hash common.Hash
+	if err := envs.Mdbx.Update(func(txn *mdbx.Txn) error {
+		w := NewBytecodeWriter(txn, envs.MdbxDBIs["Bytecodes"], 100)
+		var wrote bool
+		var err error
+		hash, wrote, err = w.Write(code)
+		if err != nil {
+			return err
+		}
+		if !wrote {
+			t.Error("first Write should report a DB write")
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if want := crypto.Keccak256Hash(code); hash != want {
+		t.Errorf("code hash: got %s want %s", hash.Hex(), want.Hex())
+	}
+
+	if err := envs.Mdbx.View(func(txn *mdbx.Txn) error {
+		val, err := txn.Get(envs.MdbxDBIs["Bytecodes"], hash[:])
+		if err != nil {
+			return fmt.Errorf("designator not in table: %w", err)
+		}
+		if want := encodeEip7702Compact(code); !bytes.Equal(val, want) {
+			t.Errorf("stored value: got %x want %x", val, want)
+		}
+		return nil
+	}); err != nil {
+		t.Errorf("verify: %v", err)
+	}
 }
 
 // TestBytecodeWriterDBSeekDedup verifies the LRU-miss → DB-seek dedup path:

--- a/client/reth/doc.go
+++ b/client/reth/doc.go
@@ -85,7 +85,9 @@
 //   - run_cgo.go / run_stub.go: build-tag-gated RunCgo entry point
 //   - dbs_cgo.go: MDBX env + RocksDB column families
 //   - data_writer_cgo.go: per-EOA state-table writes
-//   - bytecode_writer_cgo.go: deduped bytecode writes
+//   - bytecode_writer_cgo.go: deduped bytecode writes; LegacyAnalyzed for
+//     contracts, Eip7702 for delegation designators (the variant tag is
+//     load-bearing even though the state root ignores it.)
 //   - storage_writer_cgo.go: per-slot storage-table writes
 //   - contracts_writer_cgo.go: composed contract writes
 //   - metadata_cgo.go: minimum-boot MDBX metadata


### PR DESCRIPTION
## Problem

The reth bytecode writer encoded every account's code as reth's `LegacyAnalyzed` Compact variant, including EIP-7702 delegation designators (`0xEF0100 || address`) planted by the `sequential_pkey_delegations` template.

reth's `from_compact` rebuilds `LegacyAnalyzed` through `new_analyzed`, which never inspects the `0xEF01` prefix, so the delegated account ends up holding the 23 designator bytes as ordinary executable code. Calling it aborts on the undefined `0xEF` opcode (`OpcodeNotFound`, entire gas limit consumed) instead of dispatching to the delegate.

The state root cannot catch this, the trie commits `keccak(code)`, not the variant tag — so the snapshot looks correct and boots cleanly, and the failure only surfaces at execution time. geth is unaffected: it stores raw code and parses the prefix at call time.

Observed on an EEST benchmark replay: geth-filled Amsterdam fixtures whose transactions transfer to 7702-delegated receivers were rejected by reth with `receipt root mismatch`. Reconstructing the receipts trie showed every transaction failing with its full gas limit consumed and no logs; a `debug_traceCall` against the delegated account confirmed a single step at `pc 0` with `OpcodeNotFound`.

## Fix

`encodeBytecodeCompact` now branches: well-formed designators get the `Eip7702` variant (`[u32 BE 23][23 raw bytes][u8 0x04]` — no `original_len`, no jump table), everything else keeps the existing `LegacyAnalyzed` path. That id is the only one whose `from_compact` routes through `new_raw`, which re-classifies by prefix.

Detection matches revm's `Bytecode::new_eip7702_raw` exactly — exactly 23 bytes, `0xEF01` magic, version byte `0`. Anything looser stays legacy on purpose: a near-miss tagged as `Eip7702` would make `new_raw_checked` return
`Eip7702DecodeError`, and reth's `new_raw` unwraps it, panicking the node at DB-read time. geth's `ParseDelegation` is equally strict.

## Verification

- New unit tests: exact 28-byte layout and variant id for a designator; near-misses (22/24 bytes, version `0x01`, `0xEF0000`, bare `0xEF`, ordinary contract) stay `LegacyAnalyzed`; a designator round-tripped through the real MDBX writer, asserting the stored value and that the code hash stays `keccak(raw code)`.
- Cross-checked against `reth-primitives-traits` 0.5.0 (`reth-codec`): reth's own `to_compact` produces byte-identical output for the designator and for an ordinary contract, `from_compact` on the new encoding yields `is_eip7702() == true` with the expected delegate address, and the previous encoding reproduces the bug (`is_eip7702() == false`) with identical code bytes.

Only reth is affected — no other client writer analyzes bytecode or tags variants; they all store raw code.

## Follow-up (not in this PR)

`sequential_pkey_delegations` is absent from `examples/full-matrix-spec-feature.yaml`, so no e2e suite ever boots a datadir containing a designator. Adding it (plus the `TestBuildFullMatrix` entity-count pin) would turn "reth dispatches to the delegate" into end-to-end coverage.