### PR TITLE
client/geth: mirror geth's per-level Pebble options + parity guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@
   no longer written.
 
 ### Changed
+- **Geth writer mirrors geth's per-level Pebble options** (10-bit bloom
+  filters on L0–L5, none on L6, 2→128 MiB file-size ladder), locked to
+  the pinned go-ethereum by a new OPTIONS-file parity test. Effect is
+  config parity + upstream-drift detection: the shipped datadir's bulk
+  data still lands filter-less in L6 via the Close-time compaction,
+  matching a real synced geth node. The final compaction's error is no
+  longer swallowed on the success path.
 - **Pinned Nethermind image bumped 1.37.0 → 1.39.0.** The flat-DB backend and
   its startup `State backend: flat/patricia` detection log only exist in
   Nethermind ≥ 1.39.0. A new `neth.PinnedNethermindVersion` constant plus a

--- a/client/geth/run.go
+++ b/client/geth/run.go
@@ -48,10 +48,15 @@ func Populate(ctx context.Context, cfg generator.Config, opts Options) (*generat
 	if err != nil {
 		return nil, fmt.Errorf("client/geth.Populate: open writer: %w", err)
 	}
+	closed := false
 	defer func() {
-		// Best-effort close; primary errors are returned via the explicit
-		// path below.
-		_ = w.Close()
+		// Safety net for error returns only. The success path closes
+		// explicitly below: Close runs the final full-keyspace
+		// compaction, and a failure there must surface — otherwise a
+		// "successful" run hands geth an uncompacted, L0-shaped DB.
+		if !closed {
+			_ = w.Close()
+		}
 	}()
 
 	stateRoot, stats, err := writeStateAndCollectRoot(ctx, cfg, w)
@@ -83,5 +88,9 @@ func Populate(ctx context.Context, cfg generator.Config, opts Options) (*generat
 		return nil, fmt.Errorf("client/geth.Populate: write genesis json: %w", err)
 	}
 
+	closed = true
+	if err := w.Close(); err != nil {
+		return nil, fmt.Errorf("client/geth.Populate: close writer (final compaction): %w", err)
+	}
 	return stats, nil
 }

--- a/client/geth/writer.go
+++ b/client/geth/writer.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/bloom"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -91,6 +92,35 @@ func NewWriter(dbPath string) (*Writer, error) {
 	return w, nil
 }
 
+// gethLevelOptions mirrors the per-level table-format options that
+// go-ethereum's ethdb/pebble.New configures (pinned go.mod version;
+// see TestPebbleLevelOptionsMatchGeth, which locks this against geth's
+// actual code). These decide the on-disk sstable format — bloom
+// filters, target file sizes — that persists after state-actor exits
+// and geth takes over, so they must be geth's, not pebble's defaults:
+//
+//   - 10-bit bloom filters on L0–L5, deliberately NONE on the last
+//     level (geth: "Pebble doesn't use the Bloom filter at level6 for
+//     read efficiency" — a filter over ~90% of the data costs more
+//     block-cache than it saves).
+//   - TargetFileSize ladder 2 MiB → 128 MiB doubling per level.
+//
+// Runtime knobs (memtables, compaction triggers) are NOT mirrored —
+// those only shape behaviour while a process has the DB open, and our
+// bulk-import needs differ from geth's serving needs; see
+// prodPebbleOptions.
+func gethLevelOptions() []pebble.LevelOptions {
+	levels := make([]pebble.LevelOptions, 7)
+	for i := 0; i < 6; i++ {
+		levels[i] = pebble.LevelOptions{
+			TargetFileSize: (2 * 1024 * 1024) << i,
+			FilterPolicy:   bloom.FilterPolicy(10),
+		}
+	}
+	levels[6] = pebble.LevelOptions{TargetFileSize: 128 * 1024 * 1024}
+	return levels
+}
+
 // prodPebbleOptions returns pebble.Options tuned for state-actor's
 // one-shot bulk-import workload on the production geth DB. The DB is
 // write-only during generation (geth reads it only later, after the
@@ -100,6 +130,9 @@ func NewWriter(dbPath string) (*Writer, error) {
 // default L0 thresholds trigger ~6x throughput collapse mid-import
 // once L0 reaches 24 SSTs (writes stall waiting for compactors).
 //
+//   - Levels = gethLevelOptions() → the persistent sstable format
+//     (bloom filters, file-size ladder) matches what geth itself
+//     would write; everything below this line is transient tuning.
 //   - L0CompactionThreshold = MaxInt32 → no auto-compaction kicks in.
 //   - L0StopWritesThreshold = MaxInt32 → no L0 stall on writes.
 //   - MemTableSize 256 MiB → fewer (and larger) L0 flushes.
@@ -109,6 +142,7 @@ func NewWriter(dbPath string) (*Writer, error) {
 //     genesis block) — those are tiny, no point disabling.
 func prodPebbleOptions() *pebble.Options {
 	return &pebble.Options{
+		Levels:                      gethLevelOptions(),
 		MemTableSize:                256 * 1024 * 1024,
 		MemTableStopWritesThreshold: 2,
 		L0CompactionThreshold:       math.MaxInt32,

--- a/client/geth/writer.go
+++ b/client/geth/writer.go
@@ -72,7 +72,8 @@ const defaultFlushBytes = 64 * 1024 * 1024
 // behaviour from a fixed ~64 MiB byte-budget flush instead.
 //
 // The DB is opened with bulk-import-friendly defaults: large MemTable,
-// L0-compaction trigger raised, MaxConcurrentCompactions=4. WAL is kept
+// L0-compaction trigger raised, MaxConcurrentCompactions capped at 8.
+// WAL is kept
 // enabled for the production DB so a crash doesn't lose the post-import
 // metadata writes (Phase 1's scratch DB, opened separately in
 // state_writer.go, disables WAL — that's what the speed delta buys).
@@ -95,15 +96,25 @@ func NewWriter(dbPath string) (*Writer, error) {
 // gethLevelOptions mirrors the per-level table-format options that
 // go-ethereum's ethdb/pebble.New configures (pinned go.mod version;
 // see TestPebbleLevelOptionsMatchGeth, which locks this against geth's
-// actual code). These decide the on-disk sstable format — bloom
-// filters, target file sizes — that persists after state-actor exits
-// and geth takes over, so they must be geth's, not pebble's defaults:
+// actual code):
 //
 //   - 10-bit bloom filters on L0–L5, deliberately NONE on the last
 //     level (geth: "Pebble doesn't use the Bloom filter at level6 for
-//     read efficiency" — a filter over ~90% of the data costs more
-//     block-cache than it saves).
-//   - TargetFileSize ladder 2 MiB → 128 MiB doubling per level.
+//     read efficiency").
+//   - TargetFileSize ladder 2 MiB → 128 MiB doubling per level (same
+//     ladder pebble's defaults extrapolate; the filters are the real
+//     delta).
+//
+// Honest scope note: the shipped datadir does NOT end up with bloom
+// filters. Close()'s full-keyspace compaction sends all bulk data
+// straight to L6 (pebble picks baseLevel=6 when L1–L6 are empty), and
+// L6 has no filter — exactly like a real long-synced geth node, whose
+// bulk state also sits filter-less in L6. The filters here cover only
+// the transient L0 tables that exist during generation, and geth's own
+// runtime writes get filters from geth's own options regardless. The
+// value of this mirror is parity + the drift-guard test, not filters
+// in the final artifact — do NOT "fix" this by adding an L6 filter;
+// that would make bench reads faster than a real node's.
 //
 // Runtime knobs (memtables, compaction triggers) are NOT mirrored —
 // those only shape behaviour while a process has the DB open, and our
@@ -130,14 +141,15 @@ func gethLevelOptions() []pebble.LevelOptions {
 // default L0 thresholds trigger ~6x throughput collapse mid-import
 // once L0 reaches 24 SSTs (writes stall waiting for compactors).
 //
-//   - Levels = gethLevelOptions() → the persistent sstable format
-//     (bloom filters, file-size ladder) matches what geth itself
-//     would write; everything below this line is transient tuning.
+//   - Levels = gethLevelOptions() → level config matches what geth
+//     itself uses (see its honest-scope note); everything below this
+//     line is transient tuning.
 //   - L0CompactionThreshold = MaxInt32 → no auto-compaction kicks in.
 //   - L0StopWritesThreshold = MaxInt32 → no L0 stall on writes.
 //   - MemTableSize 256 MiB → fewer (and larger) L0 flushes.
-//   - MaxConcurrentCompactions = NumCPU → the final compact() at Close
-//     parallelises across all cores (it's the only compaction we run).
+//   - MaxConcurrentCompactions capped at 8 → parallelises the final
+//     compact() at Close (the only compaction we run) without the
+//     per-compactor RAM blowup NumCPU caused on the 96-core bench box.
 //   - WAL stays on for the post-import metadata writes (PathDB markers,
 //     genesis block) — those are tiny, no point disabling.
 func prodPebbleOptions() *pebble.Options {

--- a/client/geth/writer_options_parity_test.go
+++ b/client/geth/writer_options_parity_test.go
@@ -1,0 +1,86 @@
+package geth
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+	gethpebble "github.com/ethereum/go-ethereum/ethdb/pebble"
+)
+
+// TestPebbleLevelOptionsMatchGeth locks state-actor's per-level Pebble
+// table-format options to go-ethereum's own ethdb/pebble configuration.
+//
+// The per-level options (bloom filter policy, target file size, block
+// size, compression) decide the persistent sstable format of the DB we
+// hand to geth. Rather than trusting a hand-copied gethLevelOptions()
+// to stay in sync with upstream, this test opens one throwaway DB via
+// geth's ethdb/pebble.New and one via prodPebbleOptions(), then
+// compares the [Level "N"] sections Pebble records in each DB's
+// OPTIONS-* file. If a go-ethereum bump changes its level config in
+// any observable way, this fails and points at gethLevelOptions().
+//
+// Runtime-only knobs (memtable sizing, compaction thresholds, cache)
+// live in the [Options] section, which is deliberately NOT compared:
+// state-actor legitimately tunes those for one-shot bulk import, and
+// they leave no trace in the sstables geth later reads.
+func TestPebbleLevelOptionsMatchGeth(t *testing.T) {
+	gethDir := t.TempDir()
+	gdb, err := gethpebble.New(gethDir, 16, 16, "parity-test", false)
+	if err != nil {
+		t.Fatalf("open geth ethdb/pebble: %v", err)
+	}
+	if err := gdb.Close(); err != nil {
+		t.Fatalf("close geth ethdb/pebble: %v", err)
+	}
+
+	saDir := t.TempDir()
+	sdb, err := pebble.Open(saDir, prodPebbleOptions())
+	if err != nil {
+		t.Fatalf("open state-actor pebble: %v", err)
+	}
+	if err := sdb.Close(); err != nil {
+		t.Fatalf("close state-actor pebble: %v", err)
+	}
+
+	gethLevels := levelSections(t, gethDir)
+	saLevels := levelSections(t, saDir)
+	if gethLevels != saLevels {
+		t.Errorf("per-level Pebble options diverge from geth's ethdb/pebble\n--- geth ---\n%s\n--- state-actor ---\n%s", gethLevels, saLevels)
+	}
+}
+
+// levelSections returns the concatenated [Level "N"] sections of the
+// newest OPTIONS-* file in a Pebble DB directory.
+func levelSections(t *testing.T, dir string) string {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "OPTIONS-*"))
+	if err != nil || len(matches) == 0 {
+		t.Fatalf("no OPTIONS-* file in %s (err=%v)", dir, err)
+	}
+	sort.Strings(matches)
+	raw, err := os.ReadFile(matches[len(matches)-1])
+	if err != nil {
+		t.Fatalf("read %s: %v", matches[len(matches)-1], err)
+	}
+
+	var out strings.Builder
+	inLevel := false
+	for _, line := range strings.Split(string(raw), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") {
+			inLevel = strings.HasPrefix(trimmed, `[Level`)
+		}
+		if inLevel && trimmed != "" {
+			out.WriteString(trimmed)
+			out.WriteString("\n")
+		}
+	}
+	if out.Len() == 0 {
+		t.Fatalf("no [Level ...] sections found in %s", matches[len(matches)-1])
+	}
+	return out.String()
+}

--- a/client/geth/writer_options_parity_test.go
+++ b/client/geth/writer_options_parity_test.go
@@ -27,6 +27,12 @@ import (
 // live in the [Options] section, which is deliberately NOT compared:
 // state-actor legitimately tunes those for one-shot bulk import, and
 // they leave no trace in the sstables geth later reads.
+//
+// Known blind spot: pebble serializes filter_policy by NAME only
+// ("rocksdb.BuiltinBloomFilter"), not bits-per-key — a geth change
+// from bloom.FilterPolicy(10) to another bit count would pass this
+// test. There is no observable place the bit count is recorded, so
+// that dimension can only be caught by reviewing geth bumps.
 func TestPebbleLevelOptionsMatchGeth(t *testing.T) {
 	gethDir := t.TempDir()
 	gdb, err := gethpebble.New(gethDir, 16, 16, "parity-test", false)
@@ -54,7 +60,9 @@ func TestPebbleLevelOptionsMatchGeth(t *testing.T) {
 }
 
 // levelSections returns the concatenated [Level "N"] sections of the
-// newest OPTIONS-* file in a Pebble DB directory.
+// newest OPTIONS-* file in a Pebble DB directory. Lexicographic sort
+// is enough to pick "newest" here: a freshly created DB has exactly
+// one OPTIONS file.
 func levelSections(t *testing.T, dir string) string {
 	t.Helper()
 	matches, err := filepath.Glob(filepath.Join(dir, "OPTIONS-*"))


### PR DESCRIPTION
Mirrors go-ethereum's `ethdb/pebble` per-level options in the geth writer — 10-bit bloom filters on L0–L5 (none on L6, matching geth's deliberate choice), `TargetFileSize` ladder 2→128 MiB — and locks the mirror to the pinned go-ethereum with `TestPebbleLevelOptionsMatchGeth`, which compares the `[Level]` sections of the Pebble `OPTIONS-*` files written by geth's `ethdb/pebble.New` vs `prodPebbleOptions()`. Any observable upstream level-config change now fails CI at the next go.mod bump.

**Honest scope**: the shipped datadir's bulk data still ends up filter-less. The writer's `Close()` runs a full-keyspace compaction, and pebble sends an L0-only DB straight to L6 (`baseLevel=6` when L1–L6 are empty) — where geth itself configures no filter. That matches a real long-synced geth node (bulk state in L6, no filters), so it's the faithful end state for benchmarks; adding an L6 filter would make bench reads faster than reality. The filters added here cover the transient L0 tables during generation, and the mirror's lasting value is parity + the drift-guard test. Since the level layout is now load-bearing, `Populate` also stops swallowing `Close()`'s error on the success path — a failed final compaction previously handed over an L0-shaped DB behind a success summary.

Longer-term (as originally noted): derive client DB configs from client code rather than copying — the parity test is the interim enforcement of exactly that.
