### PR TITLE
clients/nethermind: copy config from nethermind code into db initializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@
   no longer written.
 
 ### Changed
+- **Nethermind writer runs Nethermind's own RocksDB configuration.** All
+  8 databases (and every column family) now parse the verbatim DbConfig
+  option strings through RocksDB's own parser instead of hand-tuned
+  grocksdb defaults — bloom/ribbon filter policies, index types, block
+  sizes, compression now match what Nethermind itself writes. Transient
+  bulk-import tuning is layered on top and leaves no trace in the SSTs.
+  A new `TestNethOptionsPersisted` locks the composed options via each
+  DB's OPTIONS-* file.
 - **Geth writer mirrors geth's per-level Pebble options** (10-bit bloom
   filters on L0–L5, none on L6, 2→128 MiB file-size ladder), locked to
   the pinned go-ethereum by a new OPTIONS-file parity test. Effect is

--- a/client/nethermind/dbs_cgo.go
+++ b/client/nethermind/dbs_cgo.go
@@ -42,6 +42,9 @@ const (
 // which case-maps "Default" → "default" at open time.
 var receiptsCFNames = []string{"default", "Transactions", "Blocks"}
 
+// receiptsBlocksCFIndex is the "Blocks" position in receiptsCFNames.
+const receiptsBlocksCFIndex = 2
+
 // nethDBs holds the open grocksdb handles state-actor writes during a
 // Nethermind genesis emission. Caller closes via Close() when done.
 type nethDBs struct {
@@ -137,7 +140,11 @@ func openNethDBs(dataDir string) (*nethDBs, error) {
 	// plus bulk-import tuning (see options_cgo.go).
 	open := func(name string) (*grocksdb.DB, error) {
 		path := filepath.Join(dbRoot, name)
-		opts, err := nethOptions(nethPerDBOptions[name])
+		fragment, ok := nethPerDBOptions[name]
+		if !ok {
+			return nil, fmt.Errorf("no Nethermind option fragment for db %q", name)
+		}
+		opts, err := nethOptions(fragment)
 		if err != nil {
 			return nil, fmt.Errorf("compose %s db options: %w", name, err)
 		}
@@ -189,7 +196,7 @@ func openNethDBs(dataDir string) (*nethDBs, error) {
 	cfOpts := make([]*grocksdb.Options, len(receiptsCFNames))
 	for i := range cfOpts {
 		fragments := []string{nethReceiptsOptions}
-		if receiptsCFNames[i] == "Blocks" {
+		if i == receiptsBlocksCFIndex {
 			fragments = append(fragments, nethReceiptsBlocksCFOptions)
 		}
 		cfOpts[i], err = nethOptions(fragments...)
@@ -209,7 +216,7 @@ func openNethDBs(dataDir string) (*nethDBs, error) {
 	}
 	dbs.receipts = receiptsDB
 	dbs.receiptsCFs = cfHandles
-	dbs.receiptsBlocksCF = cfHandles[2] // index 2 = "Blocks" per receiptsCFNames
+	dbs.receiptsBlocksCF = cfHandles[receiptsBlocksCFIndex]
 
 	// Flat-state column DB: one RocksDB with 8 CFs (default + the 7
 	// flat.ColumnNames), same multi-CF open pattern as receipts. Opened last so

--- a/client/nethermind/dbs_cgo.go
+++ b/client/nethermind/dbs_cgo.go
@@ -4,10 +4,8 @@ package nethermind
 
 import (
 	"fmt"
-	"math"
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/linxGnu/grocksdb"
 
@@ -21,27 +19,11 @@ const bulkBackgroundJobs = 8
 // perDBWriteBufferBytes is the per-DB memtable size during bulk import.
 const perDBWriteBufferBytes = 256 * 1024 * 1024
 
-// bulkRocksOptions returns *grocksdb.Options tuned for the bulk-import path:
-// L0 triggers pinned to MaxInt32 (no compaction during writes), one final
-// CompactRange at Close().
-func bulkRocksOptions() *grocksdb.Options {
-	opts := grocksdb.NewDefaultOptions()
-	opts.SetCreateIfMissing(true)
-	opts.SetCreateIfMissingColumnFamilies(true)
-	opts.SetWriteBufferSize(perDBWriteBufferBytes)
-	opts.SetMaxWriteBufferNumber(4)
-	opts.SetLevel0FileNumCompactionTrigger(math.MaxInt32)
-	opts.SetLevel0SlowdownWritesTrigger(math.MaxInt32)
-	opts.SetLevel0StopWritesTrigger(math.MaxInt32)
-	opts.SetMaxBytesForLevelBase(2 * 1024 * 1024 * 1024)
-	parallelism := runtime.NumCPU()
-	if parallelism > bulkBackgroundJobs {
-		parallelism = bulkBackgroundJobs
-	}
-	opts.IncreaseParallelism(parallelism)
-	opts.SetMaxBackgroundJobs(parallelism)
-	return opts
-}
+// Per-DB options come from nethOptions (options_cgo.go): Nethermind's own
+// DbConfig option strings parsed by RocksDB's parser, with transient
+// bulk-import tuning (big memtables, L0 triggers pinned to MaxInt32 so no
+// compaction runs during writes, one final CompactRange at Close) layered
+// on top.
 
 // nethDBNames mirrors the Nethermind.Db/DbNames.cs constants we need for
 // genesis-bootability. State, Code, Blocks, Headers, BlockNumbers, and
@@ -157,14 +139,18 @@ func openNethDBs(dataDir string) (*nethDBs, error) {
 		dbs.Close()
 	}
 
-	// Helper: open a single-CF database with bulk-import tuning.
-	// All defaults were 2 MiB memtable, 1 background thread, L0 trigger 4
-	// — those defaults caused the May-17 nethermind run's 2:42 wall time.
-	// bulkRocksOptions raises memtable to 256 MiB and defers all L0
-	// compactions; Close()'s CompactRange pays the flattening cost once.
+	// Helper: open a single-CF database with Nethermind's per-DB options
+	// plus bulk-import tuning. (The raw grocksdb defaults — 2 MiB memtable,
+	// 1 background thread, L0 trigger 4 — caused the May-17 nethermind
+	// run's 2:42 wall time; the bulk deltas raise the memtable to 256 MiB
+	// and defer all L0 compactions; Close()'s CompactRange pays the
+	// flattening cost once.)
 	open := func(name string) (*grocksdb.DB, error) {
 		path := filepath.Join(dbRoot, name)
-		opts := bulkRocksOptions()
+		opts, err := nethOptions(nethPerDBOptions[name])
+		if err != nil {
+			return nil, fmt.Errorf("compose %s db options: %w", name, err)
+		}
 		dbs.openedOpts = append(dbs.openedOpts, opts)
 
 		db, err := grocksdb.OpenDb(opts, path)
@@ -200,17 +186,28 @@ func openNethDBs(dataDir string) (*nethDBs, error) {
 		return nil, err
 	}
 
-	// Receipts: 3 column families. Use bulk-import tuning for parity with
-	// the single-CF DBs even though receipts sees few writes at genesis
-	// (one empty receipts list at the genesis row) — the cost of tuned
-	// options on a near-empty DB is negligible.
+	// Receipts: 3 column families. Per Nethermind's composition, every CF
+	// inherits default + ReceiptsDb options; only the Blocks CF has an
+	// extra override fragment.
 	receiptsPath := filepath.Join(dbRoot, dbNameReceipts)
-	receiptsOpts := bulkRocksOptions()
+	receiptsOpts, err := nethOptions(nethReceiptsOptions)
+	if err != nil {
+		cleanup()
+		return nil, fmt.Errorf("compose receipts db options: %w", err)
+	}
 	dbs.openedOpts = append(dbs.openedOpts, receiptsOpts)
 
 	cfOpts := make([]*grocksdb.Options, len(receiptsCFNames))
 	for i := range cfOpts {
-		cfOpts[i] = bulkRocksOptions()
+		fragments := []string{nethReceiptsOptions}
+		if receiptsCFNames[i] == "Blocks" {
+			fragments = append(fragments, nethReceiptsBlocksCFOptions)
+		}
+		cfOpts[i], err = nethOptions(fragments...)
+		if err != nil {
+			cleanup()
+			return nil, fmt.Errorf("compose receipts %s CF options: %w", receiptsCFNames[i], err)
+		}
 		dbs.openedOpts = append(dbs.openedOpts, cfOpts[i])
 	}
 
@@ -228,13 +225,28 @@ func openNethDBs(dataDir string) (*nethDBs, error) {
 	// Flat-state column DB: one RocksDB with 8 CFs (default + the 7
 	// flat.ColumnNames), same multi-CF open pattern as receipts. Opened last so
 	// the single-CF DBs and receipts are already in dbs for cleanup() on error.
+	// Every flat CF inherits default + FlatDb options; most columns add a
+	// Flat<Column>Db override (nethFlatCFOptions); the mandatory "default"
+	// CF has no override in Nethermind's DbConfig and takes the base as-is.
 	flatPath := filepath.Join(dbRoot, dbNameFlat)
-	flatOpts := bulkRocksOptions()
+	flatOpts, err := nethOptions(nethFlatOptions)
+	if err != nil {
+		cleanup()
+		return nil, fmt.Errorf("compose flat db options: %w", err)
+	}
 	dbs.openedOpts = append(dbs.openedOpts, flatOpts)
 
 	flatCFOpts := make([]*grocksdb.Options, len(flat.ColumnNames))
 	for i := range flatCFOpts {
-		flatCFOpts[i] = bulkRocksOptions()
+		fragments := []string{nethFlatOptions}
+		if extra, ok := nethFlatCFOptions[flat.Column(i)]; ok {
+			fragments = append(fragments, extra)
+		}
+		flatCFOpts[i], err = nethOptions(fragments...)
+		if err != nil {
+			cleanup()
+			return nil, fmt.Errorf("compose flat %s CF options: %w", flat.ColumnNames[i], err)
+		}
 		dbs.openedOpts = append(dbs.openedOpts, flatCFOpts[i])
 	}
 

--- a/client/nethermind/dbs_cgo.go
+++ b/client/nethermind/dbs_cgo.go
@@ -19,12 +19,6 @@ const bulkBackgroundJobs = 8
 // perDBWriteBufferBytes is the per-DB memtable size during bulk import.
 const perDBWriteBufferBytes = 256 * 1024 * 1024
 
-// Per-DB options come from nethOptions (options_cgo.go): Nethermind's own
-// DbConfig option strings parsed by RocksDB's parser, with transient
-// bulk-import tuning (big memtables, L0 triggers pinned to MaxInt32 so no
-// compaction runs during writes, one final CompactRange at Close) layered
-// on top.
-
 // nethDBNames mirrors the Nethermind.Db/DbNames.cs constants we need for
 // genesis-bootability. State, Code, Blocks, Headers, BlockNumbers, and
 // BlockInfos are simple single-CF databases. Receipts has 3 column
@@ -139,12 +133,8 @@ func openNethDBs(dataDir string) (*nethDBs, error) {
 		dbs.Close()
 	}
 
-	// Helper: open a single-CF database with Nethermind's per-DB options
-	// plus bulk-import tuning. (The raw grocksdb defaults — 2 MiB memtable,
-	// 1 background thread, L0 trigger 4 — caused the May-17 nethermind
-	// run's 2:42 wall time; the bulk deltas raise the memtable to 256 MiB
-	// and defer all L0 compactions; Close()'s CompactRange pays the
-	// flattening cost once.)
+	// open opens a single-CF database with Nethermind's per-DB options
+	// plus bulk-import tuning (see options_cgo.go).
 	open := func(name string) (*grocksdb.DB, error) {
 		path := filepath.Join(dbRoot, name)
 		opts, err := nethOptions(nethPerDBOptions[name])
@@ -186,9 +176,8 @@ func openNethDBs(dataDir string) (*nethDBs, error) {
 		return nil, err
 	}
 
-	// Receipts: 3 column families. Per Nethermind's composition, every CF
-	// inherits default + ReceiptsDb options; only the Blocks CF has an
-	// extra override fragment.
+	// Receipts: 3 column families; every CF inherits the ReceiptsDb
+	// fragment, only Blocks adds an override.
 	receiptsPath := filepath.Join(dbRoot, dbNameReceipts)
 	receiptsOpts, err := nethOptions(nethReceiptsOptions)
 	if err != nil {
@@ -225,9 +214,6 @@ func openNethDBs(dataDir string) (*nethDBs, error) {
 	// Flat-state column DB: one RocksDB with 8 CFs (default + the 7
 	// flat.ColumnNames), same multi-CF open pattern as receipts. Opened last so
 	// the single-CF DBs and receipts are already in dbs for cleanup() on error.
-	// Every flat CF inherits default + FlatDb options; most columns add a
-	// Flat<Column>Db override (nethFlatCFOptions); the mandatory "default"
-	// CF has no override in Nethermind's DbConfig and takes the base as-is.
 	flatPath := filepath.Join(dbRoot, dbNameFlat)
 	flatOpts, err := nethOptions(nethFlatOptions)
 	if err != nil {

--- a/client/nethermind/options_cgo.go
+++ b/client/nethermind/options_cgo.go
@@ -67,6 +67,10 @@ const (
 		"ttl=0;" +
 		"periodic_compaction_seconds=0;"
 
+	// filter_policy=null is not a value RocksDB recognizes ("nullptr" is);
+	// it only yields no-filter because unsupported values are silently
+	// dropped (ignore_unsupported_options) — typos in these strings fail
+	// the same silent way.
 	nethCodeOptions = "write_buffer_size=16000000;" +
 		"block_based_table_factory.block_cache=16000000;" +
 		"optimize_filters_for_hits=false;" +

--- a/client/nethermind/options_cgo.go
+++ b/client/nethermind/options_cgo.go
@@ -1,0 +1,283 @@
+//go:build cgo_neth
+
+package nethermind
+
+import (
+	"fmt"
+	"math"
+	"runtime"
+	"strings"
+
+	"github.com/linxGnu/grocksdb"
+
+	"github.com/ethereum/state-actor/internal/neth/flat"
+)
+
+// This file makes state-actor's Nethermind databases carry Nethermind's own
+// RocksDB configuration instead of grocksdb defaults.
+//
+// Nethermind configures every database (and every column family) by
+// concatenating RocksDB option STRINGS — a global default plus per-DB
+// overrides — and feeding the result through rocksdb_get_options_from_string
+// (DbOnTheRocks.BuildOptions). grocksdb exposes the same C entry point as
+// GetOptionsFromString, so instead of hand-porting each knob we execute
+// Nethermind's exact strings, copied verbatim below, and RocksDB's own
+// parser guarantees identical semantics.
+//
+// String provenance: src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+// at commit 2706ce9e024a679c38c18a9329c7f9f4ba7282da (2026-07-31, tracking
+// 1.39-dev). Composition rule (PerTableDbConfig.ReadRocksdbOptions):
+// effective = RocksDbOptions + <Table>DbRocksDbOptions for plain DBs, and
+// RocksDbOptions + <Table>DbRocksDbOptions + <Table><Column>DbRocksDbOptions
+// for column DBs; later fragments win. Like Nethermind's
+// NormalizeRocksDbOptions, duplicated optimize_filters_for_hits entries are
+// collapsed to the last occurrence before parsing — RocksDB rejects that
+// specific key appearing twice in one string.
+//
+// The strings decide everything persisted in the SST files Nethermind will
+// later read: filter policies (bloomfilter:15 on state, ribbonfilter:10:3 on
+// the flat CFs, none on code), per-DB optimize_filters_for_hits (whether the
+// bottommost level keeps its filters), index types, block sizes, compression,
+// format_version, target file sizes. Transient bulk-import tuning is layered
+// on top afterwards via typed setters (applyBulkImportDeltas) and leaves no
+// trace in the generated files.
+
+// nethDefaultOptions is DbConfig.RocksDbOptions — the base every DB inherits.
+const nethDefaultOptions = "min_write_buffer_number_to_merge=1;" +
+	"write_buffer_size=16000000;" +
+	"max_write_buffer_number=2;" +
+	"memtable_whole_key_filtering=true;" +
+	"memtable_prefix_bloom_size_ratio=0.02;" +
+	"level_compaction_dynamic_level_bytes=false;" +
+	"max_compaction_bytes=4000000000;" +
+	"compression=kSnappyCompression;" +
+	"optimize_filters_for_hits=true;" +
+	"advise_random_on_open=true;" +
+	"target_file_size_base=64000000;" +
+	"max_bytes_for_level_base=256000000;" +
+	"block_based_table_factory.block_size=16000;" +
+	"block_based_table_factory.pin_l0_filter_and_index_blocks_in_cache=true;" +
+	"block_based_table_factory.cache_index_and_filter_blocks_with_high_priority=true;" +
+	"block_based_table_factory.format_version=5;" +
+	"block_based_table_factory.index_type=kTwoLevelIndexSearch;" +
+	"block_based_table_factory.partition_filters=true;" +
+	"block_based_table_factory.metadata_block_size=4096;" +
+	"block_based_table_factory.filter_policy=bloomfilter:10;"
+
+// Per-DB overrides, DbConfig.<Name>DbRocksDbOptions.
+const (
+	nethStateOptions = "compression=kLZ4Compression;" +
+		"max_bytes_for_level_multiplier=30;" +
+		"max_bytes_for_level_base=350000000;" +
+		"target_file_size_multiplier=2;" +
+		"min_write_buffer_number_to_merge=2;" +
+		"block_based_table_factory.block_restart_interval=4;" +
+		"block_based_table_factory.data_block_index_type=kDataBlockBinaryAndHash;" +
+		"block_based_table_factory.data_block_hash_table_util_ratio=0.5;" +
+		"block_based_table_factory.block_size=32000;" +
+		"block_based_table_factory.filter_policy=bloomfilter:15;" +
+		"unordered_write=true;" +
+		"max_write_batch_group_size_bytes=4000000;" +
+		"ttl=0;" +
+		"periodic_compaction_seconds=0;"
+
+	nethCodeOptions = "write_buffer_size=16000000;" +
+		"block_based_table_factory.block_cache=16000000;" +
+		"optimize_filters_for_hits=false;" +
+		"prefix_extractor=capped:8;" +
+		"block_based_table_factory.index_type=kHashSearch;" +
+		"block_based_table_factory.block_size=4096;" +
+		"memtable=prefix_hash:1000000;" +
+		"block_based_table_factory.filter_policy=null;" +
+		"allow_concurrent_memtable_write=false;"
+
+	nethBlocksOptions = "write_buffer_size=64000000;" +
+		"block_based_table_factory.block_cache=32000000;" +
+		"compaction_pri=kOldestLargestSeqFirst;" +
+		"optimize_filters_for_hits=false;"
+
+	nethHeadersOptions = "write_buffer_size=8000000;" +
+		"block_based_table_factory.block_cache=32000000;" +
+		"compaction_pri=kOldestLargestSeqFirst;" +
+		"optimize_filters_for_hits=false;" +
+		"block_based_table_factory.block_size=32000;" +
+		"max_bytes_for_level_base=128000000;"
+
+	nethBlockNumbersOptions = "write_buffer_size=8000000;" +
+		"max_bytes_for_level_base=16000000;" +
+		"block_based_table_factory.block_cache=16000000;" +
+		"block_based_table_factory.block_size=4096;" +
+		"optimize_filters_for_hits=false;" +
+		"memtable=prefix_hash:1000000;" +
+		"allow_concurrent_memtable_write=false;"
+
+	nethBlockInfosOptions = "write_buffer_size=4000000;" +
+		"max_bytes_for_level_base=32000000;" +
+		"optimize_filters_for_hits=false;" +
+		"block_based_table_factory.block_cache=16000000;" +
+		"block_based_table_factory.block_size=32000;" +
+		"compaction_pri=kOldestLargestSeqFirst;"
+
+	nethReceiptsOptions = "write_buffer_size=2000000;" +
+		"block_based_table_factory.block_cache=8000000;" +
+		"optimize_filters_for_hits=false;"
+
+	// Receipts column overrides (ReceiptsDefaultDb / ReceiptsTransactionsDb
+	// are empty in DbConfig; only the Blocks column overrides).
+	nethReceiptsBlocksCFOptions = "compaction_pri=kOldestLargestSeqFirst;" +
+		"write_buffer_size=16000000;" +
+		"max_write_buffer_number=4;"
+
+	// FlatDbRocksDbOptions — common base of every flat-state column.
+	nethFlatOptions = "min_write_buffer_number_to_merge=2;" +
+		"block_based_table_factory.block_restart_interval=4;" +
+		"block_based_table_factory.data_block_index_type=kDataBlockBinaryAndHash;" +
+		"block_based_table_factory.data_block_hash_table_util_ratio=0.7;" +
+		"block_based_table_factory.block_size=16000;" +
+		"block_based_table_factory.filter_policy=ribbonfilter:10:3;" +
+		"max_write_batch_group_size_bytes=4000000;" +
+		"block_based_table_factory.pin_l0_filter_and_index_blocks_in_cache=true;" +
+		"block_based_table_factory.prepopulate_block_cache=kFlushOnly;" +
+		"block_based_table_factory.whole_key_filtering=true;" +
+		"level_compaction_dynamic_level_bytes=false;" +
+		"block_based_table_factory.partition_filters=false;" +
+		"block_based_table_factory.index_type=kBinarySearch;" +
+		"ttl=0;" +
+		"periodic_compaction_seconds=0;" +
+		"compression=kLZ4Compression;" +
+		"target_file_size_multiplier=2;" +
+		"manual_wal_flush=true;" +
+		"uncache_aggressiveness=1000;" +
+		"write_buffer_size=1000000;"
+
+	nethFlatMetadataCFOptions = "max_bytes_for_level_base=1000000;"
+
+	nethFlatAccountCFOptions = "compression=kNoCompression;" +
+		"optimize_filters_for_hits=false;" +
+		"target_file_size_multiplier=3;" +
+		"target_file_size_base=32000000;" +
+		"max_bytes_for_level_multiplier=15;" +
+		"max_bytes_for_level_base=128000000;" +
+		"block_based_table_factory.block_size=4096;" +
+		"write_buffer_size=16000000;" +
+		"max_write_buffer_number=4;"
+
+	nethFlatStorageCFOptions = "optimize_filters_for_hits=false;" +
+		"target_file_size_base=64000000;" +
+		"block_based_table_factory.block_size=8000;" +
+		"write_buffer_size=32000000;" +
+		"max_write_buffer_number=4;"
+
+	// DbConfig.FlatDbCommonTrieOptions, shared by the trie-node columns.
+	nethFlatCommonTrieOptions = "level_compaction_dynamic_level_bytes=true;" +
+		"block_based_table_factory.block_restart_interval=8;" +
+		"block_based_table_factory.block_size=16000;"
+
+	nethFlatStateTopNodesCFOptions = nethFlatCommonTrieOptions +
+		"write_buffer_size=64000000;" +
+		"max_write_buffer_number=4;"
+
+	nethFlatStateNodesCFOptions = nethFlatCommonTrieOptions +
+		"write_buffer_size=32000000;" +
+		"max_write_buffer_number=4;"
+
+	nethFlatStorageNodesCFOptions = nethFlatCommonTrieOptions +
+		"max_bytes_for_level_base=350000000;" +
+		"write_buffer_size=64000000;" +
+		"max_write_buffer_number=8;"
+
+	nethFlatFallbackNodesCFOptions = nethFlatCommonTrieOptions +
+		"max_bytes_for_level_base=4000000;"
+)
+
+// nethPerDBOptions maps the single-CF database names to their DbConfig
+// override fragment.
+var nethPerDBOptions = map[string]string{
+	dbNameState:        nethStateOptions,
+	dbNameCode:         nethCodeOptions,
+	dbNameBlocks:       nethBlocksOptions,
+	dbNameHeaders:      nethHeadersOptions,
+	dbNameBlockNumbers: nethBlockNumbersOptions,
+	dbNameBlockInfos:   nethBlockInfosOptions,
+}
+
+// nethFlatCFOptions maps flat.Column ordinals to their column override
+// fragment. The "default" CF has no Flat<Column>Db entry in DbConfig and
+// inherits the FlatDb base unchanged.
+var nethFlatCFOptions = map[flat.Column]string{
+	flat.ColMetadata:      nethFlatMetadataCFOptions,
+	flat.ColAccount:       nethFlatAccountCFOptions,
+	flat.ColStorage:       nethFlatStorageCFOptions,
+	flat.ColStateNodes:    nethFlatStateNodesCFOptions,
+	flat.ColStateTopNodes: nethFlatStateTopNodesCFOptions,
+	flat.ColStorageNodes:  nethFlatStorageNodesCFOptions,
+	flat.ColFallbackNodes: nethFlatFallbackNodesCFOptions,
+}
+
+// normalizeOptimizeFiltersForHits ports Nethermind's NormalizeRocksDbOptions:
+// keep only the LAST optimize_filters_for_hits= entry, because RocksDB's
+// options-string parser does not allow the key to appear twice.
+func normalizeOptimizeFiltersForHits(s string) string {
+	const key = "optimize_filters_for_hits="
+	last := strings.LastIndex(s, key)
+	if last == -1 {
+		return s
+	}
+	for {
+		i := strings.Index(s, key)
+		if i == -1 || i == last {
+			return s
+		}
+		end := strings.IndexByte(s[i:], ';')
+		if end == -1 {
+			return s
+		}
+		s = s[:i] + s[i+end+1:]
+		last = strings.LastIndex(s, key)
+	}
+}
+
+// nethOptions composes Nethermind's effective option string for one DB (or
+// one column family) — base + override fragments, later wins — parses it
+// with RocksDB's own parser, and layers state-actor's transient bulk-import
+// tuning on top. The caller owns the returned Options (Destroy after close).
+func nethOptions(fragments ...string) (*grocksdb.Options, error) {
+	combined := normalizeOptimizeFiltersForHits(nethDefaultOptions + strings.Join(fragments, ""))
+
+	base := grocksdb.NewDefaultOptions()
+	defer base.Destroy()
+	opts, err := grocksdb.GetOptionsFromString(base, combined)
+	if err != nil {
+		return nil, fmt.Errorf("parse Nethermind option string: %w", err)
+	}
+	applyBulkImportDeltas(opts)
+	return opts, nil
+}
+
+// applyBulkImportDeltas overlays state-actor's one-shot import tuning on a
+// parsed Nethermind option bag. Everything here is runtime-only — memtable
+// sizing, compaction scheduling, WAL flushing — and changes nothing about
+// the SST format Nethermind later reads. The write path stays the same as
+// the previous bulkRocksOptions: no compactions during the import, one
+// CompactRange at Close.
+func applyBulkImportDeltas(opts *grocksdb.Options) {
+	opts.SetCreateIfMissing(true)
+	opts.SetCreateIfMissingColumnFamilies(true)
+	opts.SetWriteBufferSize(perDBWriteBufferBytes)
+	opts.SetMaxWriteBufferNumber(4)
+	opts.SetLevel0FileNumCompactionTrigger(math.MaxInt32)
+	opts.SetLevel0SlowdownWritesTrigger(math.MaxInt32)
+	opts.SetLevel0StopWritesTrigger(math.MaxInt32)
+	// Nethermind flushes the flat DB's WAL manually from its persistence
+	// layer; state-actor has no equivalent, so let RocksDB manage the WAL.
+	opts.SetManualWALFlush(false)
+	// Nethermind's state DB enables unordered_write for its parallel commit
+	// path; our writer relies on ordered batch semantics.
+	opts.SetUnorderedWrite(false)
+	parallelism := runtime.NumCPU()
+	if parallelism > bulkBackgroundJobs {
+		parallelism = bulkBackgroundJobs
+	}
+	opts.IncreaseParallelism(parallelism)
+	opts.SetMaxBackgroundJobs(parallelism)
+}

--- a/client/nethermind/options_cgo.go
+++ b/client/nethermind/options_cgo.go
@@ -16,31 +16,17 @@ import (
 // This file makes state-actor's Nethermind databases carry Nethermind's own
 // RocksDB configuration instead of grocksdb defaults.
 //
-// Nethermind configures every database (and every column family) by
-// concatenating RocksDB option STRINGS — a global default plus per-DB
-// overrides — and feeding the result through rocksdb_get_options_from_string
-// (DbOnTheRocks.BuildOptions). grocksdb exposes the same C entry point as
-// GetOptionsFromString, so instead of hand-porting each knob we execute
-// Nethermind's exact strings, copied verbatim below, and RocksDB's own
-// parser guarantees identical semantics.
+// Nethermind configures every database and column family by concatenating
+// RocksDB option strings — a global default plus per-DB/per-column
+// overrides, later fragments winning — and parsing the result with
+// rocksdb_get_options_from_string (DbOnTheRocks.BuildOptions). grocksdb
+// exposes the same C entry point, so the strings below are executed
+// verbatim and RocksDB's own parser guarantees identical semantics.
 //
-// String provenance: src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
-// at commit 2706ce9e024a679c38c18a9329c7f9f4ba7282da (2026-07-31, tracking
-// 1.39-dev). Composition rule (PerTableDbConfig.ReadRocksdbOptions):
-// effective = RocksDbOptions + <Table>DbRocksDbOptions for plain DBs, and
-// RocksDbOptions + <Table>DbRocksDbOptions + <Table><Column>DbRocksDbOptions
-// for column DBs; later fragments win. Like Nethermind's
-// NormalizeRocksDbOptions, duplicated optimize_filters_for_hits entries are
-// collapsed to the last occurrence before parsing — RocksDB rejects that
-// specific key appearing twice in one string.
-//
-// The strings decide everything persisted in the SST files Nethermind will
-// later read: filter policies (bloomfilter:15 on state, ribbonfilter:10:3 on
-// the flat CFs, none on code), per-DB optimize_filters_for_hits (whether the
-// bottommost level keeps its filters), index types, block sizes, compression,
-// format_version, target file sizes. Transient bulk-import tuning is layered
-// on top afterwards via typed setters (applyBulkImportDeltas) and leaves no
-// trace in the generated files.
+// Provenance: src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs at
+// commit 2706ce9e02 (master, 2026-07-31). Byte-identical to the pinned
+// 1.39.0 release except ReceiptsBlocksDb, which gained two keys on master
+// — both overridden by applyBulkImportDeltas anyway.
 
 // nethDefaultOptions is DbConfig.RocksDbOptions — the base every DB inherits.
 const nethDefaultOptions = "min_write_buffer_number_to_merge=1;" +
@@ -202,8 +188,9 @@ var nethPerDBOptions = map[string]string{
 }
 
 // nethFlatCFOptions maps flat.Column ordinals to their column override
-// fragment. The "default" CF has no Flat<Column>Db entry in DbConfig and
-// inherits the FlatDb base unchanged.
+// fragment. The mandatory "default" CF is absent from Nethermind's
+// FlatDbColumns enum (RocksDbSharp seeds it with raw defaults there); we
+// give it the FlatDb base instead — equivalent for a CF that stays empty.
 var nethFlatCFOptions = map[flat.Column]string{
 	flat.ColMetadata:      nethFlatMetadataCFOptions,
 	flat.ColAccount:       nethFlatAccountCFOptions,
@@ -237,10 +224,9 @@ func normalizeOptimizeFiltersForHits(s string) string {
 	}
 }
 
-// nethOptions composes Nethermind's effective option string for one DB (or
-// one column family) — base + override fragments, later wins — parses it
-// with RocksDB's own parser, and layers state-actor's transient bulk-import
-// tuning on top. The caller owns the returned Options (Destroy after close).
+// nethOptions composes Nethermind's effective option string — base +
+// override fragments, later wins — parses it with RocksDB's parser, and
+// layers the bulk-import tuning on top. Caller owns the returned Options.
 func nethOptions(fragments ...string) (*grocksdb.Options, error) {
 	combined := normalizeOptimizeFiltersForHits(nethDefaultOptions + strings.Join(fragments, ""))
 
@@ -255,11 +241,8 @@ func nethOptions(fragments ...string) (*grocksdb.Options, error) {
 }
 
 // applyBulkImportDeltas overlays state-actor's one-shot import tuning on a
-// parsed Nethermind option bag. Everything here is runtime-only — memtable
-// sizing, compaction scheduling, WAL flushing — and changes nothing about
-// the SST format Nethermind later reads. The write path stays the same as
-// the previous bulkRocksOptions: no compactions during the import, one
-// CompactRange at Close.
+// parsed Nethermind option bag. Runtime-only knobs — nothing here changes
+// the SST format Nethermind later reads.
 func applyBulkImportDeltas(opts *grocksdb.Options) {
 	opts.SetCreateIfMissing(true)
 	opts.SetCreateIfMissingColumnFamilies(true)
@@ -268,11 +251,10 @@ func applyBulkImportDeltas(opts *grocksdb.Options) {
 	opts.SetLevel0FileNumCompactionTrigger(math.MaxInt32)
 	opts.SetLevel0SlowdownWritesTrigger(math.MaxInt32)
 	opts.SetLevel0StopWritesTrigger(math.MaxInt32)
-	// Nethermind flushes the flat DB's WAL manually from its persistence
-	// layer; state-actor has no equivalent, so let RocksDB manage the WAL.
+	// Reversals of Nethermind runtime behaviours we have no equivalent for:
+	// its persistence layer flushes the flat DB's WAL manually, and its
+	// parallel commit path wants unordered_write; ours does neither.
 	opts.SetManualWALFlush(false)
-	// Nethermind's state DB enables unordered_write for its parallel commit
-	// path; our writer relies on ordered batch semantics.
 	opts.SetUnorderedWrite(false)
 	parallelism := runtime.NumCPU()
 	if parallelism > bulkBackgroundJobs {

--- a/client/nethermind/options_cgo_test.go
+++ b/client/nethermind/options_cgo_test.go
@@ -10,13 +10,9 @@ import (
 	"testing"
 )
 
-// TestNethOptionsPersisted opens the full Nethermind DB set with the
-// composed option strings and asserts that the settings Nethermind will
-// rely on were actually recorded by RocksDB — i.e. that GetOptionsFromString
-// accepted and applied the verbatim DbConfig fragments. RocksDB writes the
-// effective (post-parse) configuration to each DB's OPTIONS-* file, per
-// column family, which is the same evidence a mainnet Nethermind LOG/OPTIONS
-// diff would use.
+// TestNethOptionsPersisted opens the full Nethermind DB set and asserts
+// the composed DbConfig strings were accepted and applied, via the
+// effective per-CF configuration RocksDB records in each OPTIONS-* file.
 func TestNethOptionsPersisted(t *testing.T) {
 	dir := t.TempDir()
 	dbs, err := openNethDBs(dir)
@@ -39,7 +35,6 @@ func TestNethOptionsPersisted(t *testing.T) {
 			{`[TableOptions/BlockBasedTable "default"]`, "index_type=kTwoLevelIndexSearch"},
 		},
 		dbNameCode: {
-			// "Bloom crash with kHashSearch index" — code must have NO filter.
 			{`[TableOptions/BlockBasedTable "default"]`, "filter_policy=nullptr"},
 			{`[TableOptions/BlockBasedTable "default"]`, "index_type=kHashSearch"},
 			{`[CFOptions "default"]`, "optimize_filters_for_hits=false"},
@@ -49,11 +44,9 @@ func TestNethOptionsPersisted(t *testing.T) {
 			{`[CFOptions "default"]`, "compaction_pri=kOldestLargestSeqFirst"},
 		},
 		dbNameFlat: {
-			// Account: uncompressed, 4K blocks, keeps last-level filters.
 			{`[CFOptions "Account"]`, "compression=kNoCompression"},
 			{`[CFOptions "Account"]`, "optimize_filters_for_hits=false"},
 			{`[TableOptions/BlockBasedTable "Account"]`, "block_size=4096"},
-			// Trie-node columns: dynamic level bytes back on.
 			{`[CFOptions "StateNodes"]`, "level_compaction_dynamic_level_bytes=true"},
 			{`[TableOptions/BlockBasedTable "Storage"]`, "block_size=8000"},
 			{`[TableOptions/BlockBasedTable "StateTopNodes"]`, "index_type=kBinarySearch"},
@@ -72,9 +65,8 @@ func TestNethOptionsPersisted(t *testing.T) {
 				t.Errorf("%s %s: missing %q", db, c.section, c.want)
 			}
 		}
-		// Filter policies: every state/flat table must have SOME filter
-		// (bloom on state, ribbon on flat) — the exact serialization of the
-		// policy name varies across RocksDB versions, so assert non-null.
+		// Every state/flat table must have SOME filter — the exact policy
+		// serialization varies across RocksDB versions, so assert non-null.
 		if db == dbNameState || db == dbNameFlat {
 			for name, body := range sections {
 				if !strings.HasPrefix(name, `[TableOptions/BlockBasedTable`) {

--- a/client/nethermind/options_cgo_test.go
+++ b/client/nethermind/options_cgo_test.go
@@ -61,7 +61,9 @@ func TestNethOptionsPersisted(t *testing.T) {
 				t.Errorf("%s: OPTIONS file has no section %s (have: %v)", db, c.section, sectionNames(sections))
 				continue
 			}
-			if !strings.Contains(body, c.want+"\n") && !strings.HasSuffix(body, c.want) {
+			// Full-line match: a substring check would let e.g.
+			// metadata_block_size=4096 satisfy a block_size=4096 case.
+			if !strings.Contains("\n"+body, "\n"+c.want+"\n") {
 				t.Errorf("%s %s: missing %q", db, c.section, c.want)
 			}
 		}

--- a/client/nethermind/options_cgo_test.go
+++ b/client/nethermind/options_cgo_test.go
@@ -1,0 +1,129 @@
+//go:build cgo_neth
+
+package nethermind
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestNethOptionsPersisted opens the full Nethermind DB set with the
+// composed option strings and asserts that the settings Nethermind will
+// rely on were actually recorded by RocksDB — i.e. that GetOptionsFromString
+// accepted and applied the verbatim DbConfig fragments. RocksDB writes the
+// effective (post-parse) configuration to each DB's OPTIONS-* file, per
+// column family, which is the same evidence a mainnet Nethermind LOG/OPTIONS
+// diff would use.
+func TestNethOptionsPersisted(t *testing.T) {
+	dir := t.TempDir()
+	dbs, err := openNethDBs(dir)
+	if err != nil {
+		t.Fatalf("openNethDBs: %v", err)
+	}
+	dbs.Close()
+
+	type check struct {
+		section string // OPTIONS-file section header prefix
+		want    string // line that must appear inside it
+	}
+	cases := map[string][]check{ // key = DB subdir
+		dbNameState: {
+			{`[CFOptions "default"]`, "optimize_filters_for_hits=true"},
+			{`[CFOptions "default"]`, "compression=kLZ4Compression"},
+			{`[CFOptions "default"]`, "level_compaction_dynamic_level_bytes=false"},
+			{`[CFOptions "default"]`, "max_bytes_for_level_multiplier=30.000000"},
+			{`[TableOptions/BlockBasedTable "default"]`, "block_size=32000"},
+			{`[TableOptions/BlockBasedTable "default"]`, "index_type=kTwoLevelIndexSearch"},
+		},
+		dbNameCode: {
+			// "Bloom crash with kHashSearch index" — code must have NO filter.
+			{`[TableOptions/BlockBasedTable "default"]`, "filter_policy=nullptr"},
+			{`[TableOptions/BlockBasedTable "default"]`, "index_type=kHashSearch"},
+			{`[CFOptions "default"]`, "optimize_filters_for_hits=false"},
+		},
+		dbNameBlocks: {
+			{`[CFOptions "default"]`, "optimize_filters_for_hits=false"},
+			{`[CFOptions "default"]`, "compaction_pri=kOldestLargestSeqFirst"},
+		},
+		dbNameFlat: {
+			// Account: uncompressed, 4K blocks, keeps last-level filters.
+			{`[CFOptions "Account"]`, "compression=kNoCompression"},
+			{`[CFOptions "Account"]`, "optimize_filters_for_hits=false"},
+			{`[TableOptions/BlockBasedTable "Account"]`, "block_size=4096"},
+			// Trie-node columns: dynamic level bytes back on.
+			{`[CFOptions "StateNodes"]`, "level_compaction_dynamic_level_bytes=true"},
+			{`[TableOptions/BlockBasedTable "Storage"]`, "block_size=8000"},
+			{`[TableOptions/BlockBasedTable "StateTopNodes"]`, "index_type=kBinarySearch"},
+		},
+	}
+
+	for db, checks := range cases {
+		sections := optionsFileSections(t, filepath.Join(dir, db))
+		for _, c := range checks {
+			body, ok := sections[c.section]
+			if !ok {
+				t.Errorf("%s: OPTIONS file has no section %s (have: %v)", db, c.section, sectionNames(sections))
+				continue
+			}
+			if !strings.Contains(body, c.want+"\n") && !strings.HasSuffix(body, c.want) {
+				t.Errorf("%s %s: missing %q", db, c.section, c.want)
+			}
+		}
+		// Filter policies: every state/flat table must have SOME filter
+		// (bloom on state, ribbon on flat) — the exact serialization of the
+		// policy name varies across RocksDB versions, so assert non-null.
+		if db == dbNameState || db == dbNameFlat {
+			for name, body := range sections {
+				if !strings.HasPrefix(name, `[TableOptions/BlockBasedTable`) {
+					continue
+				}
+				for _, line := range strings.Split(body, "\n") {
+					line = strings.TrimSpace(line)
+					if strings.HasPrefix(line, "filter_policy=") && strings.Contains(line, "nullptr") {
+						t.Errorf("%s %s: filter_policy is nullptr, expected a real filter", db, name)
+					}
+				}
+			}
+		}
+	}
+}
+
+// optionsFileSections parses the newest OPTIONS-* file of a RocksDB dir into
+// section-header → body.
+func optionsFileSections(t *testing.T, dir string) map[string]string {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "OPTIONS-*"))
+	if err != nil || len(matches) == 0 {
+		t.Fatalf("no OPTIONS-* in %s (err=%v)", dir, err)
+	}
+	sort.Strings(matches)
+	raw, err := os.ReadFile(matches[len(matches)-1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	sections := make(map[string]string)
+	var current string
+	for _, line := range strings.Split(string(raw), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") {
+			current = trimmed
+			continue
+		}
+		if current != "" && trimmed != "" {
+			sections[current] += trimmed + "\n"
+		}
+	}
+	return sections
+}
+
+func sectionNames(m map[string]string) []string {
+	names := make([]string, 0, len(m))
+	for k := range m {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}


### PR DESCRIPTION
This PR copies Nethermind configuration such that we create a database equal (or at least close to) the Nethermind code it references.