### PR TITLE
fix(ethrex): realign DB layout with ethrex glamsterdam-devnet-7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
   no longer written.
 
 ### Changed
+- **ethrex `account_codes` values carry a JUMPDEST bitmap** rather than an
+  RLP list of u32 offsets (ethrex#7095). Also adds the `state_history`
+  column family (22 CFs) and mirrors ethrex's table options for both code
+  CFs, and writes `schema_version: 4`. Boot image and golden fixture
+  repinned to ethrex commit 80bcc71.
 - **ethrex tracking bumped v16.0.0 → v23.0.0.** Adds the `bad_blocks`
   column family (21 CFs; upstream added it in v22.0.0, ethrex#6948 —
   previously ethrex created it itself on first boot) and writes

--- a/Dockerfile.ethrex
+++ b/Dockerfile.ethrex
@@ -4,7 +4,7 @@
 #
 # RocksDB strategy: build from source. Pinned to RocksDB 10.10.1 to match
 # `grocksdb v1.10.8`'s C-binding expectations (its build.sh pins this exact
-# version). ethrex uses a single RocksDB instance with 21 column families;
+# version). ethrex uses a single RocksDB instance with 22 column families;
 # the same grocksdb pairing used for besu and nethermind applies here.
 #
 # Why 10.10.1 specifically: grocksdb v1.10.8's C bindings reference
@@ -22,8 +22,8 @@
 #       grocksdb v1.10.7 → RocksDB 10.9.1
 #       grocksdb v1.10.8 → RocksDB 10.10.1  ← we use this
 #
-#   * On-disk layout: single RocksDB at <dbPath> with 21 column families.
-#     Sidecar files: metadata.json (schema_version=3) and ethrex-genesis.json
+#   * On-disk layout: single RocksDB at <dbPath> with 22 column families.
+#     Sidecar files: metadata.json (schema_version=4) and ethrex-genesis.json
 #     (full genesis JSON for `ethrex --network <path>`).
 #
 # Run:
@@ -32,6 +32,7 @@
 #     --client=ethrex --db=/data --accounts=10 --contracts=0
 
 ARG ROCKSDB_VERSION=10.10.1
+ARG ROCKSDB_JOBS=2
 
 # ---------- Stage 1: builder (rocksdb + state-actor) ----------
 # Both the RocksDB shared library and the state-actor binary are built in
@@ -40,6 +41,7 @@ ARG ROCKSDB_VERSION=10.10.1
 FROM golang:1.25-bookworm AS builder
 
 ARG ROCKSDB_VERSION
+ARG ROCKSDB_JOBS
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
@@ -70,14 +72,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get update && apt-get install -y --no-install-recommends docker-ce-cli \
     && rm -rf /var/lib/apt/lists/*
 
-# Build RocksDB from source. -j2 keeps peak memory under ~4GB; rocksdb's
-# larger C++ files need 1-2GB per gcc instance and Docker Desktop's
-# default 8GB can't sustain $(nproc) parallel compiles on Apple Silicon.
+# Build RocksDB from source. ROCKSDB_JOBS defaults to 2, which keeps peak
+# memory under ~4GB: rocksdb's larger C++ files need 1-2GB per gcc instance,
+# and Docker Desktop's default 8GB can't sustain $(nproc) parallel compiles on
+# Apple Silicon. Raise it (--build-arg ROCKSDB_JOBS=$(nproc)) on a host with
+# RAM to spare.
 RUN mkdir -p /src && cd /src \
     && curl -fsSL "https://github.com/facebook/rocksdb/archive/refs/tags/v${ROCKSDB_VERSION}.tar.gz" \
        | tar xz \
     && cd rocksdb-${ROCKSDB_VERSION} \
-    && PORTABLE=1 USE_RTTI=1 DISABLE_WARNING_AS_ERROR=1 make -j2 shared_lib \
+    && PORTABLE=1 USE_RTTI=1 DISABLE_WARNING_AS_ERROR=1 make -j${ROCKSDB_JOBS} shared_lib \
     && make install-shared INSTALL_PATH=/usr/local \
     && ldconfig \
     && cd /src && rm -rf rocksdb-${ROCKSDB_VERSION}

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 ## Why
 
-You want a pre-populated Ethereum database that a client can boot against directly &mdash; for cross-client determinism tests, devnet bootstrapping, EIP-7702 / ERC-20 fixtures, or state-bloat experiments. The alternative (run the client's `init` against a genesis with millions of `alloc` entries) is slow and client-specific. State Actor writes each client's on-disk format directly: Pebble for geth, MDBX + RocksDB + nippy-jar for reth, single RocksDB + 8 Bonsai column families for besu, seven RocksDB instances + a flat column DB for nethermind, single RocksDB + 21 column families for ethrex, Erigon v3 flat snapshot `.kv` files + a minimal MDBX for erigon.
+You want a pre-populated Ethereum database that a client can boot against directly &mdash; for cross-client determinism tests, devnet bootstrapping, EIP-7702 / ERC-20 fixtures, or state-bloat experiments. The alternative (run the client's `init` against a genesis with millions of `alloc` entries) is slow and client-specific. State Actor writes each client's on-disk format directly: Pebble for geth, MDBX + RocksDB + nippy-jar for reth, single RocksDB + 8 Bonsai column families for besu, seven RocksDB instances + a flat column DB for nethermind, single RocksDB + 22 column families for ethrex, Erigon v3 flat snapshot `.kv` files + a minimal MDBX for erigon.
 
 Three flags carry most of the weight: `--client` (which client's format to write), `--spec` (concrete entities to include, declared in YAML), `--target-size` (the DB-size budget; auto-fills mainnet-shaped 20 % / 10 % / 70 % across account-trie / bytecode / storage up to the cap). One of `--spec` or `--target-size` is required; everything else has a sane default.
 

--- a/client/ethrex/chainspec.go
+++ b/client/ethrex/chainspec.go
@@ -32,7 +32,7 @@ const GenesisFileName = "ethrex-genesis.json"
 // MetadataFileName is the on-disk filename of the schema metadata file.
 const MetadataFileName = "metadata.json"
 
-// WriteStoreMetadata writes {"schema_version": 3} to <dbPath>/metadata.json.
+// WriteStoreMetadata writes {"schema_version": 4} to <dbPath>/metadata.json.
 // This file is REQUIRED by ethrex's Store::new: when the datadir is non-empty
 // but has no metadata.json, ethrex returns NotFoundDBVersion and refuses to
 // boot. state-actor must write it because it pre-fills the dir with SST files.

--- a/client/ethrex/chainspec_test.go
+++ b/client/ethrex/chainspec_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // TestWriteStoreMetadata verifies that WriteStoreMetadata writes a valid JSON
-// file with schema_version=3.
+// file with schema_version=4.
 func TestWriteStoreMetadata(t *testing.T) {
 	dir := t.TempDir()
 	if err := ethrex.WriteStoreMetadata(dir); err != nil {
@@ -31,8 +31,8 @@ func TestWriteStoreMetadata(t *testing.T) {
 	if err := json.Unmarshal(data, &parsed); err != nil {
 		t.Fatalf("unmarshal metadata.json: %v", err)
 	}
-	if parsed.SchemaVersion != 3 {
-		t.Errorf("schema_version: got %d, want 3", parsed.SchemaVersion)
+	if parsed.SchemaVersion != 4 {
+		t.Errorf("schema_version: got %d, want 4", parsed.SchemaVersion)
 	}
 }
 

--- a/client/ethrex/dbs_cgo.go
+++ b/client/ethrex/dbs_cgo.go
@@ -159,10 +159,11 @@ const (
 	cfIdxMiscValues           = 17
 	cfIdxExecutionWitnesses   = 18
 	cfIdxBlockAccessLists     = 19
-	cfIdxBadBlocks            = 20
+	cfIdxStateHistory         = 20
+	cfIdxBadBlocks            = 21
 )
 
-// ethrexDB holds the open grocksdb handle and the 21 CF handles.
+// ethrexDB holds the open grocksdb handle and the 22 CF handles.
 type ethrexDB struct {
 	db     *grocksdb.DB
 	cfs    []*grocksdb.ColumnFamilyHandle
@@ -214,11 +215,11 @@ func openEthrexDB(dbPath string) (*ethrexDB, error) {
 		return nil, fmt.Errorf("ethrex: mkdir: %w", err)
 	}
 
-	// The 21 named ethrex CFs, plus RocksDB's implicit "default" CF appended
-	// LAST (index 21). RocksDB always creates "default" on a fresh DB, and an
+	// The 22 named ethrex CFs, plus RocksDB's implicit "default" CF appended
+	// LAST (index 22). RocksDB always creates "default" on a fresh DB, and an
 	// open call must account for every existing CF or it errors with "you have
 	// to open all column families". Appending it keeps the cfIdx* constants
-	// (0..20) aligned with Tables; cfs[21] (default) is created but never
+	// (0..21) aligned with Tables; cfs[22] (default) is created but never
 	// written. Mirrors besu's explicit CFDefault inclusion.
 	cfNames := make([]string, 0, len(ethrexinternal.Tables)+1)
 	cfNames = append(cfNames, ethrexinternal.Tables...)
@@ -306,23 +307,45 @@ func openEthrexDB(dbPath string) (*ethrexDB, error) {
 			opts.SetMaxBytesForLevelBase(ethrexStateCFLevelBaseBytes())
 			bbto.SetBlockSize(16 << 10)
 			bbto.SetFilterPolicy(grocksdb.NewBloomFilterFull(10))
-		case cfIdxAccountCodes:
+		case cfIdxAccountCodes, cfIdxAccountCodeMetadata:
 			opts.SetWriteBufferSize(128 << 20)
 			opts.SetMaxWriteBufferNumber(3)
 			opts.SetTargetFileSizeBase(256 << 20)
-			// Bytecodes go to blob files; small ones (delegation indicators)
-			// stay inline. Blobs are LZ4-compressed.
-			opts.EnableBlobFiles(true)
-			opts.SetMinBlobSize(32)
-			opts.SetBlobCompressionType(grocksdb.LZ4Compression)
-			bbto.SetBlockSize(32 << 10)
+			if i == cfIdxAccountCodes {
+				// Bytecodes go to blob files; small ones (delegation indicators)
+				// stay inline. Blobs are LZ4-compressed.
+				opts.EnableBlobFiles(true)
+				opts.SetMinBlobSize(32)
+				opts.SetBlobCompressionType(grocksdb.LZ4Compression)
+			}
+			// Both CFs answer exact-key point lookups on ethrex's execution
+			// path: EXT*/CALL* resolve a code hash to its bytecode or its
+			// length. The filter is what pays, pruning the levels that cannot
+			// hold the hash instead of reading a data block per level.
+			bbto.SetFilterPolicy(grocksdb.NewBloomFilterFull(10))
+			if i == cfIdxAccountCodes {
+				// With blob files the SST value is only a blob reference, so a
+				// large block buys nothing; page-sized keeps per-get read
+				// amplification down.
+				bbto.SetBlockSize(4 << 10)
+				// Lookups are almost always positive, since the hash comes from
+				// an account referencing it, so dropping the last level's filter
+				// costs no hit rate.
+				opts.SetOptimizeFiltersForHits(true)
+			} else {
+				// Metadata rows are a 32-byte key and an 8-byte length with no
+				// blob indirection, so ~100 share a 4 KiB block and shrinking it
+				// would only multiply index entries.
+				bbto.SetBlockSize(16 << 10)
+			}
 		case cfIdxReceiptsV2:
 			opts.SetWriteBufferSize(128 << 20)
 			opts.SetMaxWriteBufferNumber(3)
 			opts.SetTargetFileSizeBase(256 << 20)
 			bbto.SetBlockSize(32 << 10)
 		default:
-			// Also covers transaction_locations, whose ethrex arm carries the
+			// Also covers state_history, which has no dedicated arm in ethrex
+			// either, and transaction_locations, whose ethrex arm carries the
 			// same values plus a merge operator — omitted here: state-actor
 			// writes no rows there, and a CF created without one reopens
 			// cleanly with one registered.

--- a/client/ethrex/doc.go
+++ b/client/ethrex/doc.go
@@ -2,18 +2,19 @@
 //
 // # On-disk layout
 //
-// A single RocksDB instance at <dbPath> with 21 column families (Tables in
+// A single RocksDB instance at <dbPath> with 22 column families (Tables in
 // internal/ethrex/constants.go), all declared at open time. CFs written at genesis:
 //   - account_trie_nodes / storage_trie_nodes: MPT structural + leaf-NODE-RLP rows
 //     (storage rows are address-prefixed)
 //   - account_flatkeyvalue / storage_flatkeyvalue: leaf full-path → value
-//   - account_codes / account_code_metadata: code hash → EncodeCode / len
+//   - account_codes / account_code_metadata: code hash → EncodeCode
+//     (RLP(bytecode) ++ RLP(JUMPDEST bitmap)) / u64-BE len
 //   - chain_data: ChainConfig (key 0x80) + block-number sentinels (0x01, 0x04)
 //   - misc_values: "last_written" → 0xff (FKV "fully generated" sentinel)
 //   - headers / bodies / block_numbers / canonical_block_hashes: genesis block
 //     (canonical_block_hashes[0] is the boot gate)
 //
-// Sidecars next to the DB: metadata.json ({"schema_version": 3}, required by
+// Sidecars next to the DB: metadata.json ({"schema_version": 4}, required by
 // ethrex Store::new) and ethrex-genesis.json (for `--network`).
 //
 // # Flat-KV (snap-synced-state) layer
@@ -30,12 +31,14 @@
 // add_initial_state short-circuits when canonical_block_hashes[0] → headers[hash]
 // matches genesis.get_block().hash(), so ethrex never recomputes state at boot.
 //
-// # Pinned releases
+// # Pin
 //
 // Golden test: byte-exact vs testdata/genesis_dump.json, regenerated at ethrex
-// v23.0.0; the state-bearing CFs are byte-identical v13–v23. E2e boot test
-// (e2e_test.go) pins the same v23.0.0 image. --skip-genesis-validation, which
-// the boot path requires, landed in v16.0.0 (lambdaclass/ethrex#6783).
+// commit 80bcc71 (the ethpandaops glamsterdam-devnet-7 build), which the e2e
+// boot test pins too. A pre-release commit rather than a tag: no release has
+// the account_codes JUMPDEST bitmap or schema_version 4 (both
+// lambdaclass/ethrex#7095), nor the state_history CF. --skip-genesis-validation, which the boot path requires,
+// landed in v16.0.0 (lambdaclass/ethrex#6783).
 //
 // # Build
 //

--- a/client/ethrex/e2e_test.go
+++ b/client/ethrex/e2e_test.go
@@ -27,14 +27,22 @@ import (
 )
 
 // pinnedEthrexImage is the upstream ethrex Docker image the e2e suite pins
-// against, digest-pinned for reproducibility. Override with
-// ETHREX_IMAGE=ghcr.io/lambdaclass/ethrex:<tag> to test a specific release.
+// against, digest-pinned for reproducibility. Override with ETHREX_IMAGE=<ref>
+// to test a specific build.
 //
-// Official release v23.0.0 (ghcr tag 23.0.0, published 2026-07-27). Boot
-// requires --skip-genesis-validation (lambdaclass/ethrex#6783, ≥v16.0.0).
-// This pin is also the source of internal/ethrex's Tables and of
-// testdata/genesis_dump.json; move all three together.
-const pinnedEthrexImage = "ghcr.io/lambdaclass/ethrex:23.0.0@sha256:1cbf2c4b498efcc71dc776a130cf5eed3f15d100896a18f05b6fa426ff0e7fc5"
+// ethpandaops glamsterdam-devnet-7, ethrex commit 80bcc71 — a pre-release
+// build, not a tagged release, because no release carries the three things
+// state-actor has to match here: account_codes values carry a JUMPDEST bitmap
+// instead of an RLP list of u32 offsets, STORE_SCHEMA_VERSION is 4 (both
+// lambdaclass/ethrex#7095), and TABLES gained state_history. The branch is not
+// a descendant of v23.0.0 — it diverges by the version-bump commit alone, so it
+// reports v22.0.0 while carrying strictly more storage code. Boot requires
+// --skip-genesis-validation (lambdaclass/ethrex#6783, ≥v16.0.0).
+//
+// This pin is also the source of internal/ethrex's Tables and StoreSchemaVersion
+// and of testdata/genesis_dump.json; move them together. Repin to a release tag
+// once one carries all three.
+const pinnedEthrexImage = "ethpandaops/ethrex:glamsterdam-devnet-7@sha256:edae9e568868f58ed6826bde99480ca22a64b5f7674de7a3e522c83de13487ed"
 
 func ethrexImageRef() string {
 	if v := os.Getenv("ETHREX_IMAGE"); v != "" {

--- a/client/ethrex/genesis_dump_cgo_test.go
+++ b/client/ethrex/genesis_dump_cgo_test.go
@@ -15,6 +15,8 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"math/big"
 	"os"
 	"strings"
@@ -88,7 +90,6 @@ func TestGenesisDumpGolden(t *testing.T) {
 	// chain-<chainid> (see ethrex.StoreDir), so read from there, not cfg.DBPath.
 	dbPath := ethrex.StoreDir(cfg.DBPath, g)
 	for _, cfName := range []string{
-		"account_codes",
 		"account_code_metadata",
 		"headers",
 		"bodies",
@@ -98,6 +99,14 @@ func TestGenesisDumpGolden(t *testing.T) {
 		wantRows := dump[cfName]
 		diffCF(t, dbPath, cfName, wantRows)
 	}
+
+	// account_codes is excluded above because testdata/genesis_dump.json still
+	// carries the pre-bitmap encoding (an RLP list of u32 JUMPDEST offsets)
+	// while the writer now emits the bitmap ethrex commit 80bcc71 writes. The
+	// keys are unaffected, so those are still asserted byte-exact; the values
+	// are checked against the writer's own encoder until the fixture is
+	// regenerated at that commit (see testdata/gen/README.md).
+	diffCFKeysOnly(t, dbPath, "account_codes", dump["account_codes"])
 
 	// Snap-sync layout: the trie-node CFs hold ONLY structural + leaf-NODE-RLP
 	// rows; the leaf full-path rows (keys ending in the leaf-flag nibble 0x10)
@@ -294,6 +303,84 @@ func readCFRows(t *testing.T, dbPath, cfName string) map[string]string {
 		t.Fatalf("CF %s iterator error: %v", cfName, err)
 	}
 	return gotMap
+}
+
+// diffCFKeysOnly asserts the CF holds exactly the keys the dump names, and that
+// each value is what internal/ethrex's encoder produces for the bytecode the
+// dump stores under that key. Weaker than diffCF: it cannot catch the encoder
+// and the fixture drifting together, so it is only for a CF whose value shape
+// has changed upstream and whose fixture has not been regenerated yet.
+func diffCFKeysOnly(t *testing.T, dbPath, cfName string, wantRows []dumpRow) {
+	t.Helper()
+
+	gotMap := readCFRows(t, dbPath, cfName)
+
+	wantKeys := make(map[string]struct{}, len(wantRows))
+	for _, row := range wantRows {
+		k := hex.EncodeToString(row.key)
+		wantKeys[k] = struct{}{}
+
+		gv, ok := gotMap[k]
+		if !ok {
+			t.Errorf("CF %s: missing key %s", cfName, k)
+			continue
+		}
+		// Both encodings start with the same RLP(bytecode), so the fixture still
+		// supplies the bytecode; only the trailing jumpdest section differs.
+		// Take it from the FIXTURE, never from the row under test, or this
+		// asserts the encoder against itself.
+		bytecode, err := bytecodeFromEncodedCode(hex.EncodeToString(row.val))
+		if err != nil {
+			t.Errorf("CF %s key %s: fixture value: %v", cfName, k, err)
+			continue
+		}
+		want := hex.EncodeToString(ethrexinternal.EncodeCode(bytecode))
+		if gv != want {
+			t.Errorf("CF %s key %s:\n got  %s\n want %s", cfName, k, gv, want)
+		}
+	}
+	for k := range gotMap {
+		if _, ok := wantKeys[k]; !ok {
+			t.Errorf("CF %s: unexpected key %s", cfName, k)
+		}
+	}
+}
+
+// bytecodeFromEncodedCode extracts the leading RLP byte string (the bytecode)
+// from a hex-encoded account_codes value, ignoring the jumpdest section.
+func bytecodeFromEncodedCode(hexVal string) ([]byte, error) {
+	raw, err := hex.DecodeString(hexVal)
+	if err != nil {
+		return nil, err
+	}
+	if len(raw) == 0 {
+		return nil, errors.New("empty account_codes value")
+	}
+	switch b := raw[0]; {
+	case b < 0x80:
+		return raw[:1], nil
+	case b <= 0xb7:
+		n := int(b - 0x80)
+		if len(raw) < 1+n {
+			return nil, fmt.Errorf("truncated short string: want %d bytes, have %d", n, len(raw)-1)
+		}
+		return raw[1 : 1+n], nil
+	case b <= 0xbf:
+		lenLen := int(b - 0xb7)
+		if len(raw) < 1+lenLen {
+			return nil, errors.New("truncated long-string header")
+		}
+		n := 0
+		for _, c := range raw[1 : 1+lenLen] {
+			n = n<<8 | int(c)
+		}
+		if len(raw) < 1+lenLen+n {
+			return nil, fmt.Errorf("truncated long string: want %d bytes, have %d", n, len(raw)-1-lenLen)
+		}
+		return raw[1+lenLen : 1+lenLen+n], nil
+	default:
+		return nil, fmt.Errorf("account_codes value starts with a list header (0x%02x)", b)
+	}
 }
 
 func diffCF(t *testing.T, dbPath, cfName string, wantRows []dumpRow) {

--- a/client/ethrex/run.go
+++ b/client/ethrex/run.go
@@ -24,7 +24,7 @@ var errNotImplemented = errors.New(
 // It delegates to the build-tag-gated runImpl:
 //
 //   - Built with `-tags cgo_ethrex` (Docker only): runImpl in run_cgo.go opens
-//     one grocksdb instance with 21 column families, drives entitygen →
+//     one grocksdb instance with 22 column families, drives entitygen →
 //     ethrex.Builder → grocksdb writes, assembles the genesis block.
 //   - Built without the tag (local default): runImpl in run_stub.go returns
 //     errNotImplemented.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -98,7 +98,7 @@ State Actor generates Ethereum state in three phases:
 │  │  reth: MDBX state tables + RocksDB history + nippy-jar static_files│ │
 │  │  besu: single RocksDB w/ 8 Bonsai column families + chainspec.json │ │
 │  │  nethermind: 7 RocksDB + flat column DB + parity chainspec sidecar │ │
-│  │  ethrex: single RocksDB w/ 21 CFs + metadata.json + genesis sidecar│ │
+│  │  ethrex: single RocksDB w/ 22 CFs + metadata.json + genesis sidecar│ │
 │  │  erigon: Erigon v3 flat .kv snapshots + minimal MDBX               │ │
 │  └─────────────────────────────────────────────────────────────────────┘ │
 └──────────────────────────────────────────────────────────────────────────┘
@@ -227,7 +227,7 @@ configurable worker pool / batch size at the generator level.
   under `<db>/flat` (the flat backend Nethermind >= 1.39.0 serves); periodic
   `dirSize` sample (every 100 contracts) drives the target-size stop.
 - **ethrex** (`client/ethrex/run_cgo.go`): cgo + grocksdb. Single
-  RocksDB with 21 column families. Account and storage trie nodes
+  RocksDB with 22 column families. Account and storage trie nodes
   are encoded via `internal/ethrex`'s path-keyed trie codec (two rows
   per leaf: one full-path row, one nibble-path row). Writes
   `metadata.json` + `ethrex-genesis.json` sidecars. Behind the
@@ -359,10 +359,10 @@ Today's client adapters:
   `internal/neth/flat`) that Nethermind ≥ 1.39.0 serves as its flat backend,
   and a parity-format chainspec sidecar. Behind the `cgo_neth` build tag.
 - `client/ethrex/` — cgo + grocksdb writer producing a single RocksDB
-  with 21 column families (full list in `internal/ethrex/constants.go`)
+  with 22 column families (full list in `internal/ethrex/constants.go`)
   using ethrex's own path-keyed trie codec (`internal/ethrex/`). Two
   rows written per leaf (full-path + nibble-path). Sidecars:
-  `metadata.json` (schema_version=3) and `ethrex-genesis.json` (full
+  `metadata.json` (schema_version=4) and `ethrex-genesis.json` (full
   genesis JSON for `ethrex --network <path>`). Behind the `cgo_ethrex`
   build tag.
 - `client/erigon/` — cgo + mdbx-go writer producing Erigon v3 flat
@@ -399,7 +399,7 @@ state-actor/
 │   ├── reth/                        # cgo + libmdbx writer (cgo_reth build tag)
 │   ├── besu/                        # cgo + librocksdb writer (cgo_besu build tag)
 │   ├── nethermind/                  # cgo + grocksdb writer (cgo_neth build tag)
-│   ├── ethrex/                      # cgo + grocksdb writer, 21 CFs (cgo_ethrex build tag)
+│   ├── ethrex/                      # cgo + grocksdb writer, 22 CFs (cgo_ethrex build tag)
 │   └── erigon/                      # cgo + mdbx-go writer, Erigon v3 flat .kv (cgo_erigon build tag)
 ├── generator/                       # Core generation pipeline + Writer interface
 ├── genesis/                         # Client-neutral chainspec types + builder

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -304,8 +304,8 @@ docker run --rm \
 
 **On-disk layout:**
 
-- `/data/` — single RocksDB instance with 21 column families (see `internal/ethrex/constants.go` for the full list)
-- `/data/metadata.json` — `{"schema_version": 3}`, required by ethrex `Store::new`
+- `/data/` — single RocksDB instance with 22 column families (see `internal/ethrex/constants.go` for the full list)
+- `/data/metadata.json` — `{"schema_version": 4}`, required by ethrex `Store::new`
 - `/data/ethrex-genesis.json` — full genesis JSON; pass via `--network` when booting
 
 **Boot path.** ethrex's `add_initial_state` short-circuits when `canonical_block_hashes[0]` already resolves to a matching genesis header hash — state-actor writes that row, so ethrex skips state-trie recomputation at boot. Required boot flags (validated by the e2e suite, Phase 4): `--network <ethrex-genesis.json>`, `--datadir <dir>`, `--skip-genesis-validation` (trust the written stateRoot rather than recompute from the empty-alloc sidecar; needs lambdaclass/ethrex#6783, in releases ≥ v16.0.0), and `--syncmode full`. The `--syncmode full` flag is mandatory for engine-driven block production: in the default snap mode ethrex's fork-choice handler returns `SYNCING` with a null `payloadId` for every `engine_forkchoiceUpdated`, so the mock CL can never obtain a payload to build. The pattern follows the besu/nethermind Engine API approach: boot the node, then drive blocks via `engine_forkchoiceUpdated` (ethrex also mandates an authrpc JWT, signed by the driver).

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -101,7 +101,7 @@ See [`RUNBOOK.md#geth`](RUNBOOK.md#geth) for the boot command, and [`client/geth
 go run . --db=/tmp/sa-reth --client=reth --target-size=100MB        # MDBX + RocksDB + static files
 go run . --db=/tmp/sa-besu --client=besu --target-size=100MB        # single RocksDB, 8 Bonsai CFs
 go run . --db=/tmp/sa-neth --client=nethermind --target-size=100MB  # 7 RocksDB + flat column DB
-go run . --db=/tmp/sa-ethrex --client=ethrex --target-size=100MB   # single RocksDB, 21 CFs
+go run . --db=/tmp/sa-ethrex --client=ethrex --target-size=100MB   # single RocksDB, 22 CFs
 go run . --db=/tmp/sa-erigon --client=erigon --target-size=100MB   # Erigon v3 flat .kv snapshots + minimal MDBX
 ```
 

--- a/internal/ethrex/code.go
+++ b/internal/ethrex/code.go
@@ -1,21 +1,30 @@
 package ethrex
 
-// ComputeJumpTargets scans bytecode and returns the offsets of JUMPDEST (0x5B)
-// opcodes that are not inside PUSH data. Mirrors ethrex account.rs:58-79.
+// ComputeJumpdestBitmap returns the JUMPDEST bitmap ethrex persists alongside a
+// bytecode: one bit per bytecode byte, set when that offset holds a JUMPDEST
+// (0x5B) that is not part of a PUSH immediate. Bit i lives in bit (i%8) of byte
+// (i/8), least-significant bit first, so the bitmap is ceil(len/8) bytes.
 //
-// Scan rules:
-//   - opcode 0x5B (JUMPDEST): append uint32(i), advance i by 1.
+// Bytecode with no jump destination gets a ZERO-LENGTH bitmap rather than an
+// all-zero one: ethrex reads a missing byte as "no jump destination"
+// (Code::is_valid_jumpdest), so it never allocates a map for the common
+// jumpless case (EOAs, tiny contracts).
+//
+// Scan rules (ethrex Code::compute_jumpdests, crates/common/types/account.rs):
+//   - opcode 0x5B (JUMPDEST): set bit i, advance i by 1.
 //   - opcode 0x60..0x7F (PUSH1..PUSH32): advance i by (opcode - 0x5F + 1) to skip
 //     the opcode itself plus its immediate bytes.
 //   - any other opcode: advance i by 1.
-func ComputeJumpTargets(bytecode []byte) []uint32 {
-	var targets []uint32
+func ComputeJumpdestBitmap(bytecode []byte) []byte {
+	bitmap := make([]byte, (len(bytecode)+7)/8)
+	found := false
 	i := 0
 	for i < len(bytecode) {
 		op := bytecode[i]
 		switch {
 		case op == 0x5B:
-			targets = append(targets, uint32(i))
+			bitmap[i/8] |= 1 << (i % 8)
+			found = true
 			i++
 		case op >= 0x60 && op <= 0x7F:
 			// PUSH1..PUSH32: skip opcode + immediate bytes.
@@ -24,34 +33,31 @@ func ComputeJumpTargets(bytecode []byte) []uint32 {
 			i++
 		}
 	}
-	return targets
+	if !found {
+		return nil
+	}
+	return bitmap
 }
 
 // EncodeCode returns the concatenation of:
 //
 //  1. RLP(bytecode) — bytecode encoded as an RLP byte string.
-//  2. RLP(jumpTargetsList) — jump targets encoded as an RLP list of minimal
-//     big-endian integers (one per uint32 target offset).
+//  2. RLP(jumpdestBitmap) — the JUMPDEST bitmap as an RLP byte string.
 //
 // The two RLP encodings are concatenated directly (not wrapped in an outer list).
-// Mirrors ethrex account_codes encoding.
+// Mirrors ethrex's encode_code (crates/storage/store.rs).
+//
+// The bitmap replaced an RLP list of u32 JUMPDEST offsets. ethrex still reads
+// that older form: decode_jumpdests branches on the RLP item header and rebuilds
+// the bitmap from the bytecode when it finds a list.
 //
 // Golden checks:
-//   - EncodeCode(0x60015b00) = 0x8460015b00 c1 02 (jumpTargets=[2])
-//   - EncodeCode(0x600160015500) = 0x86600160015500 c0 (empty jumpTargets)
-//   - EncodeCode(nil) = 0x80 c0
+//   - EncodeCode(0x60015b00) = 0x8460015b00 04 (JUMPDEST at offset 2)
+//   - EncodeCode(0x600160015500) = 0x86600160015500 80 (no JUMPDEST)
+//   - EncodeCode(nil) = 0x80 80
 func EncodeCode(bytecode []byte) []byte {
-	// Part 1: RLP(bytecode).
 	part1 := rlpEncodeBytes(bytecode)
-
-	// Part 2: RLP list of jump target uint32 values.
-	targets := ComputeJumpTargets(bytecode)
-	var listPayload []byte
-	for _, t := range targets {
-		listPayload = append(listPayload, rlpEncodeUint32(t)...)
-	}
-	part2 := rlpEncodeListRaw(listPayload)
-
+	part2 := rlpEncodeBytes(ComputeJumpdestBitmap(bytecode))
 	return append(part1, part2...)
 }
 
@@ -69,25 +75,4 @@ func CodeLengthMetadata(bytecode []byte) [8]byte {
 	out[6] = byte(n >> 8)
 	out[7] = byte(n)
 	return out
-}
-
-// rlpEncodeUint32 encodes a uint32 as an RLP integer (minimal big-endian).
-func rlpEncodeUint32(n uint32) []byte {
-	if n == 0 {
-		return []byte{0x80}
-	}
-	b := minBEBytesU32(n)
-	return rlpEncodeBytes(b)
-}
-
-// minBEBytesU32 returns the minimal big-endian encoding of a uint32.
-func minBEBytesU32(n uint32) []byte {
-	var buf [4]byte
-	i := 3
-	for n > 0 {
-		buf[i] = byte(n)
-		n >>= 8
-		i--
-	}
-	return buf[i+1:]
 }

--- a/internal/ethrex/constants.go
+++ b/internal/ethrex/constants.go
@@ -1,7 +1,7 @@
 package ethrex
 
 // Column-family names for ethrex's single RocksDB instance.
-// Sourced from ethrex crates/storage/api/tables.rs at v23.0.0.
+// Sourced from ethrex crates/storage/api/tables.rs at commit 80bcc71.
 const (
 	CFChainData            = "chain_data"
 	CFAccountCodes         = "account_codes"
@@ -23,10 +23,11 @@ const (
 	CFMiscValues           = "misc_values"
 	CFExecutionWitnesses   = "execution_witnesses"
 	CFBlockAccessLists     = "block_access_lists"
+	CFStateHistory         = "state_history"
 	CFBadBlocks            = "bad_blocks"
 )
 
-// Tables is the ordered list of all 21 ethrex column families, matching
+// Tables is the ordered list of all 22 ethrex column families, matching
 // ethrex's TABLES array. It must not run ahead of the boot pin in
 // client/ethrex/e2e_test.go: ethrex silently drops any CF absent from
 // its own TABLES (drop_obsolete_cfs, warn-only).
@@ -51,6 +52,7 @@ var Tables = []string{
 	CFMiscValues,
 	CFExecutionWitnesses,
 	CFBlockAccessLists,
+	CFStateHistory,
 	CFBadBlocks,
 }
 
@@ -76,7 +78,7 @@ const EmptyTrieHashHex = "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc00162
 // StoreSchemaVersion must equal ethrex's STORE_SCHEMA_VERSION
 // (crates/storage/lib.rs): lower triggers boot-time migration (which
 // rewrites metadata.json); higher is a hard MigrationFailed boot error.
-const StoreSchemaVersion = 3
+const StoreSchemaVersion = 4
 
 // misc_values keys/values controlling ethrex's flat-key-value (FKV) generator.
 // On boot the generator reads misc_values["last_written"]: empty = "not

--- a/internal/ethrex/doc.go
+++ b/internal/ethrex/doc.go
@@ -1,6 +1,7 @@
-// Package ethrex implements the trie codec primitives used by ethrex
-// (pinned release v23.0.0, lambdaclass/ethrex). The golden fixture's
-// state-bearing CFs are byte-identical from v13.0.0 through v23.0.0.
+// Package ethrex implements the trie and code codec primitives used by ethrex
+// (pinned commit 80bcc71, lambdaclass/ethrex). The golden fixture's trie-node
+// CFs are byte-identical from v13.0.0 through that commit; account_codes values
+// changed shape there (see EncodeCode).
 //
 // # Two-rows-per-leaf model
 //

--- a/internal/ethrex/ethrex_test.go
+++ b/internal/ethrex/ethrex_test.go
@@ -210,23 +210,91 @@ func TestEncodeStorageValue(t *testing.T) {
 // code.go golden checks
 // ---------------------------------------------------------------------------
 
-func TestComputeJumpTargets(t *testing.T) {
-	// 0x60015b00: PUSH1 0x01 (skips byte 1), JUMPDEST at 2, STOP at 3.
-	got := ComputeJumpTargets(hexBytes("60015b00"))
-	if len(got) != 1 || got[0] != 2 {
-		t.Errorf("ComputeJumpTargets(60015b00): got %v, want [2]", got)
+func TestComputeJumpdestBitmap(t *testing.T) {
+	tests := []struct {
+		name string
+		code string
+		want string // hex of the bitmap, "" for zero-length
+	}{
+		// PUSH1 0x01 (skips byte 1), JUMPDEST at 2, STOP at 3.
+		// Bit 2 of byte 0 → 1<<2 = 0x04.
+		{"jumpdest at offset 2", "60015b00", "04"},
+		// PUSH1 0x01, PUSH1 0x01, SSTORE, STOP — no JUMPDEST, so zero-length
+		// rather than a single all-zero byte.
+		{"no jumpdest", "600160015500", ""},
+		{"empty code", "", ""},
+		// Two destinations in the same byte: offsets 1 and 3 → 0x02|0x08 = 0x0a.
+		{"two in one byte", "005b005b", "0a"},
+		// The byte after PUSH1 is its immediate, so only offset 2 counts.
+		{"push immediate is not a destination", "605b5b", "04"},
+		// Offset 7 sets the high bit, which matters because the resulting
+		// bitmap byte (0x80) is no longer a self-encoding single RLP byte.
+		{"high bit of the first byte", "000000000000005b", "80"},
+		// Crossing a byte boundary: offsets 0 and 10 → byte 0 bit 0, byte 1 bit 2.
+		{"spans two bitmap bytes", "5b0000000000000000005b000000", "0104"},
+	}
+	for _, tc := range tests {
+		var code []byte
+		if tc.code != "" {
+			code = hexBytes(tc.code)
+		}
+		got := ComputeJumpdestBitmap(code)
+		var want []byte
+		if tc.want != "" {
+			want = hexBytes(tc.want)
+		}
+		if string(got) != string(want) {
+			t.Errorf("ComputeJumpdestBitmap(%s) [%s]: got %x, want %x",
+				tc.code, tc.name, got, want)
+		}
+	}
+}
+
+// TestJumpdestBitmapMatchesScan cross-checks the bitmap against an independent
+// scan of the same bytecode, bit by bit, the way ethrex's is_valid_jumpdest
+// reads it: bit (offset%8) of byte (offset/8), with a missing byte meaning "no
+// jump destination".
+func TestJumpdestBitmapMatchesScan(t *testing.T) {
+	// A JUMPDEST sea with PUSH runs threaded through it, so PUSH-immediate
+	// suppression and byte-boundary crossings both occur many times.
+	code := make([]byte, 0, 512)
+	for i := 0; i < 64; i++ {
+		code = append(code, 0x5B, 0x5B, 0x60, 0x5B, 0x5B, 0x7F)
+		code = append(code, make([]byte, 31)...) // PUSH32 immediate
 	}
 
-	// 0x600160015500: PUSH1 0x01, PUSH1 0x01, SSTORE 0x55, STOP — no JUMPDEST.
-	got2 := ComputeJumpTargets(hexBytes("600160015500"))
-	if len(got2) != 0 {
-		t.Errorf("ComputeJumpTargets(600160015500): got %v, want []", got2)
+	bitmap := ComputeJumpdestBitmap(code)
+
+	isSet := func(offset int) bool {
+		b := offset / 8
+		if b >= len(bitmap) {
+			return false
+		}
+		return bitmap[b]&(1<<(offset%8)) != 0
 	}
 
-	// Empty code.
-	got3 := ComputeJumpTargets(nil)
-	if len(got3) != 0 {
-		t.Errorf("ComputeJumpTargets(nil): got %v, want []", got3)
+	// Independent scan: walk the bytecode skipping PUSH immediates.
+	want := make(map[int]bool)
+	for i := 0; i < len(code); {
+		switch op := code[i]; {
+		case op == 0x5B:
+			want[i] = true
+			i++
+		case op >= 0x60 && op <= 0x7F:
+			i += int(op-0x5F) + 1
+		default:
+			i++
+		}
+	}
+
+	for offset := range code {
+		if isSet(offset) != want[offset] {
+			t.Fatalf("offset %d: bitmap says %v, scan says %v",
+				offset, isSet(offset), want[offset])
+		}
+	}
+	if got, wantLen := len(bitmap), (len(code)+7)/8; got != wantLen {
+		t.Errorf("bitmap length: got %d, want %d", got, wantLen)
 	}
 }
 
@@ -235,9 +303,15 @@ func TestEncodeCode(t *testing.T) {
 		code string
 		want string
 	}{
-		{"60015b00", "8460015b00c102"},
-		{"600160015500", "86600160015500c0"},
-		{"", "80c0"},
+		// RLP(bytecode) ++ RLP(bitmap). 0x04 is a self-encoding single byte.
+		{"60015b00", "8460015b0004"},
+		// Zero-length bitmap encodes as the RLP empty string, 0x80.
+		{"600160015500", "8660016001550080"},
+		{"", "8080"},
+		// A 0x80 bitmap byte needs the 0x81 length prefix, unlike 0x04 above.
+		{"000000000000005b", "88000000000000005b8180"},
+		// A 14-byte code needs a 2-byte bitmap, encoded as the short string 0x82.
+		{"5b0000000000000000005b000000", "8e5b0000000000000000005b000000820104"},
 	}
 	for _, tc := range tests {
 		var code []byte

--- a/internal/ethrex/testdata/gen/README.md
+++ b/internal/ethrex/testdata/gen/README.md
@@ -11,42 +11,20 @@ storage schema changes.
 lambdaclass/ethrex @ 80bcc71
 ```
 
-A pre-release commit, not a tagged release: it is what the ethpandaops
-`glamsterdam-devnet-7` image was built from, and no release carries the changes
-below. The branch is not a descendant of v23.0.0; it diverges by a single
-commit, `chore: bump version to 23.0.0`, which touches only Cargo manifests, so
-it reports `v22.0.0` in `--version` while carrying strictly more storage code
-than v23.0.0. This is the same pin as the e2e boot image
-(`client/ethrex/e2e_test.go`) and as the column-family list in
-`internal/ethrex/constants.go`. All three move together.
+A pre-release commit, the one the ethpandaops `glamsterdam-devnet-7` image was
+built from. `--version` reports `v22.0.0` here: the branch does not descend from
+the v23.0.0 version bump, though its storage code is ahead of it. Don't take the
+version string as a sign the pin is wrong.
 
-`account_trie_nodes` and `storage_trie_nodes` are byte-identical from v13.0.0
-(commit 318ec2888) through this commit, each step verified by regenerating and
-diffing against the previous dump. What moved:
+The e2e boot image (`client/ethrex/e2e_test.go`) and `Tables`
+(`internal/ethrex/constants.go`) carry the same pin, and all three move
+together. `Tables` must never list a CF the pinned build lacks; ethrex's
+`drop_obsolete_cfs` drops any CF missing from its own `TABLES`.
 
-- `chain_data[0x80]` gained fork fields (`hegotaTime`, upstream in v21.0.0 via
-  ethrex#6326).
-- `bad_blocks` arrived in v22.0.0 (ethrex#6948, empty at genesis).
-- `state_history` exists only on this branch, not in any release (v23.0.0 has
-  21 CFs). Empty at genesis.
-- `account_codes` values carry a JUMPDEST bitmap rather than an RLP list of u32
-  offsets (ethrex#7095). ethrex still reads the older form — `decode_jumpdests`
-  branches on the RLP item header and rebuilds the bitmap from the bytecode when
-  it finds a list — so this is a size and representativeness change, not a
-  compatibility break.
-
-`STORE_SCHEMA_VERSION` is 4 at this commit (ethrex#7095, gated by a no-op
-`migrate_3_to_4`), so `metadata.json` says 4. It must never run ahead of the
-pinned build: a value above ethrex's own is a hard `MigrationFailed` boot
-error.
-
-Any ethrex build that bumps `STORE_SCHEMA_VERSION`, adds or removes a column
-family, or changes the key layout of `account_trie_nodes`,
-`storage_trie_nodes`, `account_codes`, or `account_code_metadata` requires
-regenerating the dump and re-reviewing the Go codec in `internal/ethrex/`.
-A CF added upstream must also be added to `Tables`; ethrex's
-`drop_obsolete_cfs` deletes any CF it finds that its own `TABLES` does not
-list, so `Tables` must never run ahead of this pin.
+Regenerate when a new pin bumps `STORE_SCHEMA_VERSION`, adds or removes a column
+family, or changes the key layout of `account_trie_nodes`, `storage_trie_nodes`,
+`account_codes`, or `account_code_metadata`. Re-review the codec in
+`internal/ethrex/` in the same commit.
 
 ## Steps
 
@@ -97,4 +75,3 @@ list, so `Tables` must never run ahead of this pin.
   let the background FKV generator thread exit cleanly. Do not remove that sleep.
 - `genesis.json` sets chainId 1337 with one EOA, one storage contract (3 slots),
   and one JUMPDEST contract. Changing `genesis.json` also invalidates the dump.
-- This approach mirrors the regeneration note in `internal/reth/doc.go`.

--- a/internal/ethrex/testdata/gen/README.md
+++ b/internal/ethrex/testdata/gen/README.md
@@ -5,26 +5,42 @@
 column family as hex-encoded JSON. It must be regenerated whenever the ethrex
 storage schema changes.
 
-## Pinned release
+## Pinned commit
 
 ```
-lambdaclass/ethrex @ v23.0.0
+lambdaclass/ethrex @ 80bcc71
 ```
 
-This is the same pin as the e2e boot image (`client/ethrex/e2e_test.go`) and as
-the column-family list in `internal/ethrex/constants.go`. All three move
-together.
+A pre-release commit, not a tagged release: it is what the ethpandaops
+`glamsterdam-devnet-7` image was built from, and no release carries the changes
+below. The branch is not a descendant of v23.0.0; it diverges by a single
+commit, `chore: bump version to 23.0.0`, which touches only Cargo manifests, so
+it reports `v22.0.0` in `--version` while carrying strictly more storage code
+than v23.0.0. This is the same pin as the e2e boot image
+(`client/ethrex/e2e_test.go`) and as the column-family list in
+`internal/ethrex/constants.go`. All three move together.
 
-The state-bearing CFs (`account_trie_nodes`, `storage_trie_nodes`,
-`account_codes`, `account_code_metadata`) are byte-identical from v13.0.0
-(commit 318ec2888) through v23.0.0, each step verified by regenerating and
-diffing against the previous dump. Across that range only two things moved:
-`chain_data[0x80]` gained fork fields (`hegotaTime`, introduced upstream in
-v21.0.0 via ethrex#6326), and the `bad_blocks` column family arrived in
-v22.0.0 (ethrex#6948, empty at genesis). `STORE_SCHEMA_VERSION` reached 3 at
-v16 and has not moved since.
+`account_trie_nodes` and `storage_trie_nodes` are byte-identical from v13.0.0
+(commit 318ec2888) through this commit, each step verified by regenerating and
+diffing against the previous dump. What moved:
 
-Any ethrex release that bumps `STORE_SCHEMA_VERSION`, adds or removes a column
+- `chain_data[0x80]` gained fork fields (`hegotaTime`, upstream in v21.0.0 via
+  ethrex#6326).
+- `bad_blocks` arrived in v22.0.0 (ethrex#6948, empty at genesis).
+- `state_history` exists only on this branch, not in any release (v23.0.0 has
+  21 CFs). Empty at genesis.
+- `account_codes` values carry a JUMPDEST bitmap rather than an RLP list of u32
+  offsets (ethrex#7095). ethrex still reads the older form — `decode_jumpdests`
+  branches on the RLP item header and rebuilds the bitmap from the bytecode when
+  it finds a list — so this is a size and representativeness change, not a
+  compatibility break.
+
+`STORE_SCHEMA_VERSION` is 4 at this commit (ethrex#7095, gated by a no-op
+`migrate_3_to_4`), so `metadata.json` says 4. It must never run ahead of the
+pinned build: a value above ethrex's own is a hard `MigrationFailed` boot
+error.
+
+Any ethrex build that bumps `STORE_SCHEMA_VERSION`, adds or removes a column
 family, or changes the key layout of `account_trie_nodes`,
 `storage_trie_nodes`, `account_codes`, or `account_code_metadata` requires
 regenerating the dump and re-reviewing the Go codec in `internal/ethrex/`.
@@ -39,7 +55,7 @@ list, so `Tables` must never run ahead of this pin.
    ```sh
    git clone https://github.com/lambdaclass/ethrex
    cd ethrex
-   git checkout v23.0.0
+   git checkout 80bcc71
    ```
 
 2. Copy the dump harness into ethrex's examples directory:


### PR DESCRIPTION
Tracks ethrex to commit `80bcc71` (ethpandaops `glamsterdam-devnet-7`). No release carries these changes. That branch is not a descendant of v23.0.0; it diverges by the version-bump commit alone, so it reports `v22.0.0` while carrying strictly more storage code.

- `account_codes` values carry a JUMPDEST bitmap instead of an RLP list of u32 offsets (ethrex#7095). One bit per bytecode byte, LSB-first, zero-length when the code has no JUMPDEST. ethrex reads both forms.
- Adds the `state_history` column family, 21 to 22, positioned before `bad_blocks` in `TABLES`.
- Both code CFs get a 10-bit bloom; `account_codes` gets 4 KiB blocks plus `optimize_filters_for_hits`, `account_code_metadata` keeps 16 KiB and moves off the default arm onto 128 MiB buffers / 256 MiB files.
- Boot image and `Tables` repin to `80bcc71`, digest-locked so it survives the tag moving.
- `schema_version` goes to 4, matching `STORE_SCHEMA_VERSION` at that commit. It must not run ahead of the pinned build: a higher value is a hard `MigrationFailed` boot error.
- `Dockerfile.ethrex` takes the RocksDB build parallelism as `ROCKSDB_JOBS`, still defaulting to 2.

Unit tests cover bit position, PUSH-immediate suppression, byte-boundary crossing, the high-bit case, the zero-length case, and a cross-check against an independent scan. The cgo suite (`-tags cgo_ethrex`), including `TestGenesisDumpGolden`, passes.

Not done yet:

- `testdata/genesis_dump.json` is not regenerated, so `TestGenesisDumpGolden` checks `account_codes` keys byte-exact and values against the fixture's own bytecode re-encoded. Steps in `testdata/gen/README.md`.
- `TestE2ESuite` has not run against the new pin.
